### PR TITLE
Bugfix. Add quotes in selector.

### DIFF
--- a/src/patterns/checkedflag.js
+++ b/src/patterns/checkedflag.js
@@ -32,7 +32,7 @@ define([
         onChangeRadio: function(e) {
             var $el = $(this),
                 $label = $el.closest("label"),
-                selector = "label:has(input[name=" + this.name + "]:not(:checked))",
+                selector = "label:has(input[name='" + this.name + "']:not(:checked))",
                 $siblings = (this.form===null) ? $(selector) : $(selector, this.form);
 
             $siblings.removeClass("checked").addClass("unchecked");


### PR DESCRIPTION
Otherwise the selector breaks with a name like "extensions:list"
