### PR TITLE
Add information on subform fields on submit so that history can set the right url

### DIFF
--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -116,6 +116,10 @@ define([
              */
             var $el = $sub.parents("form"),
                 cfgs = $sub.data("pat-inject");
+
+            // store the params of the subform in the config, to be used by history
+            $(cfgs).each(function(i, v) {v.params = $.param($sub.serializeArray())});
+
             try {
                 $el.trigger("patterns-inject-triggered");
             } catch (e) {
@@ -350,9 +354,13 @@ define([
             });
             // Now the injection actually happens.
             if (inject._inject(trigger, $src, $target, cfg)) { inject._afterInjection($el, $injected, cfg); }
-            // History support.
+            // History support. if subform is submitted, append form params
             if ((cfg.history === "record") && ("pushState" in history)) {
-                history.pushState({'url': cfg.url}, "", cfg.url);
+                if (cfg.params) {
+                    history.pushState({'url': cfg.url + '?' + cfg.params}, "", cfg.url + '?' + cfg.params);
+                } else {
+                    history.pushState({'url': cfg.url}, "", cfg.url);
+                }
             }
         },
 


### PR DESCRIPTION
# Problem

When performing an injection on form submit, the history back doesn't work.

# Reason

Right after the injection is done, pat-inject puts the config url into the history. 
It gets this config url by looking at the injection url. 
* Either it was explicitly specified as url in the data-pat-inject
* Or it was specified as a formaction on a button
* Or it comes from the href attribute of a link
* Or it comes from an action attribute of the current elem
* Or it comes from an action attribute from a surrounding form element.

However, if this falls back to the action attribute of a form, there is no query string. Imagine the following process on a search form that injects its results on subsequent searches:

* The user uses some sitewide form field to initiate a search by typing “X” as search term
* The search form loads, the SearchableText field is prepopulated with “X”, the results show for “X”; no injection so far
* Now the user changes “X” to “Y”. Autosubmit kicks in and the form is submitted with the SearchableText=Y form field
* Injection does not find any url parameter, nor has a href, instead it finds the action attribute which is the name of the search form. However no form fields are retrieved and thus not submitted.
* As a result, the plain search form without any parameters is added to the history.

This is not desirable because now a user might click a search result, then press the back button to go back to the results and instead gets an empty search form. The search results are gone.

Note that this happens only with FF and IE. Safari and Chrome have decided to not actually go back but to cache the DOM, so it appears as if it works in these browsers.

# Solution approach

This commit stores the form fields of the current subform into the configurations (cfgs) in a serialised form. Then the history push checks if params are available and appends them to the url if present.

