### PR TITLE
pat-modal fix to avoid collisions with pat-collapsible

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.1.1 - unreleased
+
+- pat-modal: Only add a panel-header to the first panel-content element within pat-modal, not everyone. Otherwise this may collide with pat-collapsible which also creates a panel-content class further down the DOM (pilz)
+
+
 ## 2.1.0 - Jun. 26, 2017
 
 - pat-gallery: Also include the node with the ``pat-gallery`` class trigger for initializing the gallery.

--- a/src/pat/modal/modal.js
+++ b/src/pat/modal/modal.js
@@ -64,7 +64,7 @@ define([
             } else {
                 this.$el.append("<div class='panel-content' />");
             }
-            $(".panel-content", this.$el).before($header);
+            this.$el.children(".panel-content").before($header);
             this.$el.children(this.options.panelHeaderContent).prependTo($header);
 
             // Restore focus in case the active element was a child of $el and


### PR DESCRIPTION
pat-modal: Only add a panel-header to the first panel-content element within pat-modal, not everyone. Otherwise this may collide with pat-collapsible which also creates a panel-content class further down the DOM (pilz)