### PR TITLE
Fix masonry layouting

### DIFF
--- a/src/pat/masonry/masonry.js
+++ b/src/pat/masonry/masonry.js
@@ -45,7 +45,7 @@
             this.initMasonry();
             var imgLoad = imagesLoaded(this.$el);
             imgLoad.on("progress", function() {
-                this.msnry.layout();
+                this.layout();
             }.bind(this));
             imgLoad.on("done", this.layout.bind(this));
             // Update if something gets injected inside the pat-masonry


### PR DESCRIPTION
https://github.com/Patternslib/Patterns/commit/e243605ae097ef45cee065c2ae4a95794aedb937 breaks because the masonry-ready class is now only set if imgLoad actually throws a done. If all images are cached, this doesn't happen. I would like to actually call this.layout simply twice, instead of doing only this.msnry.layout() in line 48