### PR TITLE
453 scroll calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,10 @@ watch::
 
 ########################################################################
 
-serve:: all
-	@printf "\nDesigner, you can be happy now.\n Go to http://localhost:4001/demo/ to see the demo \n\n"
+serve:: all _serve
+
+_serve:
+	@printf "\nDesigner, you can be happy now.\n Go to http://localhost:4001/ to see the demo \n\n"
 	@$(HTTPSERVE) -p 4001
 
 designerhappy:: serve

--- a/src/pat/scroll/debug.html
+++ b/src/pat/scroll/debug.html
@@ -130,11 +130,11 @@
           <aside>
             <h2>Scroll navigation</h2>
             <ol class="mainnav" id="demo-main-nav">
-                <li><a href="#top" class="pat-scroll defunct">Top</a></li>
-                <li><a href="#p1" class="pat-scroll defunct">Shakespeare's Sonnet 001</a></li>
-                <li><a href="#p2" class="pat-scroll defunct">Shakespeare's Sonnet 002</a></li>
-                <li><a href="#p3" class="pat-scroll defunct">Shakespeare's Sonnet 003</a></li>
-                <li><a href="#bottom" class="pat-scroll defunct">Bottom</a></li>
+                <li><a href="#top" class="pat-scroll">Top</a></li>
+                <li><a href="#p1" class="pat-scroll">Shakespeare's Sonnet 001</a></li>
+                <li><a href="#p2" class="pat-scroll">Shakespeare's Sonnet 002</a></li>
+                <li><a href="#p3" class="pat-scroll">Shakespeare's Sonnet 003</a></li>
+                <li><a href="#bottom" class="pat-scroll">Bottom</a></li>
             </ol>
             <h2>Fragment navigation</h2>
             <ol class="fragnav" id="demo-frag-nav">

--- a/src/pat/scroll/debug.html
+++ b/src/pat/scroll/debug.html
@@ -123,7 +123,7 @@
               <a href="#p1" class="pat-scroll">001</a> | 
               <a href="#p2" class="pat-scroll">002</a> | 
               <a href="#p3" class="pat-scroll">003</a> |
-              <a href="#bottom" class="pat-scroll weird">Bottom</a> |
+              <a href="#bottom" class="pat-scroll">Bottom</a> |
               <a href="#bottom" class="pat-scroll" data-pat-scroll="trigger: auto">Bottom autoscroll</a>
             </p>
         </article>
@@ -146,9 +146,9 @@
             </ol>
             <h2>Injection</h2>
             <ol class="fragnav" id="demo-frag-nav">
-                <li><a href="#p1" class="pat-inject weird" data-pat-inject="source: #p1; target: #p1-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 001</a></li>
-                <li><a href="#p2" class="pat-inject weird" data-pat-inject="source: #p2; target: #p2-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 002</a></li>
-                <li><a href="#p3" class="pat-inject weird" data-pat-inject="source: #p3; target: #p3-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 003</a></li>
+                <li><a href="#p1" class="pat-inject" data-pat-inject="source: #p1; target: #p1-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 001</a></li>
+                <li><a href="#p2" class="pat-inject" data-pat-inject="source: #p2; target: #p2-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 002</a></li>
+                <li><a href="#p3" class="pat-inject" data-pat-inject="source: #p3; target: #p3-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 003</a></li>
             </ol>
             <p>The injection links duplicate the targeted section content, changing the length of the scrollable, then
               also re-inject the bottom auto-scroll link, which should trigger a re-auto-scroll.

