### PR TITLE
Fixes #403 and #404.

### DIFF
--- a/src/pat/bumper/bumper.js
+++ b/src/pat/bumper/bumper.js
@@ -22,6 +22,7 @@ define([
     parser.addArgument("bump-remove");
     parser.addArgument("unbump-add");
     parser.addArgument("unbump-remove", "bumped");
+    parser.addArgument("side", "top");
 
     // XXX Handle resize
     var bumper = {
@@ -56,8 +57,14 @@ define([
                         }
                     }
                     $(container).on("scroll.bumper", null, this, bumper._onScrollContainer);
-                    bumper._updateContainedStatus(container, this);
+                    bumper._updateStatus(this, container);
                 }
+
+                var bumpall = (options.side.indexOf("all") > -1);
+                options.bumptop =    bumpall || (options.side.indexOf("top") > -1);
+                options.bumpright =  bumpall || (options.side.indexOf("right") > -1);
+                options.bumpbottom = bumpall || (options.side.indexOf("bottom") > -1);
+                options.bumpleft =   bumpall || (options.side.indexOf("left") > -1);
             });
         },
 
@@ -85,34 +92,26 @@ define([
         _onScrollContainer: function bumper_onScrollContainer(e) {
             var container = e.currentTarget,
                 sticker = e.data;
-            bumper._updateContainedStatus(container, sticker);
+            bumper._updateStatus(sticker, container);
         },
 
         _onScrollWindow: function bumper_onScrollWindow(e) {
             bumper._updateStatus(e.data);
         },
 
-        _updateContainedStatus: function bumper_updateContainerSstatus(container, sticker) {
-            var $sticker = $(sticker),
-                options = $sticker.data("pat-bumper:config"),
-                top = sticker.style.top ? parseInt(sticker.style.top, 10) : 0,
-                delta = sticker.offsetTop - container.scrollTop - top;
-
-            if (delta<0) {
-                bumper._markBumped($sticker, options, true);
-                sticker.style.top=(-delta)+"px";
-            } else {
-                bumper._markBumped($sticker, options, false);
-                sticker.style.top="";
-            }
-        },
-
         _updateStatus: function(sticker) {
             var $sticker = $(sticker),
                 options = $sticker.data("pat-bumper:config"),
-                viewport = bumper._getViewport(),
-                box = bumper._getBoundingBox($sticker, options.margin),
+                margin = options ? options.margin : 0,
+                frame,
+                box = bumper._getBoundingBox($sticker, margin),
                 delta = {};
+
+            if (arguments.length == 1)
+              frame = bumper._getViewport();
+            else if (arguments.length == 2)
+              frame = bumper._getBoundingBox($(arguments[1]), margin);
+
             delta.top=sticker.style.top ? parseFloat($sticker.css("top")) : 0;
             delta.left=sticker.style.left ? parseFloat($sticker.css("left")) : 0;
 
@@ -121,17 +120,17 @@ define([
             box.left-=delta.left;
             box.right-=delta.left;
 
-            if (viewport.top > box.top)
-                sticker.style.top=(viewport.top - box.top) + "px";
-            else if (viewport.bottom < box.bottom)
-                sticker.style.top=(viewport.bottom - box.bottom) + "px";
+            if ((frame.top > box.top) && options.bumptop)
+                sticker.style.top=(frame.top - box.top) + "px";
+            else if ((frame.bottom < box.bottom) && options.bumpbottom)
+                sticker.style.top=(frame.bottom - box.bottom) + "px";
             else
                 sticker.style.top="";
 
-            if (viewport.left > box.left)
-                sticker.style.left=(viewport.left - box.left) + "px";
-            else if (viewport.right < box.right)
-                sticker.style.left=(viewport.right - box.right) + "px";
+            if ((frame.left > box.left) && options.bumpleft)
+                sticker.style.left=(frame.left - box.left) + "px";
+            else if ((frame.right < box.right) && options.bumpright)
+                sticker.style.left=(frame.right - box.right) + "px";
             else
                 sticker.style.left="";
 

--- a/src/pat/bumper/documentation.md
+++ b/src/pat/bumper/documentation.md
@@ -63,3 +63,4 @@ The available options are:
 | `bump-remove` | *unset* | CSS class(es) to removed when an element is bumped. | String |
 | `unbump-add` | *unset* | CSS class(es) to add when an element is no longer bumped. | String |
 | `unbump-remove` | `bumped` | CSS class(es) to removed when an element is no longer bumped. | String |
+| `side` | `top` | The side which should bump.  A combination of `all top right bottom left`.  `all` is equivalent to `top right bottom left`. | String |

--- a/tests/specs/pat/bumper.js
+++ b/tests/specs/pat/bumper.js
@@ -15,7 +15,7 @@ define(["pat-bumper"], function(pattern) {
         });
 
         describe("Check if _findScrollContainer", function() {
-            it("handles an normal object", function() {
+            it("handles a normal object", function() {
                 $("#lab").append("<div id='sticker'/>");
                 var el = document.getElementById("sticker");
                 expect(pattern._findScrollContainer(el)).toBeNull();
@@ -64,8 +64,8 @@ define(["pat-bumper"], function(pattern) {
             });
         });
 
-        describe("Check if _updateContainedStatus", function() {
-            it("correctly transitions an element to bumped", function() {
+        describe("Check if in a scrolling container _updateStatus", function() {
+            it("correctly transitions an element to bumped at the top", function() {
                 var lab = document.getElementById("lab"),
                     container = document.createElement("div"),
                     padding = document.createElement("div"),
@@ -83,7 +83,8 @@ define(["pat-bumper"], function(pattern) {
                 container.appendChild(padding);
                 container.scrollTop=5;
                 spyOn(pattern, "_markBumped");
-                pattern._updateContainedStatus(container, sticker);
+                $(sticker).data("pat-bumper:config", {margin: 0, bumptop: true});
+                pattern._updateStatus(sticker, container);
                 expect(pattern._markBumped).toHaveBeenCalled();
                 expect(pattern._markBumped.mostRecentCall.args[2]).toBeTruthy();
                 expect(sticker.style.top).toBe("5px");
@@ -107,7 +108,7 @@ define(["pat-bumper"], function(pattern) {
                 container.appendChild(padding);
                 container.scrollTop=0;
                 spyOn(pattern, "_markBumped");
-                pattern._updateContainedStatus(container, sticker);
+                pattern._updateStatus(sticker, container);
                 expect(pattern._markBumped).toHaveBeenCalled();
                 expect(pattern._markBumped.mostRecentCall.args[2]).toBeFalsy();
                 expect(sticker.style.top).toBe("");
@@ -115,7 +116,7 @@ define(["pat-bumper"], function(pattern) {
         });
 
         describe("Check if _updateStatus", function() {
-            it("correctly transitions to bumped", function() {
+            it("correctly transitions to bumped at the top", function() {
                 var lab = document.getElementById("lab"),
                     padding = document.createElement("div"),
                     sticker = document.createElement("p");
@@ -123,7 +124,7 @@ define(["pat-bumper"], function(pattern) {
                 sticker.style.height="5px";
                 sticker.style.position="relative";
                 lab.appendChild(sticker);
-                $(sticker).data("pat-bumper:config", {margin: 0});
+                $(sticker).data("pat-bumper:config", {margin: 0, bumptop: true});
                 padding.style.clear="both";
                 padding.style.height="3000px";
                 lab.appendChild(padding);
@@ -135,7 +136,7 @@ define(["pat-bumper"], function(pattern) {
                 expect(Math.floor(sticker.style.top.replace("px", ""))).toBe(5);
             });
 
-            it("correctly transitions to unbumped", function() {
+            it("correctly transitions to unbumped at the top", function() {
                 var lab = document.getElementById("lab"),
                     padding = document.createElement("div"),
                     sticker = document.createElement("p");


### PR DESCRIPTION
@jcbrand I merged the `_updateStatus` and `_updateContainedStatus` functions into one, since the logic should be the same, save for the type of container.

I fixed the tests accordingly, but currently we are only testing that we bump against the top side, none of the other sides.  How do you suggest to structure additional tests?  Technically, it should be a 3D matrix:
(scrolling container/window) x (top/right/bottom/left) x (all/)
That could get unwieldy.

@cornae this fixes #403 and fixes #404.