### PR TITLE
Flexible vertical modal position

### DIFF
--- a/src/pat/modal.js
+++ b/src/pat/modal.js
@@ -8,6 +8,7 @@ define([
     var parser = new Parser("modal");
 
     parser.add_argument("class");
+    parser.add_argument("top", "center");
 
     var modal = {
         name: "modal",
@@ -104,7 +105,11 @@ define([
             } else {
                 return;
             }
-            $el.css("top", ($(window).innerHeight() - $el.outerHeight(true)) / 2);
+
+            if (cfg.top==="center")
+                $el.css("top", ($(window).innerHeight() - $el.outerHeight(true)) / 2);
+            else
+                $el.css("top", cfg.top);
 
             // XXX: This is a hack. When you have a modal inside a
             // modal.max-height, the CSS of the outermost modal affects the


### PR DESCRIPTION
I have a site where my content is in an iframe. When I use a modal in that iframe it is vertically centered in the iframe, but the end result is that the modal is partially below the fold in the outer page.

We worked around this by applying a negative top margin to the modal, but that is somewhat fragile. To handle this kind of situation it would be useful to be able to give a (vertical) positioning hint, for example "top of the page".