### PR TITLE
Pat scroll enhancement

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -16,6 +16,7 @@
   Backwards incompatible change: The ``photoswipe-template`` RequireJS configuration variable is removed and a the ``pat-gallery-url`` variable is defined instead.
 - always recalculate masonry also at the very end, even if there are no images to be loaded
 - Fix a bug in pat-scroll that would only properly leave nav items alone if their urls end in a slash
+- An href can also contain a url left of the hashmark. pat-scroll should only care for the part right of the hashmark
 
 ## 2.0.14 - Aug. 15, 2016
 

--- a/src/pat/scroll/scroll.js
+++ b/src/pat/scroll/scroll.js
@@ -131,7 +131,14 @@ define([
                 // starting from the *target*
                 // The intent is to move target into view within scrollable
                 // if the scrollable has no scrollbar, do not scroll body
-                var target = $(this.$el.attr('href'));
+
+                href = this.$el.attr('href');
+                fragment = href.indexOf('#') !== -1 && href.split('#').pop() || undefined;
+                var target = $('#'+fragment);
+                if (target.length === 0) {
+                    return;
+                }
+
                 scrollable = $(target.parents().filter(function() {
                     return ( $(this).css('overflow') === 'auto' ||
                              $(this).css('overflow') === 'scroll' );


### PR DESCRIPTION
An href can also contain a url left of the hashmark. pat-scroll should only care for the part right of the hashmark