--- a/src/pat/scroll/debug.html
+++ b/src/pat/scroll/debug.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<title>Scroll demo</title>
+    	<link rel="stylesheet" href="/style/common.css" type="text/css">
+        <script src="/main.js" type="text/javascript" charset="utf-8"></script>
+		<script data-main="/src/pat/main" src="/src/bower_components/requirejs/require.js" type="text/javascript" charset="utf-8"></script>
+	</head>
+    <style>
+        .current {
+            background-color: beige;
+        }
+        .defunct:after {
+           content: " [defunct]";
+           color: orange;
+        }
+        .weird {
+           font-weight: bold;
+           color: red;
+        }
+        .weird:after {
+           content: " [weird!]"
+        }
+        article {
+            width: 70%;
+            height: 25em;
+            overflow: auto;
+            position: absolute;
+            top: 2em;
+            right: 0;
+        }
+        aside {
+            width: 29%;
+            position: fixed;
+            top: 2em;
+            left: 1em;
+        }
+    </style>
+	<body>
+          <article class="pat-rich">
+            <p id="top">
+              <a href="#top" class="pat-scroll">Top</a> |
+              <a href="#p1" class="pat-scroll">001</a> |
+              <a href="#p2" class="pat-scroll">002</a> |
+              <a href="#p3" class="pat-scroll">003</a> |              
+              <a href="#bottom" class="pat-scroll">Bottom</a>
+            </p>
+            <section id="p1">
+                <h3>1</h3>
+                <p>
+                    From fairest creatures we desire increase,<br>
+                    That thereby beauty's rose might never die,<br>
+                    But as the riper should by time decease,<br>
+                    His tender heir might bear his memory:<br>
+                    But thou contracted to thine own bright eyes,<br>
+                    Feed'st thy light's flame with self-substantial fuel,<br>
+                    Making a famine where abundance lies,<br>
+                    Thy self thy foe, to thy sweet self too cruel:<br>
+                    Thou that art now the world's fresh ornament,<br>
+                    And only herald to the gaudy spring,<br>
+                    Within thine own bud buriest thy content,<br>
+                    And tender churl mak'st waste in niggarding:<br>
+                    Pity the world, or else this glutton be,<br>
+                    To eat the world's due, by the grave and thee.
+                </p>
+                <p id="p1-nav">
+                  <a href="#top" class="pat-scroll">Back to top</a> |
+                  <a href="#p1" class="pat-scroll">001</a> | 
+                  <a href="#p2" class="pat-scroll">002</a> | 
+                  <a href="#p3" class="pat-scroll">003</a> |
+                  <a href="#bottom" class="pat-scroll">Bottom</a>
+                </p>
+            </section>
+            <section id="p2">
+                <h3>2</h3>
+                <p>
+                    When forty winters shall besiege thy brow,<br>
+                    And dig deep trenches in thy beauty's field,<br>
+                    Thy youth's proud livery so gazed on now,<br>
+                    Will be a tattered weed of small worth held:<br>
+                    Then being asked, where all thy beauty lies,<br>
+                    Where all the treasure of thy lusty days;<br>
+                    To say within thine own deep sunken eyes,<br>
+                    Were an all-eating shame, and thriftless praise.<br>
+                    How much more praise deserved thy beauty's use,<br>
+                    If thou couldst answer 'This fair child of mine<br>
+                    Shall sum my count, and make my old excuse'<br>
+                    Proving his beauty by succession thine.<br>
+                    This were to be new made when thou art old,<br>
+                    And see thy blood warm when thou feel'st it cold.
+                </p>
+                <p id="p2-nav">
+                  <a href="#top" class="pat-scroll">Back to top</a> |
+                  <a href="#p1" class="pat-scroll">001</a> | 
+                  <a href="#p2" class="pat-scroll">002</a> | 
+                  <a href="#p3" class="pat-scroll">003</a> |
+                  <a href="#bottom" class="pat-scroll">Bottom</a>
+                </p>                
+            </section>
+            <section id="p3">
+                <h3>3</h3>
+                <p>
+                    Look in thy glass and tell the face thou viewest,<br>
+                    Now is the time that face should form another,<br>
+                    Whose fresh repair if now thou not renewest,<br>
+                    Thou dost beguile the world, unbless some mother.<br>
+                    For where is she so fair whose uneared womb<br>
+                    Disdains the tillage of thy husbandry?<br>
+                    Or who is he so fond will be the tomb,<br>
+                    Of his self-love to stop posterity?<br>
+                    Thou art thy mother's glass and she in thee<br>
+                    Calls back the lovely April of her prime,<br>
+                    So thou through windows of thine age shalt see,<br>
+                    Despite of wrinkles this thy golden time.<br>
+                    But if thou live remembered not to be,<br>
+                    Die single and thine image dies with thee.
+                </p>
+                <p id="p3-nav"></p>
+            </section>
+            <p id="bottom">
+              <a href="#top" class="pat-scroll">Back to top</a> |
+              <a href="#p1" class="pat-scroll">001</a> | 
+              <a href="#p2" class="pat-scroll">002</a> | 
+              <a href="#p3" class="pat-scroll">003</a> |
+              <a href="#bottom" class="pat-scroll weird">Bottom</a> |
+              <a href="#bottom" class="pat-scroll" data-pat-scroll="trigger: auto">Bottom autoscroll</a>
+            </p>
+        </article>
+          <aside>
+            <h2>Scroll navigation</h2>
+            <ol class="mainnav" id="demo-main-nav">
+                <li><a href="#top" class="pat-scroll defunct">Top</a></li>
+                <li><a href="#p1" class="pat-scroll defunct">Shakespeare's Sonnet 001</a></li>
+                <li><a href="#p2" class="pat-scroll defunct">Shakespeare's Sonnet 002</a></li>
+                <li><a href="#p3" class="pat-scroll defunct">Shakespeare's Sonnet 003</a></li>
+                <li><a href="#bottom" class="pat-scroll defunct">Bottom</a></li>
+            </ol>
+            <h2>Fragment navigation</h2>
+            <ol class="fragnav" id="demo-frag-nav">
+                <li><a href="#top">Top</a></li>              
+                <li><a href="#p1">Shakespeare's Sonnet 001</a></li>
+                <li><a href="#p2">Shakespeare's Sonnet 002</a></li>
+                <li><a href="#p3">Shakespeare's Sonnet 003</a></li>
+                <li><a href="#bottom">Bottom</a></li>
+            </ol>
+            <h2>Injection</h2>
+            <ol class="fragnav" id="demo-frag-nav">
+                <li><a href="#p1" class="pat-inject weird" data-pat-inject="source: #p1; target: #p1-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 001</a></li>
+                <li><a href="#p2" class="pat-inject weird" data-pat-inject="source: #p2; target: #p2-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 002</a></li>
+                <li><a href="#p3" class="pat-inject weird" data-pat-inject="source: #p3; target: #p3-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 003</a></li>
+            </ol>
+            <p>The injection links duplicate the targeted section content, changing the length of the scrollable, then
+              also re-inject the bottom auto-scroll link, which should trigger a re-auto-scroll.
+              Clicking these links multiple times demonstrates the "see-saw" effect.</p>
+        </aside>
+	</body>
+</html>

