### PR TITLE
Fix an example to make it fit the description

### DIFF
--- a/demo/inject/documentation.md
+++ b/demo/inject/documentation.md
@@ -54,7 +54,7 @@ Perhaps inserting a single block of content is not enough for your needs? Don't 
 
     <section id="section">
       <form action="/my/form" class="pat-inject"
-       data-pat-inject="#content && #notice #notices::after">
+       data-pat-inject="#content #section && #notice #notices::after">
         …
       </form>
     </section>


### PR DESCRIPTION
As it is, the example would make `#content` from the response replace `#content` on the page, plus the other stuff.

I think the point of the example is to show how to replace multiple blocks of content, so I fixed it to make it do what the description says.