### PR TITLE
Don't close a tooltip if validation warnings show

### DIFF
--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -288,6 +288,10 @@ define([
                 if (data.pattern == "clone" && data.action == "remove") {
                     this.validateForm(ev);
                 }
+            } else if (data.pattern == "validation") {
+                // validation throws pat-update itself. If that happens within a tooltip, the tooltip closes.
+                // returning false here prevents this. @jc, any idea why this is a fix and whether this is harmful?
+                return false;
             }
             return true;
         },


### PR DESCRIPTION
@jcbrand do you have perhaps an idea why this works and whether it poses any problems?

In calendar, when I add an event by clicking into a day, a tooltip with the add event form opens. If I enter an invalid date or don't enter a title, validation is triggered, throws a pat-update, catches that itself, returns true and the tooltip closes. 

If I catch it like in this PR, all seems to behave fine.