### PR TITLE
move checked class behaviour to pat-checklist

### DIFF
--- a/_sass/_patterns.scss
+++ b/_sass/_patterns.scss
@@ -46,5 +46,5 @@
 @import "src/pat/switch/switch";
 @import "src/pat/toggle/toggle";
 @import "src/pat/tooltip/tooltip";
-@import "src/pat/validate/validate";
+@import "src/pat/validation/validation";
 @import "src/pat/zoom/zoom";

--- a/src/pat/selectbox/selectbox.js
+++ b/src/pat/selectbox/selectbox.js
@@ -12,7 +12,7 @@ define([
 ], function($, patterns) {
     var selectbox = {
         name: "selectbox",
-        trigger: "select",
+        trigger: ".pat-select,.pat-selectbox",
 
         init: function($el) {
             var $forms = $();

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -19,7 +19,7 @@ define([
     "pat-bumper",
     "pat-calendar",
     "pat-carousel",
-    "pat-checkedflag",
+//    "pat-checkedflag",
     "pat-checklist",
     "pat-chosen",
     "pat-clone",

--- a/style/patterns.css
+++ b/style/patterns.css
@@ -10,7 +10,6 @@
 @import url(/patternslib/style/fontello/css/fontello.css);
 @import url(/patternslib/style/fontello/css/fontello.css);
 @import url(/patternslib/style/fontello/css/fontello.css);
-@import url(/patternslib/style/fontello/css/fontello.css);
 .pat-button {
   font-family: "Source Sans Pro", sans-serif;
   margin: 0 0.5em 0 0;
@@ -4793,52 +4792,5 @@ li.mode-Blue {
       overflow: auto; }
     .tooltip-container.type-auto > .close-panel, .tooltip-container.type-sticky > .close-panel, .tooltip-container.type-close-button > .close-panel {
       display: block; } }
-.pat-checklist > br {
-  display: none; }
-.pat-checklist label {
-  padding-left: 1.5em;
-  position: relative;
-  display: block; }
-  .pat-checklist label.checked:before, .pat-checklist label.unchecked:before {
-    font-family: fontello;
-    content: "󢀂";
-    float: left;
-    position: absolute;
-    left: 0;
-    top: 0em; }
-  .pat-checklist label.checked:before {
-    content: "󢀃"; }
-  .pat-checklist label input[type="checkbox"],
-  .pat-checklist label input[type="radio"] {
-    opacity: 0;
-    position: absolute; }
-.pat-checklist.radio label:before {
-  content: "󢀀"; }
-.pat-checklist.radio label.checked:before {
-  content: "󢀁"; }
-.pat-checklist fieldset.composed {
-  padding-left: 0;
-  margin-bottom: 0;
-  position: relative; }
-
-label.valid, fieldset.valid {
-  background-color: #f5fff5; }
-
-label.warning, fieldset.warning {
-  background-color: #ffefe6; }
-
-/* @group Form messages */
-form em.validation.message {
-  margin-top: 0.5em;
-  margin-bottom: 1em;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  box-sizing: border-box; }
-
-.horizontal label em.validation.message {
-  clear: both;
-  width: 185%; }
-
-/* @end */
 
 /*# sourceMappingURL=patterns.css.map */


### PR DESCRIPTION
pat-checkedlist is a pattern which was developer induced. It's functionality should be implemented by pat-selectbox and pat-checklist instead. This PR moves relevant code to handle checked classes on labels from checkedflag to checklist.