### PR TITLE
pat-tooltip: add content_html option for source parameter

### DIFF
--- a/src/pat/clone/clone.js
+++ b/src/pat/clone/clone.js
@@ -58,8 +58,21 @@ define("pat-clone",[
             $clone.appendTo(this.$el);
             $clone.children().addBack().contents().addBack().filter(this.incrementValues.bind(this));
             $clone.find(this.options.removeElement).on("click", this.remove.bind(this, $clone));
+
+            // IE BUG : Placeholder text becomes actual value after deep clone on textarea
+            // https://connect.microsoft.com/IE/feedback/details/781612/placeholder-text-becomes-actual-value-after-deep-clone-on-textarea
+            if ($.browser.msie !== undefined) {
+              $(':input[placeholder]', $clone).each(function(i, item) {
+                  var $item = $(item);
+                  if ($item.attr('placeholder') === $item.val()) {
+                    $item.val('');
+                  }
+              });
+            }
+
             $clone.removeAttr("hidden");
             registry.scan($clone);
+
             $clone.trigger("pat-update", {'pattern':"clone", '$el': $clone});
             if (this.num_clones >= this.options.max) {
                 $(this.options.triggerElement).hide();

--- a/src/pat/selectbox/selectbox.js
+++ b/src/pat/selectbox/selectbox.js
@@ -59,6 +59,7 @@ define([
                 "data-option",
                 $select.find("option:selected").text()
             );
+            $select.parent().attr("data-option-value", $select.val());
         }
     };
 

--- a/src/pat/tooltip/tooltip.js
+++ b/src/pat/tooltip/tooltip.js
@@ -26,7 +26,7 @@ define([
     parser.addArgument("height", "auto", ["auto", "max"]);
     parser.addArgument("trigger", "click", ["click", "hover"]);
     parser.addArgument("closing", "auto", ["auto", "sticky", "close-button"]);
-    parser.addArgument("source", "title", ["auto", "ajax", "content", "title"]);
+    parser.addArgument("source", "title", ["auto", "ajax", "content", "content-html", "title"]);
     parser.addArgument("ajax-data-type", "html", ["html", "markdown"]);
     parser.addArgument("delay", 0);
     parser.addArgument("class");
@@ -35,6 +35,7 @@ define([
     var tooltip = {
         name: "tooltip",
         trigger: ".pat-tooltip",
+        jquery_plugin: true,
 
         count: 0,
 
@@ -262,6 +263,9 @@ define([
                 break;
             case "title":
                 $content=$("<p/>").text(options.title);
+                break;
+            case "content-html":
+                $content = $("<div/>").html(options.content);
                 break;
             case "content":
                 href = $trigger.attr("href");


### PR DESCRIPTION
- when content_html is set as source you can pass any html string and that is going to be used inserted in tooltip.

- added ``data-option-value`` option for pat-selectbox pattern

- fixed IE9-11 bug in pat-clone that was happening with textareas and placeholder


/cc @pilz @cornae




<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/patternslib/patterns/410)
<!-- Reviewable:end -->