--- a/src/pat/scroll/index.html
+++ b/src/pat/scroll/index.html
@@ -11,41 +11,14 @@
         .current {
             background-color: beige;
         }
-        .defunct:after {
-           content: " [defunct]";
-           color: orange;
-        }
-        .weird {
-           font-weight: bold;
-           color: red;
-        }
-        .weird:after {
-           content: " [weird!]"
-        }
-        article {
-            width: 70%;
-            height: 25em;
-            overflow: auto;
-            position: absolute;
-            top: 2em;
-            right: 0;
-        }
-        aside {
-            width: 29%;
-            position: fixed;
-            top: 2em;
-            left: 1em;
-        }
     </style>
 	<body>
-          <article class="pat-rich">
-            <p id="top">
-              <a href="#top" class="pat-scroll">Top</a> |
-              <a href="#p1" class="pat-scroll">001</a> |
-              <a href="#p2" class="pat-scroll">002</a> |
-              <a href="#p3" class="pat-scroll">003</a> |              
-              <a href="#bottom" class="pat-scroll">Bottom</a>
-            </p>
+        <article class="pat-rich">
+            <ol class="mainnav" id="demo-main-nav">
+                <li><a href="#p1" class="pat-scroll">Shakespeare's Sonnet 001</a></li>
+                <li><a href="#p2" class="pat-scroll">Shakespeare's Sonnet 002</a></li>
+                <li><a href="#p3" class="pat-scroll">Shakespeare's Sonnet 003</a></li>
+            </ol>
             <section id="p1">
                 <h3>1</h3>
                 <p>
