### PR TITLE
pat-masonry: initialize just before layouting

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,7 @@
 
 ## 2.1.0 - (unreleased)
 
+- pat-masonry: Initialize masonry just before layouting gets startet, which is after first image has been loaded or at loading has finished. This avoids overlapping images while they are still being loaded.
 - pat-gallery: UX improvements - do not close on scroll or pinch.
 - pat-gallery: UX improvements - remove scrollbars when gallery is opened. 
 - pat-gallery: add option ``item-selector`` for gallery items, which are added to the gallery.

--- a/src/pat/masonry/masonry.js
+++ b/src/pat/masonry/masonry.js
@@ -42,12 +42,19 @@
 
         init: function masonryInit($el, opts) {
             this.options = parser.parse(this.$el, opts);
-            this.initMasonry();
             var imgLoad = imagesLoaded(this.$el);
             imgLoad.on("progress", function() {
+                if (! this.msnry) {
+                    this.initMasonry();
+                }
                 this.quicklayout();
             }.bind(this));
-            imgLoad.on("always", this.layout.bind(this));
+            imgLoad.on("always", function () {
+                if (! this.msnry) {
+                    this.initMasonry();
+                }
+                this.layout();
+            }.bind(this));
             // Update if something gets injected inside the pat-masonry
             // element.
             this.$el


### PR DESCRIPTION
pat-masonry: Initialize masonry just before layouting gets startet, which is after first image has been loaded or at loading has finished.
This avoids overlapping images while they are still being loaded.