### PR TITLE
Added an option to select (or omit) the header

### DIFF
--- a/src/pat/modal/index.html
+++ b/src/pat/modal/index.html
@@ -10,7 +10,7 @@
 	<body>
 		<form action="#modal-source" method="get" class="pat-modal">
 			<fieldset class="button-bar">
-				<button type="submit" class="pat-button">Open a Modal panel via a form submit</button> 
+				<button type="submit" class="pat-button">Open a Modal panel via a form submit</button>
 			</fieldset>
 		</form>
 		<p>
@@ -19,13 +19,41 @@
 		<p>
 			Open a <a href="#modal-source" class="pat-modal" data-pat-modal="class: large"> Modal panel with an extra class 'large' on it</a>.
 		</p>
+    <p>
+			Open a <a href="#modal-source-headerless" class="pat-modal" data-pat-modal="panel-header-content: none"> Modal with no header</a>.
+		</p>
+
+    <p>
+			Open a <a href="#modal-source-customheader" class="pat-modal" data-pat-modal="panel-header-content: .custom-header"> Modal with a custom header</a>.
+		</p>
 
 		<div id="modal-source" hidden>
 			<h3>
 				Modal example
 			</h3>
 			<p>
-				Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. 
+				Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
+			</p>
+		</div>
+
+    <div id="modal-source-headerless" hidden>
+      <h3>
+				Header goes into panel
+			</h3>
+			<p>
+				Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
+			</p>
+		</div>
+
+    <div id="modal-source-customheader" hidden>
+      <h3>
+				Use the custom one instead of me
+			</h3>
+      <h3 class="custom-header">
+        Custom header
+      </h3>
+			<p>
+				Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
 			</p>
 		</div>
 

--- a/src/pat/modal/modal.js
+++ b/src/pat/modal/modal.js
@@ -10,6 +10,7 @@ define([
     parser.addArgument("class");
     parser.addArgument("closing", ["close-button"], ["close-button", "outside"], true);
     parser.addArgument("close-text", 'Close');
+    parser.addArgument("panel-header-content", ":first:not(.header)");
 
     return Base.extend({
         name: "modal",
@@ -50,15 +51,21 @@ define([
             if (this.options.closing.indexOf("close-button")!==-1) {
                 $("<button type='button' class='close-panel'>" + this.options.closeText + "</button>").appendTo($header);
             }
+
             // We cannot handle text nodes here
-            var $children = this.$el.children(":last, :not(:first)");
+            if (this.options.panelHeaderContent === "none") {
+              var $children = this.$el.children();
+            } else {
+              var $children = this.$el.children(":last, :not(" + this.options.panelHeaderContent +")");
+            }
+
             if ($children.length) {
                 $children.wrapAll("<div class='panel-content' />");
             } else {
                 this.$el.append("<div class='panel-content' />");
             }
             $(".panel-content", this.$el).before($header);
-            this.$el.children(":first:not(.header)").prependTo($header);
+            this.$el.children(this.options.panelHeaderContent).prependTo($header);
 
             // Restore focus in case the active element was a child of $el and
             // the focus was lost during the wrapping.


### PR DESCRIPTION
This change allows it to configure the behavior of pat-modal which moves the first child of the panel-content into the header. With the windows-style modal boxes going slowly away and the move to mobile style modals, we want to be able to steer that behavior. 

This PR is done to be backwards compatible. So if you don't do anything, all will work like before. If you add the new attribute 'panel-header-content: .custom-header' (or even set it to none for no moving), you can make use of the new functionality.