@@ -63,14 +36,7 @@
                     And tender churl mak'st waste in niggarding:<br>
                     Pity the world, or else this glutton be,<br>
                     To eat the world's due, by the grave and thee.
-                </p>
-                <p id="p1-nav">
-                  <a href="#top" class="pat-scroll">Back to top</a> |
-                  <a href="#p1" class="pat-scroll">001</a> | 
-                  <a href="#p2" class="pat-scroll">002</a> | 
-                  <a href="#p3" class="pat-scroll">003</a> |
-                  <a href="#bottom" class="pat-scroll">Bottom</a>
-                </p>
+                </p>      
             </section>
             <section id="p2">
                 <h3>2</h3>
@@ -90,13 +56,6 @@
                     This were to be new made when thou art old,<br>
                     And see thy blood warm when thou feel'st it cold.
                 </p>
-                <p id="p2-nav">
-                  <a href="#top" class="pat-scroll">Back to top</a> |
-                  <a href="#p1" class="pat-scroll">001</a> | 
-                  <a href="#p2" class="pat-scroll">002</a> | 
-                  <a href="#p3" class="pat-scroll">003</a> |
-                  <a href="#bottom" class="pat-scroll">Bottom</a>
-                </p>                
             </section>
             <section id="p3">
                 <h3>3</h3>
@@ -116,43 +75,10 @@
                     But if thou live remembered not to be,<br>
                     Die single and thine image dies with thee.
                 </p>
-                <p id="p3-nav"></p>
             </section>
-            <p id="bottom">
-              <a href="#top" class="pat-scroll">Back to top</a> |
-              <a href="#p1" class="pat-scroll">001</a> | 
-              <a href="#p2" class="pat-scroll">002</a> | 
-              <a href="#p3" class="pat-scroll">003</a> |
-              <a href="#bottom" class="pat-scroll weird">Bottom</a> |
-              <a href="#bottom" class="pat-scroll" data-pat-scroll="trigger: auto">Bottom autoscroll</a>
+            <p>
+                <a href="#demo-main-nav" class="pat-scroll" data-pat-scroll="trigger:auto">Back to top</a>
             </p>
         </article>
-          <aside>
-            <h2>Scroll navigation</h2>
-            <ol class="mainnav" id="demo-main-nav">
-                <li><a href="#top" class="pat-scroll defunct">Top</a></li>
-                <li><a href="#p1" class="pat-scroll defunct">Shakespeare's Sonnet 001</a></li>
-                <li><a href="#p2" class="pat-scroll defunct">Shakespeare's Sonnet 002</a></li>
-                <li><a href="#p3" class="pat-scroll defunct">Shakespeare's Sonnet 003</a></li>
-                <li><a href="#bottom" class="pat-scroll defunct">Bottom</a></li>
-            </ol>
-            <h2>Fragment navigation</h2>
-            <ol class="fragnav" id="demo-frag-nav">
-                <li><a href="#top">Top</a></li>              
-                <li><a href="#p1">Shakespeare's Sonnet 001</a></li>
-                <li><a href="#p2">Shakespeare's Sonnet 002</a></li>
-                <li><a href="#p3">Shakespeare's Sonnet 003</a></li>
-                <li><a href="#bottom">Bottom</a></li>
-            </ol>
-            <h2>Injection</h2>
-            <ol class="fragnav" id="demo-frag-nav">
-                <li><a href="#p1" class="pat-inject weird" data-pat-inject="source: #p1; target: #p1-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 001</a></li>
-                <li><a href="#p2" class="pat-inject weird" data-pat-inject="source: #p2; target: #p2-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 002</a></li>
-                <li><a href="#p3" class="pat-inject weird" data-pat-inject="source: #p3; target: #p3-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 003</a></li>
-            </ol>
-            <p>The injection links duplicate the targeted section content, changing the length of the scrollable, then
-              also re-inject the bottom auto-scroll link, which should trigger a re-auto-scroll.
-              Clicking these links multiple times demonstrates the "see-saw" effect.</p>
-        </aside>
 	</body>
 </html>

