### PR TITLE
Layout fix

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -11,6 +11,7 @@
 - Fix ``pat-gallery`` to work with ``requirejs-text`` instead ``requirejs-tpl-jcbrand``.
   Fixes an obscure "window undefined" error.
   Backwards incompatible change: The ``photoswipe-template`` RequireJS configuration variable is removed and a the ``pat-gallery-url`` variable is defined instead.
+- always recalculate masonry also at the very end, even if there are no images to be loaded
 
 ## 2.0.14 - Aug. 15, 2016
 

--- a/src/pat/masonry/masonry.js
+++ b/src/pat/masonry/masonry.js
@@ -45,7 +45,7 @@
             this.initMasonry();
             var imgLoad = imagesLoaded(this.$el);
             imgLoad.on("progress", function() {
-                this.msnry.layout();
+                this.layout();
             }.bind(this));
             imgLoad.on("done", this.layout.bind(this));
             // Update if something gets injected inside the pat-masonry

--- a/src/pat/masonry/masonry.js
+++ b/src/pat/masonry/masonry.js
@@ -47,7 +47,7 @@
             imgLoad.on("progress", function() {
                 this.layout();
             }.bind(this));
-            imgLoad.on("done", this.layout.bind(this));
+            imgLoad.on("always", this.layout.bind(this));
             // Update if something gets injected inside the pat-masonry
             // element.
             this.$el.on("patterns-injected.pat-masonry",


### PR DESCRIPTION
Use always instead of done, because this is called always, not only when images are done loading. This makes sure that we get that final call that will set the masonry-ready class.