### PR TITLE
Trigger a relayout when an update event is triggered by pat-switch et al

### DIFF
--- a/src/pat/masonry/masonry.js
+++ b/src/pat/masonry/masonry.js
@@ -45,13 +45,17 @@
             this.initMasonry();
             var imgLoad = imagesLoaded(this.$el);
             imgLoad.on("progress", function() {
-                this.msnry.layout();
+                this.quicklayout();
             }.bind(this));
             imgLoad.on("done", this.layout.bind(this));
             // Update if something gets injected inside the pat-masonry
             // element.
-            this.$el.on("patterns-injected.pat-masonry",
-                    utils.debounce(this.update.bind(this), 100));
+            this.$el
+                .on("patterns-injected.pat-masonry",
+                    utils.debounce(this.update.bind(this), 100))
+                .parents().on("pat-update", 
+                    utils.debounce(this.quicklayout.bind(this), 200));
+
         },
 
         initMasonry: function () {
@@ -85,6 +89,11 @@
             this.msnry.remove();
             this.initMasonry();
             this.layout();
+        },
+
+        quicklayout: function() {
+            // Just calling again without triggering the class change
+            this.msnry.layout();
         },
 
         layout: function () {


### PR DESCRIPTION
If e.g. a pat-switch changes the amount of space available to or within the masonry, it needs to layout again. Listening to the pat-update event does this.