### PR TITLE
Also take the header into account when determining if modal is larger…

### DIFF
--- a/src/pat/modal/modal.js
+++ b/src/pat/modal/modal.js
@@ -124,9 +124,10 @@ define([
             var max_height = $(window).innerHeight() - modal_padding;
             var $tallest_child = this.getTallestChild();
             var tallest_child_height = $tallest_child.outerHeight(true);
+            var header_size = this.$el.find('.header').outerHeight(true);
 
             if (tallest_child_height !== modal_height) {
-                modal_height = tallest_child_height + modal_padding;
+                modal_height = tallest_child_height + header_size + modal_padding;
             }
             if (max_height < modal_height) {
                 this.$el.addClass("max-height").css("height", max_height);


### PR DESCRIPTION
… than viewport

There is a small margin where this problem happens. If the content of a modal is just as big as the viewport with a tolerance of the size of the modal header, this breaks.
This PR includes the header of the modal into the calculation of the modal is too big or not.