### PR TITLE
Clicking on an autoload visible link should inject properly

### DIFF
--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -660,11 +660,13 @@ define([
             var $scrollable = $el.parents(":scrollable"), checkVisibility;
 
             // function to trigger the autoload and mark as triggered
-            function trigger() {
+            function trigger(event) {
                 $el.data("pat-inject-autoloaded", true);
                 inject.onTrigger.apply($el[0], []);
+                event && event.preventDefault();
                 return true;
             }
+            $el.click(trigger);
 
             // Use case 1: a (heigh-constrained) scrollable parent
             if ($scrollable.length) {
@@ -676,7 +678,7 @@ define([
                     }
                     if (!$el.is(":visible")) {
                         return false;
-                    } 
+                    }
                     var reltop = $el.offset().top - $scrollable.offset().top - 1000,
                         doTrigger = reltop <= $scrollable.innerHeight();
                     if (doTrigger) {
@@ -761,7 +763,7 @@ define([
             }
             return;
         }
-        // Not only change the URL, also reload the page. 
+        // Not only change the URL, also reload the page.
         window.location.reload();
     });
 


### PR DESCRIPTION
Fixes an issue that happens when the autoload visible link is injected in a collapsed element (see #555).
The collapsed element has no scrollbar until it is expanded.
When it is expanded and we scroll down until the link is visible it is already too late: the link will not be injected.
Clicking it was not triggering the injection.
Only resizing the window triggered the injection.