### PR TITLE
Need to provide script tag, not just URL to library

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
 			<div class="column column-1">
 				<h3>1. Hosted externally</h3>
 				<p>To use patterns hosted externally, just paste the following line into your HTML:</p>
-				<textarea class="url" rows="1">http://www.patternslib.com/bundles/patterns.min.js</textarea>
+				<textarea class="url" rows="1">&lt;script data-main="http://www.patternslib.com/bundles/patterns.min.js" src="http://www.patternslib.com/src/3rdparty/require-jquery.js" type="text/javascript"&gt;&lt;/script&gt;</textarea>
 			</div>
 			<div class="column column-2">
 				<h3>2. Hosted on your own site</h3>


### PR DESCRIPTION
In the "Hosted externally", the full script tag to embed should be provided.
