### PR TITLE
Supporting id/text data for Autosuggest prefill.

### DIFF
--- a/src/pat/autosuggest.js
+++ b/src/pat/autosuggest.js
@@ -65,9 +65,14 @@ define([
             }
 
             if (cfg.data.length) {
-                $el.val(cfg.data);
+                var data = jQuery.parseJSON(cfg.data);
+                var ids = [];
+                for (d in data) {
+                    ids.push(data[d].id);
+                }
+                $el.val(ids);
+                
                 config.initSelection = function (element, callback) {
-                    var data = jQuery.parseJSON(cfg.data);
                     callback(data);
                 };
             }


### PR DESCRIPTION
At the moment the pre-fill attribute only supports a simple comma-separated list of values. But we need to be able to pre-fill with data that has both text and id so that we can be consistent with the auto-suggested data.

I'm not sure of the best way to do this. I first tried adding a "pre-fill-data" argument, but that changed the behaviour of the "pre-fill" argument so it was no longer called 'cfg.preFill'. Instead I added a 'data' argument that will take JSON data, which is a simple and robust solution, although Cornelis suggested that it might not be designer-friendly. Suggestions welcome.
