### PR TITLE
Resize a masonry that contains an equalize after the latter has been …

### DIFF
--- a/src/pat/equaliser/equaliser.js
+++ b/src/pat/equaliser/equaliser.js
@@ -24,8 +24,8 @@ define([
                 var $container = $(this),
                     options = parser.parse($container, opts);
                 $container.data("pat-equaliser", options);
-                $container.on("pat-update.pat-equaliser", null, this, equaliser._onEvent);
-                $container.on("patterns-injected.pat-equaliser", null, this, equaliser._onEvent);
+                $container.on("pat-update.pat-equaliser", null, this, utils.debounce(equaliser._onEvent, 100));
+                $container.on("patterns-injected.pat-equaliser", null, this, utils.debounce(equaliser._onEvent, 100));
                 $(window).on("resize.pat-equaliser", null, this, utils.debounce(equaliser._onEvent, 100));
                 $container.parents('.pat-stacks').on("pat-update", null, this, utils.debounce(equaliser._onEvent, 100));
                 imagesLoaded(this, $.proxy(function() {
@@ -54,7 +54,7 @@ define([
 
             var new_css = {height: max_height+"px"};
 
-            switch (options.transition) {
+            switch (options && options.transition) {
                 case "none":
                     $children.css(new_css).addClass("equalised");
                     break;
@@ -64,6 +64,7 @@ define([
                     });
                     break;
             }
+            $container.trigger('pat-update', {pattern: 'equaliser'});
         },
 
         _onEvent: function(event) {
@@ -76,5 +77,3 @@ define([
     patterns.register(equaliser);
     return equaliser;
 });
-
-

--- a/src/pat/masonry/masonry.js
+++ b/src/pat/masonry/masonry.js
@@ -60,7 +60,7 @@
             this.$el
                 .on("patterns-injected.pat-masonry",
                     utils.debounce(this.update.bind(this), 100))
-                .parents().on("pat-update",
+                .on("pat-update",
                     utils.debounce(this.quicklayout.bind(this), 200));
 
         },
@@ -99,7 +99,16 @@
         },
 
         quicklayout: function() {
-            // Just calling again without triggering the class change
+            if (!this.msnry) {
+                // Not initialized yet
+                return;
+            }
+            // call masonry layout on the children before calling it on this element
+            this.$el.find('.pat-masonry').each(
+                function(idx, child) {
+                    $(child).patMasonry('quicklayout');
+                }
+            );
             this.msnry.layout();
         },
 
@@ -109,11 +118,7 @@
                 this.$el.addClass("masonry-ready");
             }.bind(this));
             this.msnry.layout();
-            this.$el.find('.pat-masonry').each(
-                function(idx, child) {
-                    $(child).patMasonry('quicklayout');
-                }
-           );
+            this.quicklayout();
         },
 
         getTypeCastedValue: function (original) {


### PR DESCRIPTION
…updated

This is a follow up of #505.

If a .pat-masonry element contains a .pat-equalise, when this one is updated it will trigger a `pat-updated` event that will cause the parent pat-masonry to resize properly and will also resize its children pat-masonry.