### PR TITLE
Add a safety border to avoid modals to expand over the full height

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -19,6 +19,7 @@
 - An href can also contain a url left of the hashmark. pat-scroll should only care for the part right of the hashmark
 - Issue a delayed redraw of the calendar to prevent rendering race conditions
 - make list of calendar categories unique to speed up js processing on sites with many calendars.
+- Add a safety border to avoid modals to expand over the full height 
 
 ## 2.0.14 - Aug. 15, 2016
 

--- a/src/pat/modal/modal.js
+++ b/src/pat/modal/modal.js
@@ -121,12 +121,13 @@ define([
         resize: function() {
             var modal_height = this.$el.outerHeight(true);
             var modal_padding = modal_height - this.$el.outerHeight();
-            var max_height = $(window).innerHeight() - modal_padding;
+            // Introducing an arbitrary amount of padding that should always be given for a modal to keep a safety distance to the edges of a browser
+            var max_height = $(window).innerHeight() - modal_padding - 100;
             var $tallest_child = this.getTallestChild();
             var tallest_child_height = $tallest_child.outerHeight(true);
             var header_size = this.$el.find('.header').outerHeight(true);
 
-            if (tallest_child_height !== modal_height) {
+            if (tallest_child_height > modal_height - header_size) {
                 modal_height = tallest_child_height + header_size + modal_padding;
             }
             if (max_height < modal_height) {


### PR DESCRIPTION
Attempt to get rid of the calculation issue where the modal is "just" too big for the modal.