### PR TITLE
Fix pat-switch

### DIFF
--- a/src/pat/switch/switch.js
+++ b/src/pat/switch/switch.js
@@ -83,6 +83,7 @@ define([
                 if (option._storage)
                     option._storage.set(option.selector, {remove: option.remove, add: option.add});
             }
+            $trigger.trigger('resize');
         },
 
         _validateOptions: function(options) {


### PR DESCRIPTION
This fixes the injection of links with the option `trigger: autoload-visible` inside an hidden element made visible after a pat-switch event.