--- a/src/pat/scroll/index.html
+++ b/src/pat/scroll/index.html
@@ -44,7 +44,7 @@
               <a href="#p1" class="pat-scroll">001</a> |
               <a href="#p2" class="pat-scroll">002</a> |
               <a href="#p3" class="pat-scroll">003</a> |              
-              <a href="#bottom" class="pat-scroll" data-pat-scroll="trigger:auto">Auto scroll to bottom</a>
+              <a href="#bottom" class="pat-scroll">Bottom</a>
             </p>
             <section id="p1">
                 <h3>1</h3>
@@ -64,14 +64,13 @@
                     Pity the world, or else this glutton be,<br>
                     To eat the world's due, by the grave and thee.
                 </p>
-                <p>
+                <p id="p1-nav">
                   <a href="#top" class="pat-scroll">Back to top</a> |
                   <a href="#p1" class="pat-scroll">001</a> | 
                   <a href="#p2" class="pat-scroll">002</a> | 
                   <a href="#p3" class="pat-scroll">003</a> |
                   <a href="#bottom" class="pat-scroll">Bottom</a>
                 </p>
-                
             </section>
             <section id="p2">
                 <h3>2</h3>
@@ -91,6 +90,13 @@
                     This were to be new made when thou art old,<br>
                     And see thy blood warm when thou feel'st it cold.
                 </p>
+                <p id="p2-nav">
+                  <a href="#top" class="pat-scroll">Back to top</a> |
+                  <a href="#p1" class="pat-scroll">001</a> | 
+                  <a href="#p2" class="pat-scroll">002</a> | 
+                  <a href="#p3" class="pat-scroll">003</a> |
+                  <a href="#bottom" class="pat-scroll">Bottom</a>
+                </p>                
             </section>
             <section id="p3">
                 <h3>3</h3>
@@ -110,13 +116,15 @@
                     But if thou live remembered not to be,<br>
                     Die single and thine image dies with thee.
                 </p>
+                <p id="p3-nav"></p>
             </section>
             <p id="bottom">
               <a href="#top" class="pat-scroll">Back to top</a> |
               <a href="#p1" class="pat-scroll">001</a> | 
               <a href="#p2" class="pat-scroll">002</a> | 
               <a href="#p3" class="pat-scroll">003</a> |
-              <a href="#bottom" class="pat-scroll weird">Bottom</a>
+              <a href="#bottom" class="pat-scroll weird">Bottom</a> |
+              <a href="#bottom" class="pat-scroll" data-pat-scroll="trigger: auto">Bottom autoscroll</a>
             </p>
         </article>
           <aside>
@@ -127,7 +135,6 @@
                 <li><a href="#p2" class="pat-scroll defunct">Shakespeare's Sonnet 002</a></li>
                 <li><a href="#p3" class="pat-scroll defunct">Shakespeare's Sonnet 003</a></li>
                 <li><a href="#bottom" class="pat-scroll defunct">Bottom</a></li>
-
             </ol>
             <h2>Fragment navigation</h2>
             <ol class="fragnav" id="demo-frag-nav">
@@ -136,8 +143,16 @@
                 <li><a href="#p2">Shakespeare's Sonnet 002</a></li>
                 <li><a href="#p3">Shakespeare's Sonnet 003</a></li>
                 <li><a href="#bottom">Bottom</a></li>
-                
             </ol>
