### PR TITLE
Support time units

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -421,6 +421,23 @@ define([
         }
     };
 
+    function parseTime(time) {
+        var m = /^(\d+(?:\.\d+)?)\s*(\w*)/.exec(time);
+        if (!m) {
+            throw new Error('Invalid time');
+        }
+        var amount = parseFloat(m[1])
+        switch (m[2]) {
+            case 's':
+                return Math.round(amount * 1000);
+            case 'm':
+                return Math.round(amount * 1000 * 60);
+            case 'ms':
+            default:
+                return Math.round(amount);
+        }
+    }
+
     var utils = {
         // pattern pimping - own module?
         jqueryPlugin: jqueryPlugin,
@@ -437,7 +454,8 @@ define([
         removeDuplicateObjects: removeDuplicateObjects,
         mergeStack: mergeStack,
         isElementInViewport: isElementInViewport,
-        hasValue: hasValue
+        hasValue: hasValue,
+        parseTime: parseTime
     };
     return utils;
 });

--- a/src/pat/inject/index.html
+++ b/src/pat/inject/index.html
@@ -14,7 +14,7 @@
 			</p>
 			<ul>
 				<li>
-					<a href="inject-sources.html#pos-1" class="pat-inject" data-pat-inject="delay: 2000ms">Place "Rilke" in column 1 after 2 seconds</a>
+					<a href="inject-sources.html#pos-1" class="pat-inject" data-pat-inject="delay: 2s">Place "Rilke" in column 1 after 2 seconds</a>
 					<em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">&lt;a href=&quot;inject-sources.html#pos-1&quot; class=&quot;pat-inject&quot;&gt;</code></em>
 				</li>
 				<li>

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -20,7 +20,7 @@ define([
     parser.addArgument("next-href");
     parser.addArgument("source");
     parser.addArgument("trigger", "default", ["default", "autoload", "autoload-visible", "idle"]);
-    parser.addArgument("delay", 0);    // only used in autoload
+    parser.addArgument("delay");    // only used in autoload
     parser.addArgument("confirm", 'class', ['never', 'always', 'form-data', 'class']);
     parser.addArgument("confirm-message", 'Are you sure you want to leave this page?');
     parser.addArgument("hooks", [], ["raptor"], true); // After injection, pat-inject will trigger an event for each hook: pat-inject-hook-$(hook)
@@ -209,6 +209,14 @@ define([
                 }
 
                 cfg.selector = cfg.selector || defaultSelector;
+                if (cfg.delay) {
+                    try {
+                        cfg.delay = utils.parseTime(cfg.delay);
+                    } catch (e) {
+                        log.warn("Invalid delay value: ", cfg.delay)
+                        cfg.delay = null;
+                    }
+                }
                 cfg.processDelay = 0;
             });
             return cfgs;

--- a/src/pat/tooltip/tooltip.js
+++ b/src/pat/tooltip/tooltip.js
@@ -10,10 +10,11 @@ define([
     "jquery",
     "pat-logger",
     "pat-registry",
+    "pat-utils",
     "pat-parser",
     "pat-inject",
     "pat-remove"
-], function($, logger, registry, Parser, inject) {
+], function($, logger, registry, utils, Parser, inject) {
     var log = logger.getLogger("tooltip"),
         parser = new Parser("tooltip");
 
@@ -28,7 +29,7 @@ define([
     parser.addArgument("closing", "auto", ["auto", "sticky", "close-button"]);
     parser.addArgument("source", "title", ["auto", "ajax", "content", "content-html", "title"]);
     parser.addArgument("ajax-data-type", "html", ["html", "markdown"]);
-    parser.addArgument("delay", 0);
+    parser.addArgument("delay");
     parser.addArgument("mark-inactive", true);
     parser.addArgument("class");
     parser.addArgument("target", "body");
@@ -45,6 +46,10 @@ define([
                 var $trigger = $(this),
                     href,
                     options = parser.parse($trigger, opts);
+
+                if (options.delay) {
+                    options.delay = utils.parseTime(options.delay);
+                }
 
                 if (options.source==="auto") {
                     href = $trigger.attr("href");

--- a/tests/specs/core/utils.js
+++ b/tests/specs/core/utils.js
@@ -332,4 +332,35 @@ define(["underscore", "pat-utils"], function(_, utils) {
             expect(utils.hasValue(el)).toBeTruthy();
         });
     });
+
+    describe("parseTime", function() {
+        it("raises exception for invalid input", function() {
+            var p = function() {
+                utils.parseTime("abc");
+            };
+            expect(p).toThrow();
+        });
+
+        it("handles units", function() {
+            expect(utils.parseTime("1000ms")).toBe(1000);
+            expect(utils.parseTime("1s")).toBe(1000);
+            expect(utils.parseTime("1m")).toBe(60000);
+        });
+
+        it("accepts fractional units", function() {
+            expect(utils.parseTime("0.5s")).toBe(500);
+        });
+
+        it("rounds fractional units to whole milliseconds", function() {
+            expect(utils.parseTime("0.8ms")).toBe(1);
+        });
+
+        it("assumes milliseconds by default", function() {
+            expect(utils.parseTime("1000")).toBe(1000);
+        });
+
+        it("treats unknown units as milliseconds", function() {
+            expect(utils.parseTime("1000w")).toBe(1000);
+        });
+    });
 });


### PR DESCRIPTION
This PR add a utility method to parse time periods. It assumes milliseconds by default (which guarantees backwards compatibility). Supported units are:

* `s`: seconds
* `ms`: milliseconds
* `m`: minutes

This is currently used by the delay option for the injection and tooltip patterns.