### PR TITLE
Wait for injection to be triggered before closing the tooltip

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,7 @@ Breaking Changes
 
 - fixed path to spectrum-colorpicker
 - fixed #512 by also setting the data-option-value attribute
+- pat-tooltip: before hiding the tooltip wait for the injection to be triggered. (ale-rt)
 
 
 ## 2.1.2 - Aug. 29, 2017


### PR DESCRIPTION
On recent chrome versions, if you have tooltip containing a `form.pat-inject`, the form may not be submitted when you submit it clickiing on a `.close-panel` button with the following error:
```
Form submission canceled because the form is not connected
```

This patch prevents the error hiding the tooltip only after the injection is triggered.

Closes ploneintranet/issues#1498