+            <h2>Injection</h2>
+            <ol class="fragnav" id="demo-frag-nav">
+                <li><a href="#p1" class="pat-inject weird" data-pat-inject="source: #p1; target: #p1-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 001</a></li>
+                <li><a href="#p2" class="pat-inject weird" data-pat-inject="source: #p2; target: #p2-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 002</a></li>
+                <li><a href="#p3" class="pat-inject weird" data-pat-inject="source: #p3; target: #p3-nav::element::after && source: #bottom; target: #bottom">Shakespeare's Sonnet 003</a></li>
+            </ol>
+            <p>The injection links duplicate the targeted section content, changing the length of the scrollable, then
+              also re-inject the bottom auto-scroll link, which should trigger a re-auto-scroll.
+              Clicking these links multiple times demonstrates the "see-saw" effect.</p>
         </aside>
 	</body>
 </html>

--- a/src/pat/scroll/index.html
+++ b/src/pat/scroll/index.html
@@ -11,14 +11,41 @@
         .current {
             background-color: beige;
         }
+        .defunct:after {
+           content: " [defunct]";
+           color: orange;
+        }
+        .weird {
+           font-weight: bold;
+           color: red;
+        }
+        .weird:after {
+           content: " [weird!]"
+        }
+        article {
+            width: 70%;
+            height: 25em;
+            overflow: auto;
+            position: absolute;
+            top: 2em;
+            right: 0;
+        }
+        aside {
+            width: 29%;
+            position: fixed;
+            top: 2em;
+            left: 1em;
+        }
     </style>
 	<body>
-        <article class="pat-rich">
-            <ol class="mainnav" id="demo-main-nav">
-                <li><a href="#p1" class="pat-scroll">Shakespeare's Sonnet 001</a></li>
-                <li><a href="#p2" class="pat-scroll">Shakespeare's Sonnet 002</a></li>
-                <li><a href="#p3" class="pat-scroll">Shakespeare's Sonnet 003</a></li>
-            </ol>
+          <article class="pat-rich">
+            <p id="top">
+              <a href="#top" class="pat-scroll">Top</a> |
+              <a href="#p1" class="pat-scroll">001</a> |
+              <a href="#p2" class="pat-scroll">002</a> |
+              <a href="#p3" class="pat-scroll">003</a> |              
+              <a href="#bottom" class="pat-scroll" data-pat-scroll="trigger:auto">Auto scroll to bottom</a>
+            </p>
             <section id="p1">
                 <h3>1</h3>
                 <p>
@@ -36,7 +63,15 @@
                     And tender churl mak'st waste in niggarding:<br>
                     Pity the world, or else this glutton be,<br>
                     To eat the world's due, by the grave and thee.
-                </p>      
+                </p>
+                <p>
+                  <a href="#top" class="pat-scroll">Back to top</a> |
+                  <a href="#p1" class="pat-scroll">001</a> | 
+                  <a href="#p2" class="pat-scroll">002</a> | 
+                  <a href="#p3" class="pat-scroll">003</a> |
+                  <a href="#bottom" class="pat-scroll">Bottom</a>
+                </p>
+                
             </section>
             <section id="p2">
                 <h3>2</h3>
@@ -76,9 +111,33 @@
                     Die single and thine image dies with thee.
                 </p>
             </section>
-            <p>
-                <a href="#demo-main-nav" class="pat-scroll" data-pat-scroll="trigger:auto">Back to top</a>
+            <p id="bottom">
+              <a href="#top" class="pat-scroll">Back to top</a> |
+              <a href="#p1" class="pat-scroll">001</a> | 
+              <a href="#p2" class="pat-scroll">002</a> | 
+              <a href="#p3" class="pat-scroll">003</a> |
+              <a href="#bottom" class="pat-scroll weird">Bottom</a>
             </p>
         </article>
