### PR TITLE
Completely redo the scrolling algorithm.

### DIFF
--- a/src/pat/scroll/debug.html
+++ b/src/pat/scroll/debug.html
@@ -6,7 +6,6 @@
     	<link rel="stylesheet" href="/style/common.css" type="text/css">
         <script src="/main.js" type="text/javascript" charset="utf-8"></script>
 		<script data-main="/src/pat/main" src="/src/bower_components/requirejs/require.js" type="text/javascript" charset="utf-8"></script>
-	</head>
     <style>
         .current {
             background-color: beige;
@@ -22,23 +21,42 @@
         .weird:after {
            content: " [weird!]"
         }
+        .high {
+          height: 100px;
+          background-color: #ddd;
+        }
         article {
             width: 70%;
             height: 25em;
             overflow: auto;
             position: absolute;
-            top: 2em;
-            right: 0;
+            top: 50px;
+           right: 0;
+        border: solid blue 1px;
+           padding: 5px;
         }
         aside {
             width: 29%;
             position: fixed;
-            top: 2em;
+            top: 5em;
             left: 1em;
         }
+        .wrapper {
+          position: relative;
+          border: dotted red 1px;
+          padding: 5px;
+        }
     </style>
+
+	</head>
 	<body>
-          <article class="pat-rich">
+          <article class="pat-rich" id="scrollable">
+            <div class="wrapper"><!-- inner scrollable with position:relative -->
+            <h1>Some more</h1>
+            <p class="high">A lot of stuff above top</p>
+            <h2>.. and more</h2>
+            <div class="wrapper">
+            <p class="high">A lot of stuff above top</p>
             <p id="top">
               <a href="#top" class="pat-scroll">Top</a> |
               <a href="#p1" class="pat-scroll">001</a> |
@@ -126,6 +144,12 @@
               <a href="#bottom" class="pat-scroll">Bottom</a> |
               <a href="#bottom" class="pat-scroll" data-pat-scroll="trigger: auto">Bottom autoscroll</a>
             </p>
+            <p class="high">some extra stuff</p>
+            <p class="high">some extra stuff</p>
+            <p class="high">some extra stuff</p>
+            </div><!-- /wrapper -->
+            </div><!-- /wrapper -->
+            
         </article>
           <aside>
             <h2>Scroll navigation</h2>

--- a/src/pat/scroll/debug.html
+++ b/src/pat/scroll/debug.html
@@ -51,7 +51,6 @@
 	</head>
 	<body>
           <article class="pat-rich" id="scrollable">
-            <div class="wrapper"><!-- inner scrollable with position:relative -->
             <h1>Some more</h1>
             <p class="high">A lot of stuff above top</p>
             <h2>.. and more</h2>
@@ -147,7 +146,6 @@
             <p class="high">some extra stuff</p>
             <p class="high">some extra stuff</p>
             <p class="high">some extra stuff</p>
-            </div><!-- /wrapper -->
             </div><!-- /wrapper -->
             
         </article>

--- a/src/pat/scroll/index.html
+++ b/src/pat/scroll/index.html
@@ -17,9 +17,16 @@
         #debug a {
             color: #999;
         }
+        #scrollable {
+            overflow: auto;
+            // max-height: 500px;
+        }
     </style>
 	<body>
-          <article class="pat-rich">
+          <article style="height:100px">
+            <p>Some filler</p>
+          </article>
+          <article class="pat-rich" id="scrollable">
             <p id="debug"><a href="debug.html">(debug page)</a></p>
             <ol class="mainnav" id="demo-main-nav">
                 <li><a href="#p1" class="pat-scroll">Shakespeare's Sonnet 001</a></li>

--- a/src/pat/scroll/scroll.js
+++ b/src/pat/scroll/scroll.js
@@ -176,6 +176,7 @@ define([
                         break;
                     }
                 }
+                // calculate the  scroll by adding all the relative parent offsets
                 var scroll_to = 0;
                 if ( this.options.direction == "top") {
                     // this assumes the grandparent aligns with the top of the scrollable
@@ -189,7 +190,12 @@ define([
                     });
                 }
                 options[scroll] = Math.floor(scroll_to);
+
+                // now we can and should remove the .inner-scrollable
+                $(inner_scrollable).children().unwrap('.inner-scrollable');
+
             }
