### PR TITLE
speed up by switching to sets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,8 @@ Breaking Changes
 - Extend pat-focus to add `has-value` class and `data-placeholder` attribute.
 - Add idle trigger to injection.
 - Fixed injection so that urls with data: in them don't get prefixed with a / anymore.
+- pat-checklist now uses Sets to collect its siblings, that should make it much faster with large lists of icons.
+
 
 ## 2.1.2 - Aug. 29, 2017
 

--- a/src/pat/checklist/checklist.js
+++ b/src/pat/checklist/checklist.js
@@ -133,19 +133,23 @@ define([
 
         /* The following methods are moved here from pat-checked-flag, which is being deprecated */
         _getLabelAndFieldset: function(el) {
-            var $result = $(utils.findLabel(el));
-            return $result.add($(el).closest("fieldset"));
+            var result = new Set();
+            result.add($(utils.findLabel(el)) );
+            result.add($(el).closest("fieldset"));
+            return result;
         },
 
         _getSiblingsWithLabelsAndFieldsets: function(el) {
             var selector = "input[name=\""+el.name+"\"]",
                 $related = (el.form===null) ? $(selector) : $(selector, el.form),
                 $result = $();
+            var result = new Set();
             $result = $related=$related.not(el);
+            $result.each(function(item) {result.add($result[item])});
             for (var i=0; i<$related.length; i++) {
-                $result=$result.add(_._getLabelAndFieldset($related[i]));
+                result = new Set ([...result, ..._._getLabelAndFieldset($related[i]) ] );
             }
-            return $result;
+            return result;
         },
 
         _onChangeCheckbox: function() {
@@ -184,11 +188,16 @@ define([
 
             if ($el.closest("ul.radioList").length) {
                 $label=$label.add($el.closest("li"));
-                $siblings=$siblings.closest("li");
+                var newset = new Set();
+                for (item of $siblings.values()) {
+                    newset.add($(item).closest("li"));
+                }
+                $siblings=newset;
             }
 
             if (update_siblings) {
-                 $siblings.removeClass("checked").addClass("unchecked");
+                for (item of $siblings.values())
+                     $(item).removeClass("checked").addClass("unchecked");
             }
             if (input.checked) {
                 $label.add($fieldset).removeClass("unchecked").addClass("checked");


### PR DESCRIPTION
…ecause of some bugs in sizzle.uniquesort. Upgrading to jQuery 3 would solve this. As an alternative, we can use ES5 Sets to circumvent the problem.

Refs:
- https://bugs.jquery.com/ticket/13331
- https://github.com/jquery/sizzle/issues/191
<img width="1279" alt="js-profile" src="https://user-images.githubusercontent.com/138906/34440897-b75b73b8-ecb8-11e7-8381-a8c1e58f7583.png">
