### PR TITLE
minor version update of phantomjs from 1.8.0 to 1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "jshint": "~0.9.1",
         "pegjs": "0.7.0",
         "phantom-jasmine": "0.1.8",
-        "phantomjs": "1.8.0-1",
+        "phantomjs": "1.8.1-1",
         "requirejs": ""
     },
     "homepage": "https://gitub.com/Patternslib/Patterns",


### PR DESCRIPTION
1.8.0 does not provide a package for linux-i686, but 1.8.1 does

See 
https://code.google.com/p/phantomjs/downloads/list?can=4&q=&colspec=Filename+Summary+Uploaded+ReleaseDate+Size+DownloadCount
