### PR TITLE
Support delay on click

### DIFF
--- a/src/pat/inject/index.html
+++ b/src/pat/inject/index.html
@@ -14,7 +14,7 @@
 			</p>
 			<ul>
 				<li>
-					<a href="inject-sources.html#pos-1" class="pat-inject">Place "Rilke" in column 1</a> 
+					<a href="inject-sources.html#pos-1" class="pat-inject" data-pat-inject="delay: 2000">Place "Rilke" in column 1 after 2 seconds</a>
 					<em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">&lt;a href=&quot;inject-sources.html#pos-1&quot; class=&quot;pat-inject&quot;&gt;</code></em>
 				</li>
 				<li>

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -95,6 +95,11 @@ define([
             } else {
                 switch (cfgs[0].trigger) {
                 case "default":
+                    cfgs.forEach(function(cfg) {
+                        if (cfg.delay) {
+                            cfg.processDelay = cfg.delay;
+                        }
+                    });
                     // setup event handlers
                     if ($el.is("form")) {
                         $el.on("submit.pat-inject", inject.onTrigger)
@@ -204,6 +209,7 @@ define([
                 }
 
                 cfg.selector = cfg.selector || defaultSelector;
+                cfg.processDelay = 0;
             });
             return cfgs;
         },
@@ -457,9 +463,11 @@ define([
             inject.stopBubblingFromRemovedElement($el, cfgs, ev);
             sources$ = inject.callTypeHandler(cfgs[0].dataType, "sources", $el, [cfgs, data, ev]);
             cfgs.forEach(function(cfg, idx) {
-                cfg.$target.each(function() {
-                    inject._performInjection.apply(this, [$el, sources$[idx], cfg, ev.target]);
-                });
+                setTimeout(function() {
+                    cfg.$target.each(function() {
+                        inject._performInjection.apply(this, [$el, sources$[idx], cfg, ev.target]);
+                    });
+                }, cfg.processDelay);
             });
             if (cfgs[0].nextHref && $el.is("a")) {
                 // In case next-href is specified the anchor's href will


### PR DESCRIPTION
This adds support for `delay` on normal click triggers for injection. Note that the timer starts counting from the moment the AJAX call has completed.