### PR TITLE
Cleanup core/utils.js dependencies

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -1,8 +1,8 @@
 define([
     "jquery",
-    "jquery.browser",
-    "underscore"
-], function($) {
+    "underscore",
+    "jquery.browser"  // adds itself to the jquery object, no need to pass to the define callback.
+], function($, _) {
 
     $.fn.safeClone = function () {
         var $clone = this.clone();


### PR DESCRIPTION
Remove unused jquery.browser and underscore dependencies from core/utils.js.

I suspect the ``jquery.browser`` dependency being the cause, why patternslib cannot be built on CMFPlone, where we do not include it.