### PR TITLE
more verbose parser warnings

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -237,7 +237,7 @@ define([
                 if (!part) { return; }
                 var matches = part.match(this.named_param_pattern);
                 if (!matches) {
-                    this.log.warn("Invalid parameter: " + part);
+                    this.log.warn("Invalid parameter: " + part + ": " + argstring);
                     return;
                 }
                 var name = matches[1],


### PR DESCRIPTION
Shows which argstring throws a parsing error.
Online edit, I don't have a full JS dev stack with tests.