### PR TITLE
Let TinyMCE load custom themes with the 'pat-' prefix

### DIFF
--- a/src/3rdparty/tiny_mce/tiny_mce_src.js
+++ b/src/3rdparty/tiny_mce/tiny_mce_src.js
@@ -13486,11 +13486,15 @@ tinymce.create('tinymce.ui.Toolbar:tinymce.ui.Container', {
 
 			// Load scripts
 			function loadScripts() {
+				var isPatternsTheme = s.theme.substr(0, 4) == "pat-", editor_template = "/editor_template" + tinymce.suffix + ".js";
+
 				if (s.language && s.language_load !== false)
 					sl.add(tinymce.baseURL + '/langs/' + s.language + '.js');
 
-				if (s.theme && typeof s.theme != "function" && s.theme.charAt(0) != '-' && !ThemeManager.urls[s.theme])
-					ThemeManager.load(s.theme, 'themes/' + s.theme + '/editor_template' + tinymce.suffix + '.js');
+				if (!isPatternsTheme && s.theme && typeof s.theme != "function" && s.theme.charAt(0) != '-' && !ThemeManager.urls[s.theme])
+					ThemeManager.load(s.theme, 'themes/' + s.theme + editor_template);
+				else if (isPatternsTheme) ThemeManager.load(s.theme, "/_themes/Libraries/tiny_mce/themes/" + s.theme + editor_template);
+
 
 				each(explode(s.plugins), function(p) {
 					if (p &&!PluginManager.urls[p]) {


### PR DESCRIPTION
TinyMCE expects themes to be in a directory relative to the TinyMCE source: e.g. src/3rdparty/tiny_mce/themes/. To decouple TinyMCE from the theme this patch handles themes with names which start with 'pat-' separately. Currently it loads them from /Libraries/tiny_mce/themes/ instead.

I'd also like to look into how we can load custom skins for plugins.

If there's a cleaner approach that would be really great.
