### PR TITLE
Allow to configure different data-pat-inject per formaction, so that …

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -5,6 +5,7 @@
 - A fix for pat-scroll to scroll up to current scroll container instead of body. 
 - A fix for pat-scroll to await loading of all images before determining the amount to scroll up.
 - A fix for IE10/11 where the modal wouldn`t close anymore due to activeElement being undefined
+- Allow to configure different data-pat-inject per formaction, so that different targets can be configured per formaction
 
 ## 2.0.13 - Apr. 27, 2016
 

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -108,7 +108,8 @@ define([
                 formaction = $button.attr("formaction"),
                 $form = $button.parents(".pat-inject").first(),
                 opts = {url: formaction},
-                cfgs = inject.extractConfig($form, opts);
+                $cfg_node = $button.closest("[data-pat-inject]"),
+                cfgs = inject.extractConfig($cfg_node, opts);
 
             ev.preventDefault();
             $form.trigger("patterns-inject-triggered");

--- a/src/pat/inject/tests.js
+++ b/src/pat/inject/tests.js
@@ -673,6 +673,30 @@ define(["pat-inject", "pat-utils"], function(pattern, utils) {
                         expect($target1.html()).toBe("some");
                         expect($target2.html()).toBe("other");
                     });
+                    it("formaction works source and target on the button", function() {
+                        var $submit1 = $("<input type=\"submit\" name=\"submit\" value=\"default\" />"),
+                            $submit2 = $("<input type=\"submit\" name=\"submit\" value=\"special\" />"),
+                            $target1 = $("<div id=\"target1\" />"),
+                            $target2 = $("<div id=\"target2\" />");
+
+                        $submit2.attr("data-pat-inject", "#someid #target1 && #otherid #target2");
+                        $submit2.attr("formaction", "other.html#otherid");
+                        $form.append($submit1).append($submit2);
+                        $div.append($target1).append($target2);
+
+                        pattern.init($form);
+                        $submit2.trigger("click");
+                        answer("<html><body>" +
+                               "<div id=\"someid\">some</div>" +
+                               "<div id=\"otherid\">other</div>" +
+                               "</body></html>");
+
+                        expect($.ajax).toHaveBeenCalled();
+                        expect($.ajax.mostRecentCall.args[0].url).toContain("submit=special");
+                        expect($.ajax.mostRecentCall.args[0].url).toBe("other.html?submit=special");
+                        expect($target1.html()).toBe("some");
+                        expect($target2.html()).toBe("other");
+                    });
                 });
             });
         });


### PR DESCRIPTION
…different targets can be configured per formaction.

This solves a longstanding issue where you can configure different formactions, but the response of these formactions must be always the same because you can only have one data-pat-inject - the one on the form itself.

This change allows to override the data-pat-inject on the button, or even on a node in between, to configure custom sources and targets.