### PR TITLE
Improved some of the website copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,13 +37,13 @@
 				<p>Patterns is a combination of a library and a workflow. That workflow goes something like this:</p>
 				<ol class="usps">
 					<li>
-						<p>Designer creates an HTML5 prototype. By including Patterns library, he can use a series of rich interaction patterns by applying dedicated classes and data-attributes instead of writing Javascript. The prototype he contains an example of all important page types with working interaction patterns such as form elements, modal panels, AJAX injections, etc. </p>
+						<p>The designer creates an HTML5 prototype. By including Patterns library, they can use a series of rich interaction patterns by applying dedicated classes and data-attributes instead of writing JavaScript. The prototype contains examples of all important page types with working interaction patterns such as form elements, modal panels, and AJAX injections. </p>
 					</li>
 					<li>
-						<p>Now the designer can validate a rich prototype with both the business stakeholders and the developer. All possibilities and impossibilities will surface before anything is built. This will prevent a lot of change requests and headaches during the development phase</p>
+						<p>Now the designer can validate a rich prototype with both the business stakeholders and the developers. All possibilities and impossibilities will become apparent before anything is built. This will prevent a lot of change requests and headaches during the development phase.</p>
 					</li>
 					<li>
-						<p>Designer hands the prototype over to the developer who copies most of the HTML over into his own templates. By doing that, all the interaction patterns work already as applied by the designer. In some cases, the developer can write some extra JavaScript, or apply some patterns on his own, as a prototype is never fully complete. </p>
+						<p>The designer hands the prototype over to the developers who copy most of the HTML over into their own templates. By doing that, all the interaction patterns already work as implemented by the designer. In some cases, the developers can write some extra JavaScript, or apply some patterns on their own, as a prototype is never fully complete. </p>
 					</li>
 				</ol>
 				<p>
@@ -58,7 +58,7 @@
 			
 			<section id="download">
 				<h2>Got it? Get it!</h2>
-				<p>There are three ways of getting patterns in your site or prototype. You can download the patterns package and host it from your own server, or included it hosted from our server. It's up to you what you find easiest. </p>
+				<p>There are three ways of getting patterns into your site or prototype. You can download the patterns package and host it from your own server, or include it hosted from our server. It's up to you what you find easiest. </p>
 				<div class="column column-1">
 					<h3>1. Hosted externally</h3>
 					<p>To use patterns hosted externally, just paste the following line into your HTML:</p>
@@ -71,7 +71,7 @@
 					</p>
 				</div>
 				<div class="column column-3">
-					<h3>3. Clone from Github</h3>
+					<h3>3. Clone from GitHub</h3>
 					<p>
 						<a href="https://github.com/Patternslib/Patterns" class="clone-patterns-large"><img src="media/icon-github.png" width="200" alt="" /></a>
 					</p>


### PR DESCRIPTION
- Refers to "the designer" now, instead of a mix of "designer" and "the
  designer"
- Refers to developers, as a plural
- Refers to the designer as "they", the designer does not have a gender
- No longer refers to the prototype as 'he'
- Got rid of etc. as its meaning is derived from "such as"
- Workflow description section 2 now ends with a full stop.
- "Applied by the designer" is now "Implemented by the designer"
- Getting  patters in your site -> should be "into your site"
- "included it" -> "include it" as it is present tense
- "Github" is now "GitHub"