+          <aside>
+            <h2>Scroll navigation</h2>
+            <ol class="mainnav" id="demo-main-nav">
+                <li><a href="#top" class="pat-scroll defunct">Top</a></li>
+                <li><a href="#p1" class="pat-scroll defunct">Shakespeare's Sonnet 001</a></li>
+                <li><a href="#p2" class="pat-scroll defunct">Shakespeare's Sonnet 002</a></li>
+                <li><a href="#p3" class="pat-scroll defunct">Shakespeare's Sonnet 003</a></li>
+                <li><a href="#bottom" class="pat-scroll defunct">Bottom</a></li>
+
+            </ol>
+            <h2>Fragment navigation</h2>
+            <ol class="fragnav" id="demo-frag-nav">
+                <li><a href="#top">Top</a></li>              
+                <li><a href="#p1">Shakespeare's Sonnet 001</a></li>
+                <li><a href="#p2">Shakespeare's Sonnet 002</a></li>
+                <li><a href="#p3">Shakespeare's Sonnet 003</a></li>
+                <li><a href="#bottom">Bottom</a></li>
+                
+            </ol>
+        </aside>
 	</body>
 </html>

--- a/src/pat/scroll/index.html
+++ b/src/pat/scroll/index.html
@@ -11,9 +11,16 @@
         .current {
             background-color: beige;
         }
+        #debug {
+           float: right;
+        }
+        #debug a {
+            color: #999;
+        }
     </style>
 	<body>
-        <article class="pat-rich">
+          <article class="pat-rich">
+            <p id="debug"><a href="debug.html">(debug page)</a></p>
             <ol class="mainnav" id="demo-main-nav">
                 <li><a href="#p1" class="pat-scroll">Shakespeare's Sonnet 001</a></li>
                 <li><a href="#p2" class="pat-scroll">Shakespeare's Sonnet 002</a></li>

--- a/src/pat/scroll/scroll.js
+++ b/src/pat/scroll/scroll.js
@@ -126,10 +126,12 @@ define([
                 $el = this.options.selector ? $(this.options.selector) : this.$el;
                 options[scroll] = this.options.offset;
             } else {
-                // Get the first element with overflow auto starting from the trigger
-                // (the scroll container)
+                // Get the first element with overflow auto (the scroll container)
+                // starting from the *target*
                 // Then calculate the offset relatively to that container
-                $el = $(this.$el.parents()
+                var target = $(this.$el.attr('href'));
+                
+                $el = $(target.parents()
                     .filter(function() { 
                         return $(this).css('overflow') === 'auto'; })
                     .first())
@@ -138,12 +140,12 @@ define([
                 }
 
                 var scroll_container = Math.floor( $el.offset().top );
-                var target = Math.floor( $(this.$el.attr('href')).offset().top );
+                var target_top = Math.floor( target.offset().top );
 
-                if (target == scroll_container) {
+                if (target_top == scroll_container) {
                     options[scroll] = scroll_container;
-                } else if (target >= scroll_container) {
-                    options[scroll] = target - scroll_container;
+                } else if (target_top >= scroll_container) {
+                    options[scroll] = target_top - scroll_container;
                     $el.animate(options, {
                         duration: 500,
                         start: function() {
@@ -151,7 +153,7 @@ define([
                         }
                     });
                 } else {
-                    options[scroll] = target + scroll_container ;
+                    options[scroll] = target_top + scroll_container ;
                     $el.animate(options, {
                         duration: 500,
                         start: function() {

--- a/src/pat/scroll/scroll.js
+++ b/src/pat/scroll/scroll.js
@@ -140,7 +140,7 @@ define([
                 }
 
                 var scroll_container = Math.floor( $el.offset().top );
-                var target_top = Math.floor( target.offset().top );
+                var target_top = Math.floor( target.prop('offsetTop') );
 
                 if (target_top == scroll_container) {
                     options[scroll] = scroll_container;


### PR DESCRIPTION
This fixes #453 : 2 issues with pat-scroll:

- Offset was calculated as *visible* offset, not taking into account the actual height of an overflowed scrollable, in which part of the dom is not visible.

- There was an assumption that both the trigger link and the target would be contained within the scrollable element. Actually only the target needs to be within the scrollable. This now makes it possible to have working pat-scroll links outside the actual scrollable.