### PR TITLE
pat-gallery: add option item-selector

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,9 @@
 
 ## 2.1.0 - (unreleased)
 
+- pat-gallery: add option ``item-selector`` for gallery items, which are added to the gallery.
+  Defaults to ``a``.
+  Fixes situations, when gallery items and normal links are mixed within the same container and normal links would open within the gallery lightbox.
 - Update to jQuery 1.11.3.
 - While images are loading, already do masonry layouting.
 - Remove the ``clear-imagesloaded-cache`` trigger, as cache functionality was removed from imagesloaded from version 3.2.0.

--- a/src/pat/gallery/gallery.js
+++ b/src/pat/gallery/gallery.js
@@ -14,6 +14,7 @@ define('pat-gallery', [
     'underscore'
 ], function($, patterns, Base, Parser, PhotoSwipe, PhotoSwipeUI, template, _) {
     var parser = new Parser('gallery');
+    parser.addArgument('item-selector', 'a');  // selector for anchor element, which is added to the gallery.
     parser.addArgument('loop', true);
     parser.addArgument('scale-method', 'fit', ['fit', 'fitNoUpscale', 'zoom']);
     parser.addArgument('delay', 30000);
@@ -28,7 +29,7 @@ define('pat-gallery', [
             if ($('#photoswipe-template').length === 0) {
                 $('body').append(_.template(template)());
             }
-            var images = $('a', this.$el).map(function () {
+            var images = $(this.options.itemSelector, this.$el).map(function () {
                 return { 'w': 0, 'h': 0, 'src': this.href, 'title': $(this).find('img').attr('title') };
             });
             var pswpElement = document.querySelectorAll('.pswp')[0];
@@ -40,7 +41,7 @@ define('pat-gallery', [
                 hideAnimationDuration: this.options.effectDuration,
                 showAnimationDuration: this.options.effectDuration
             };
-            $('a', this.$el).click(function (ev) {
+            $(this.options.itemSelector, this.$el).click(function (ev) {
                 ev.preventDefault();
                 if (this.href) {
                     options.index = _.indexOf(_.pluck(images, 'src'), this.href);

--- a/src/pat/gallery/index.html
+++ b/src/pat/gallery/index.html
@@ -10,10 +10,19 @@
     <script data-main="/src/pat/main" src="/src/bower_components/requirejs/require.js" type="text/javascript" charset="utf-8"></script>
   </head>
   <body>
+    <h1>Normal gallery</h1>
     <nav class="pat-gallery" data-pat-gallery="hide-overlay: 0">
       <a href="full-1.jpg"><img src="thumb-1.jpg" title="Aurora Borealis. Photo by Beverly &amp; Pack"/></a>
       <a href="full-2.jpg"><img src="thumb-2.jpg" title="Photo by Doug88888"/></a>
       <a href="full-3.jpg"><img src="thumb-3.jpg" title="Photy by Paulo Brandao"/></a>
+    </nav>
+    <h1>Gallery with mixed content</h1>
+    <p>Only items which match the selecor ``a.add-to-gallery`` are added.</p>
+    <nav class="pat-gallery" data-pat-gallery="item-selector: a.add-to-gallery">
+      <a href="full-1.jpg" class="add-to-gallery"><img src="thumb-1.jpg" title="Aurora Borealis. Photo by Beverly &amp; Pack"/></a>
+      <a href="full-2.jpg"><img src="thumb-2.jpg" title="Photo by Doug88888"/></a>
+      <a href="">Link only</a>
+      <a href="full-3.jpg" class="add-to-gallery"><img src="thumb-3.jpg" title="Photy by Paulo Brandao"/></a>
     </nav>
   </body>
 </html>


### PR DESCRIPTION
pat-gallery: add option ``item-selector`` for gallery items, which are added to the gallery.
Defaults to ``a``.
Fixes situations, when gallery items and normal links are mixed within the same container and normal links would open within the gallery lightbox.
