### PR TITLE
pat-inject/pat-modal spinner bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "patterns",
+  "name": "patternslib",
   "version": "2.0.9",
   "main": "bundle.js",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "patterns",
+  "name": "patternslib",
   "version": "2.0.6",
   "title": "Markup patterns to drive behaviour.",
   "description": "Patterns is a JavaScript library that enables designers to build rich interactive prototypes without the need for writing any Javascript. All events are triggered by classes and other attributes in the HTML, without abusing the HTML as a programming language. Accessibility, SEO and well structured HTML are core values of Patterns.",

--- a/src/pat/modal/modal.js
+++ b/src/pat/modal/modal.js
@@ -37,6 +37,11 @@ define([
             if (!this.$el.closest("#pat-modal")) {
                 $("#pat-modal").detach();
             }
+
+            this.$el.on("pat-inject-missingSource pat-inject-missingTarget", function() {
+                $("#pat-modal").detach();
+            });
+
             inject.init(this.$el, opts);
         },
 


### PR DESCRIPTION
- when source/target missing error event is raised detach modal
- use already registered name in bower.json otherwise ``bower link`` that is
  ment for development cannot be used

## How to reproduce the bug:
- git clone github/ploneintranet.prototype
- make dev-bundle
- make serve
- open browser at http://127.0.0.1:4000/minutes-of-2014-06-09/
- click "Delete this document" button
- without this PR spinner icon is not removed

/cc @pilz

-

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/patternslib/patterns/408)
<!-- Reviewable:end -->
