### PR TITLE
Pat scroll fix

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -15,6 +15,7 @@
   Fixes an obscure "window undefined" error.
   Backwards incompatible change: The ``photoswipe-template`` RequireJS configuration variable is removed and a the ``pat-gallery-url`` variable is defined instead.
 - always recalculate masonry also at the very end, even if there are no images to be loaded
+- Fix a bug in pat-scroll that would only properly leave nav items alone if their urls end in a slash
 
 ## 2.0.14 - Aug. 15, 2016
 

--- a/src/pat/scroll/scroll.js
+++ b/src/pat/scroll/scroll.js
@@ -61,12 +61,14 @@ define([
         clearIfHidden: function(ev) {
             var active_target = '#' + window.location.hash.substr(1),
                 $active_target = $(active_target),
-                target = this.$el[0].href.split('/').pop();
+                target = '#' + this.$el[0].href.split('#').pop();
+                log.warn($active_target);
+                log.warn(target);
             if ($active_target.length > 0) {
                 if (active_target != target) {
                     // if the element does not match the one listed in the url #,
                     // clear the current class from it.
-                    var $target = $(this.$el[0].href.split('/').pop());
+                    var $target = $('#' + this.$el[0].href.split('#').pop());
                     $target.removeClass("current");
                     this.$el.removeClass("current");
                 }

--- a/src/pat/scroll/scroll.js
+++ b/src/pat/scroll/scroll.js
@@ -62,8 +62,6 @@ define([
             var active_target = '#' + window.location.hash.substr(1),
                 $active_target = $(active_target),
                 target = '#' + this.$el[0].href.split('#').pop();
-                log.warn($active_target);
-                log.warn(target);
             if ($active_target.length > 0) {
                 if (active_target != target) {
                     // if the element does not match the one listed in the url #,


### PR DESCRIPTION
Until now this assumed that a url ends with a slash.

This surfaced when updating jekyll and the default to create pages in directories changed to create pages with .html. That killed the detection of which elements to clear so that all items were always cleared.