### PR TITLE
pat-masonry: fix layout of nested .pat-masonry elements

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -5,6 +5,7 @@
 - fix input-change-events for <input type="number" />
 - pat-autosubmit: allow nested autosubmitting subforms with different delays.
 - pat-masonry: Initialize masonry just before layouting gets startet, which is after first image has been loaded or at loading has finished. This avoids overlapping images while they are still being loaded.
+- pat-masonry: fix layout of nested .pat-masonry elements
 - pat-gallery: UX improvements - do not close on scroll or pinch.
 - pat-gallery: UX improvements - remove scrollbars when gallery is opened.
 - pat-gallery: add option ``item-selector`` for gallery items, which are added to the gallery.

--- a/src/pat/masonry/masonry.js
+++ b/src/pat/masonry/masonry.js
@@ -60,7 +60,7 @@
             this.$el
                 .on("patterns-injected.pat-masonry",
                     utils.debounce(this.update.bind(this), 100))
-                .parents().on("pat-update", 
+                .parents().on("pat-update",
                     utils.debounce(this.quicklayout.bind(this), 200));
 
         },
@@ -109,6 +109,11 @@
                 this.$el.addClass("masonry-ready");
             }.bind(this));
             this.msnry.layout();
+            this.$el.find('.pat-masonry').each(
+                function(idx, child) {
+                    $(child).patMasonry('quicklayout');
+                }
+           );
         },
 
         getTypeCastedValue: function (original) {


### PR DESCRIPTION
This patch fixes the layout of nested .pat-masonry elements by calling a `quicklayout` on the children.