### PR TITLE
Fix pat validation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@ Breaking Changes
     Has been superceeded by pat-validation and is no longer maintained.
   - pat-checkedflag will go away. Its functionality is duplicated by pat-select and pat-checklist
 
+- pat-validation: fix date validation
 - pat-switch: after a switch occurs, trigger a resize event (some elements may have been appeared and we might need a redraw)
 - fixed path to spectrum-colorpicker
 - fixed #512 by also setting the data-option-value attribute

--- a/src/pat/validation/tests.js
+++ b/src/pat/validation/tests.js
@@ -127,6 +127,29 @@ define(["pat-registry", "pat-validation"], function(registry, pattern) {
             expect($el.find('em.warning').text()).toBe("Slegs heelgetalle");
         });
 
+        it("validates dates", function() {
+            var $el = $(
+                '<form class="pat-validation">'+
+                    '<input type="date" name="date" data-pat-validation="type: date;">'+
+                '</form>');
+            var $input = $el.find(':input');
+            $input.val('2000-02-30');
+            pattern.init($el);
+            $input.trigger('change');
+            expect($el.find('em.warning').length).toBe(1);
+            expect($el.find('em.warning').text()).toBe("This value must be a valid date");
+
+            $el = $(
+                '<form class="pat-validation">'+
+                    '<input type="date" name="date" data-pat-validation="type: date;">'+
+                '</form>');
+            $input = $el.find(':input');
+            $input.val('2000-02-28');
+            pattern.init($el);
+            $input.trigger('change');
+            expect($el.find('em.warning').length).toBe(0);
+        });
+
         it("doesn't validate disabled elements", function() {
             var $el = $(
                 '<form class="pat-validation">'+

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -35,6 +35,21 @@ define([
         'date': 'date'
     };
 
+    // Before using it we must add the parse and format functions
+    // Here is a sample implementation using moment.js
+    validate.extend(validate.validators.datetime, {
+      // The value is guaranteed not to be null or undefined but otherwise it
+      // could be anything.
+      parse: function(value, options) {
+        return +moment.utc(value);
+      },
+      // Input is a unix timestamp
+      format: function(value, options) {
+        var format = options.dateOnly ? "YYYY-MM-DD" : "YYYY-MM-DD hh:mm:ss";
+        return moment.utc(value).format(format);
+      }
+    });
+
     return Base.extend({
         name: "validation",
         trigger: "form.pat-validation",


### PR DESCRIPTION
Currently the validation of date inputs is broken because we need to pass a format and a parser, see:

- https://validatejs.org/#validators-date