+            // execute the scroll
             scrollable.animate(options, {
                 duration: 500,
                 start: function() {

--- a/src/pat/scroll/scroll.js
+++ b/src/pat/scroll/scroll.js
@@ -142,7 +142,10 @@ define([
                 // Immediately *within* the scrollable, around all the scrollable content,
                 // we need a special wrapper div that provides a positioning context
                 // by being position:relative. Let's call this .inner-scrollable.
-                var inner_scrollable = $(scrollable).children()[0];
+                $(scrollable).wrapInner(function() {
+                    return "<div class='inner-scrollable' style='position:relative'></div>";
+                })
+                var inner_scrollable = $(scrollable).children('.inner-scrollable')[0]
                 // This enables us to measure the scrolling distance between the #target
                 // and the top of the scrollable, represented by .inner-scrollable.
                 // We cannot measure directly against the scrollable itself, because if

--- a/src/pat/scroll/scrollcalculation.svg
+++ b/src/pat/scroll/scrollcalculation.svg
@@ -1,0 +1,408 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="297mm"
+   height="210mm"
+   viewBox="0 0 1052.3622 744.09448"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="scrollcalculation.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="480.64598"
+     inkscape:cy="441.68487"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1531"
+     inkscape:window-x="1200"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Laag 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-308.26772)">
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4209"
+       width="349.28571"
+       height="589.28571"
+       x="43.571426"
+       y="408.07651" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#80e5ff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4136-0"
+       width="270.00003"
+       height="352.14285"
+       x="80.714287"
+       y="461.2908" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ff8080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4140"
+       width="240.00002"
+       height="284.28571"
+       x="96.428574"
+       y="498.5051" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4136"
+       width="202.85715"
+       height="190.71428"
+       x="117.14285"
+       y="538.79077" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ff8080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4138"
+       width="169.28572"
+       height="78.571426"
+       x="133.57144"
+       y="564.50507" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffff00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4142"
+       width="157.14287"
+       height="24.285713"
+       x="138.71428"
+       y="609.50507" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="159.28572"
+       y="625.93359"
+       id="text4156"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4158"
+         x="159.28572"
+         y="625.93359">target</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="141.42857"
+       y="529.93365"
+       id="text4160"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4162"
+         x="141.42857"
+         y="529.93365">position:relative</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="145.43938"
+       y="588.07684"
+       id="text4160-0"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4162-3"
+         x="145.43938"
+         y="588.07684">position:relative</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="174.28572"
+       y="435.21939"
+       id="text4211"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4213"
+         x="174.28572"
+         y="435.21939"
+         style="fill:#ffffff;stroke:none">document</tspan></text>
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4223"
+       width="19.285715"
+       height="142.85713"
+       x="354.14279"
+       y="460.79077" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#00ffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4225"
+       width="17.142859"
+       height="38.57143"
+       x="355.57141"
+       y="462.07648" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.61000001;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4136-0-0"
+       width="270.00003"
+       height="139.28571"
+       x="80.571411"
+       y="607.43359" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000080;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="104.00003"
+       y="481.07648"
+       id="text4164"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4166"
+         x="104.00003"
+         y="481.07648">overflow:auto</tspan></text>
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.61000001;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4136-0-0-2"
+       width="270.00003"
+       height="65.714279"
+       x="80.571411"
+       y="746.29077" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#666666;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4209-5"
+       width="349.28571"
+       height="589.28571"
+       x="672.78571"
+       y="409.14795" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#80e5ff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4136-0-1"
+       width="270.00003"
+       height="352.14285"
+       x="709.92859"
+       y="462.36224" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ff8080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4140-1"
+       width="240.00002"
+       height="284.28571"
+       x="725.64288"
+       y="499.57654" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4136-08"
+       width="202.85715"
+       height="190.71428"
+       x="746.35712"
+       y="539.86218" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ff8080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4138-5"
+       width="169.28572"
+       height="78.571426"
+       x="762.78571"
+       y="565.57648" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffff00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4142-0"
+       width="157.14287"
+       height="24.285713"
+       x="767.92859"
+       y="610.57648" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="788.5"
+       y="627.005"
+       id="text4156-6"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4158-4"
+         x="788.5"
+         y="627.005">target</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="770.64288"
+       y="531.00507"
+       id="text4160-6"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4162-2"
+         x="770.64288"
+         y="531.00507">position:relative</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="774.65369"
+       y="589.14825"
+       id="text4160-0-5"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4162-3-8"
+         x="774.65369"
+         y="589.14825">position:relative</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="803.5"
+       y="436.29083"
+       id="text4211-6"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4213-2"
+         x="803.5"
+         y="436.29083"
+         style="fill:#ffffff;stroke:none">document</tspan></text>
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4223-8"
+       width="19.285715"
+       height="142.85713"
+       x="983.35706"
+       y="603.86218" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#00ffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4225-4"
+       width="17.142859"
+       height="38.57143"
+       x="984.78571"
+       y="660.86218" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.61000001;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4136-0-0-7"
+       width="270.00003"
+       height="139.28571"
+       x="709.78571"
+       y="464.50507" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000080;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="733.21429"
+       y="482.14789"
+       id="text4164-2"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4166-4"
+         x="733.21429"
+         y="482.14789">overflow:auto</tspan></text>
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.61000001;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4136-0-0-2-0"
+       width="270.00003"
+       height="65.714279"
+       x="709.78571"
+       y="747.36218" />
+    <path
+       style="fill:#00ffff;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 401,460.93363 c 70.71429,0 70.71429,0 70.71429,0"
+       id="path4466"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#00ffff;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 594.64286,610.93364 c 70.71429,0 70.71429,0 70.71429,0"
+       id="path4466-6"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="416.08127"
+       y="476.21936"
+       id="text4483"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4485"
+         x="416.08127"
+         y="476.21936">START</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="604.93713"
+       y="625.93365"
+       id="text4487"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4489"
+         x="604.93713"
+         y="625.93365">SCROLL</tspan></text>
+    <path
+       style="fill:#00ffff;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 401,602.36221 c 70.71429,0 70.71429,0 70.71429,0"
+       id="path4466-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#00ffff;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 594.64286,753.21935 c 70.71429,0 70.71429,0 70.71429,0"
+       id="path4466-9"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.61000001;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#00ffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4512"
+       width="10.714286"
+       height="42.142857"
+       x="654.28571"
+       y="564.50507" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.61000001;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#00ffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4514"
+       width="10"
+       height="37.857143"
+       x="656.42859"
+       y="462.36218" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.61000001;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#00ffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="rect4512-9"
+       width="10.714286"
+       height="61.428574"
+       x="640.92859"
+       y="499.50507" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="541.28571"
+       y="587.93365"
+       id="text4531"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4533"
+         x="541.28571"
+         y="587.93365"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.25px;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch'">target.offsetTop</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="522.96039"
+       y="531.29395"
+       id="text4531-2"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         id="tspan4533-4"
+         x="522.96039"
+         y="531.29395"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.25px;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch'">parent.offsetTop</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75px;line-height:139.99999762%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans, Normal';text-align:justify;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       x="525.10327"
+       y="481.29391"
+       id="text4531-2-5"
+       sodipodi:linespacing="140%"><tspan
+         sodipodi:role="line"
+         x="525.10327"
+         y="481.29391"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:11.25px;font-family:'Courier 10 Pitch';-inkscape-font-specification:'Courier 10 Pitch'"
+         id="tspan4577">x-parent.offsetTop</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
**edit: the description below is now superseded. See tail of comments **

> 
> **edit** Actually the backward compatibility injection *does* work so no API change!
> 
> The actual calculation is difficult and requires special markup wich is auto-added and also auto-removed again.
> 
> Immediately *within* the scrollable, around all the scrollable content,
> we need a special wrapper div that provides a positioning context
> by being position:relative. Let's call this .inner-scrollable.
> 
> This enables us to measure the scrolling distance between the #target
> and the top of the scrollable, represented by .inner-scrollable.
> We cannot measure directly against the scrollable itself, because if
> the scrollable is scrolled down, there's invisible (overflowed) content
> 'sticking out' *above* the top of the scrollable.
> 
> Using the .inner-scrollable top enables us to measure this top overflow.
> It doesn't matter whether the scrollable itself provides a positioning
> context, since we cannot use that in our calculations anyway.
> 
> Because we use .position() which measures the offset versus the positioning
> context, we need to walk up the dom across all nested positioning contexts
> until we reach the (logical) top of the scrollable: .inner-scrollable.
> We MUST ignore the offset of .inner-scrollable versus the scrollable itself!!!
> 