### PR TITLE
Use GET to get a vocabulary of words. This avoids CORS blocking of PO…

### DIFF
--- a/src/pat/auto-suggest/auto-suggest.js
+++ b/src/pat/auto-suggest/auto-suggest.js
@@ -181,7 +181,7 @@ define([
                     ajax: {
                         url: pat_config.ajax.url,
                         dataType: pat_config.ajax["data-type"],
-                        type: "POST",
+                        type: "GET",
                         quietMillis: 400,
                         data: function (term, page) {
                             return {


### PR DESCRIPTION
…ST requests

When fetching a words json per ajax, post requests are blocked with a 405 by Github and Jekyll webrick nowadays.

It seems that GET is the default behavior for getting a json of words per ajax (http://select2.github.io/select2/). I don't find any reason why it should be a POST either as we are not writing anything.

So I propose to change this hard coded behavior to GET. 