### PR TITLE
do not hide an event if one of its categories is deactivated, ...

### DIFF
--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -323,10 +323,10 @@ define([
                 regex = new RegExp(searchText, "i");
             }
 
-            var hiddenCats = $el.categories.filter(function() {
+            var shownCats = $el.categories.filter(function() {
                 var cat = this;
                 return $el.$catControls.filter(function() {
-                    return !this.checked &&
+                    return this.checked &&
                         $(this)
                             .parents()
                             .andSelf()
@@ -342,7 +342,7 @@ define([
                     return false;
                 }
 
-                return !hiddenCats.filter(function() {
+                return shownCats.filter(function() {
                     return $event.hasClass(this);
                 }).length;
             }).map(function(idx, event) {


### PR DESCRIPTION
...only if all of them are deactivated. I.e. if at least one category of an event is activated, show the event.

See https://github.com/syslabcom/staralliance.webwork/wiki/Business-rules-events

Also @cornae voiced the opinion that in general it is more natural to apply an _OR_ to css classes than an _AND_.
