### PR TITLE
pat-gallery fixes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "patternslib",
-  "version": "2.0.13",
+  "version": "2.1",
   "main": "bundle.js",
   "devDependencies": {
     "jasmine": "https://github.com/jcbrand/jasmine.git#1_3_x"
@@ -11,7 +11,6 @@
     "jquery": "1.11.1",
     "modernizr": "2.8.3",
     "requirejs": "",
-    "requirejs-tpl-jcbrand": "*",
     "requirejs-text": "~2.0.12",
     "jcrop": "0.9.12",
     "AnythingSlider": "1.8.17",

--- a/changes.md
+++ b/changes.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 2.0.14 - (unreleased)
+## 2.1.0 - (unreleased)
 
+- Fix ``pat-gallery`` to work with ``requirejs-text`` instead ``requirejs-tpl-jcbrand``.
+  Fixes an obscure "window undefined" error.
+  Backwards incompatible change: The ``photoswipe-template`` RequireJS configuration variable is removed and a the ``pat-gallery-url`` variable is defined instead.
 - A fix for pat-scroll to scroll up to current scroll container instead of body. 
 - A fix for pat-scroll to await loading of all images before determining the amount to scroll up.
 - A fix for IE10/11 where the modal wouldn`t close anymore due to activeElement being undefined

--- a/main.js
+++ b/main.js
@@ -37,7 +37,6 @@ require.config({
         "patternslib.slides":               "bower_components/slides/src/slides",
         "photoswipe":                       "bower_components/photoswipe/dist/photoswipe",
         "photoswipe-ui":                    "bower_components/photoswipe/dist/photoswipe-ui-default",
-        "photoswipe-template":              "pat/gallery/template",
         "pikaday":                          "bower_components/pikaday/pikaday",
         "prefixfree":                       "bower_components/prefixfree/prefixfree.min",
         "select2":                          "bower_components/select2/select2.min",
@@ -47,7 +46,6 @@ require.config({
         "showdown-table":                   "bower_components/showdown/src/extensions/table",
         "spectrum":                         "bower_components/spectrum/spectrum",
         "text":                             "bower_components/requirejs-text/text",
-        "tpl":                              "bower_components/requirejs-tpl-jcbrand/tpl",
         "tinymce":                          "bower_components/jquery.tinymce/jscripts/tiny_mce/jquery.tinymce",
         "underscore":                       "bower_components/underscore/underscore",
         "validate":                         "bower_components/validate/validate",
@@ -104,6 +102,7 @@ require.config({
         "pat-form-state":              "pat/form-state/form-state",
         "pat-forward":                 "pat/forward/forward",
         "pat-gallery":                 "pat/gallery/gallery",
+        "pat-gallery-url":             "pat/gallery",
         "pat-grid":                    "pat/grid/grid",  // Hack, there's no grid jS, but we need for website bundler
         "pat-syntax-highlight":        "pat/syntax-highlight/syntax-highlight",
         "pat-image-crop":              "pat/image-crop/image-crop",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patternslib",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "title": "Markup patterns to drive behaviour.",
   "description": "Patternslib is a JavaScript library that enables designers to build rich interactive prototypes without the need for writing any Javascript. All events are triggered by classes and other attributes in the HTML, without abusing the HTML as a programming language. Accessibility, SEO and well structured HTML are core values of Patterns.",
   "author": {

--- a/src/pat/gallery/gallery.js
+++ b/src/pat/gallery/gallery.js
@@ -10,7 +10,7 @@ define('pat-gallery', [
     'pat-parser',
     'photoswipe',
     'photoswipe-ui',
-    'tpl!photoswipe-template',
+    'text!pat-gallery-url/template.html',
     'underscore'
 ], function($, patterns, Base, Parser, PhotoSwipe, PhotoSwipeUI, template, _) {
     var parser = new Parser('gallery');
@@ -26,7 +26,7 @@ define('pat-gallery', [
         init: function patGalleryInit($el, opts) {
             this.options = parser.parse(this.$el, opts);
             if ($('#photoswipe-template').length === 0) {
-                $('body').append(template());
+                $('body').append(_.template(template)());
             }
             var images = $('a', this.$el).map(function () {
                 return { 'w': 0, 'h': 0, 'src': this.href, 'title': $(this).find('img').attr('title') };

--- a/src/pat/gallery/gallery.js
+++ b/src/pat/gallery/gallery.js
@@ -3,32 +3,32 @@
  *
  * Copyright 2013 Simplon B.V. - Wichert Akkerman
  */
-define("pat-gallery", [
-    "jquery",
-    "pat-registry",
-    "pat-base",
-    "pat-parser",
-    "photoswipe",
-    "photoswipe-ui",
-    "tpl!photoswipe-template",
-    "underscore"
+define('pat-gallery', [
+    'jquery',
+    'pat-registry',
+    'pat-base',
+    'pat-parser',
+    'photoswipe',
+    'photoswipe-ui',
+    'tpl!photoswipe-template',
+    'underscore'
 ], function($, patterns, Base, Parser, PhotoSwipe, PhotoSwipeUI, template, _) {
-    var parser = new Parser("gallery");
-    parser.addArgument("loop", true);
-    parser.addArgument("scale-method", "fit", ["fit", "fitNoUpscale", "zoom"]);
-    parser.addArgument("delay", 30000);
-    parser.addArgument("effect-duration", 250);
+    var parser = new Parser('gallery');
+    parser.addArgument('loop', true);
+    parser.addArgument('scale-method', 'fit', ['fit', 'fitNoUpscale', 'zoom']);
+    parser.addArgument('delay', 30000);
+    parser.addArgument('effect-duration', 250);
 
     return Base.extend({
-        name: "gallery",
-        trigger: ".pat-gallery",
+        name: 'gallery',
+        trigger: '.pat-gallery',
 
         init: function patGalleryInit($el, opts) {
             this.options = parser.parse(this.$el, opts);
             if ($('#photoswipe-template').length === 0) {
                 $('body').append(template());
             }
-            var images = $("a", this.$el).map(function () {
+            var images = $('a', this.$el).map(function () {
                 return { 'w': 0, 'h': 0, 'src': this.href, 'title': $(this).find('img').attr('title') };
             });
             var pswpElement = document.querySelectorAll('.pswp')[0];
@@ -40,7 +40,7 @@ define("pat-gallery", [
                 hideAnimationDuration: this.options.effectDuration,
                 showAnimationDuration: this.options.effectDuration
             };
-            $("a", this.$el).click(function (ev) {
+            $('a', this.$el).click(function (ev) {
                 ev.preventDefault();
                 if (this.href) {
                     options.index = _.indexOf(_.pluck(images, 'src'), this.href);


### PR DESCRIPTION
Fix ``pat-gallery`` to work with ``requirejs-text`` instead ``requirejs-tpl-jcbrand``.
Fixes an obscure "window undefined" error.
Backwards incompatible change: The ``photoswipe-template`` RequireJS configuration variable is removed and a the ``pat-gallery-url`` variable is defined instead.

There is a "Bug" label missing. It's also - but not only - code cleanup.

/cc @jcbrand 