### PR TITLE
Add jquery form to the arguments

### DIFF
--- a/src/pat/ajax/ajax.js
+++ b/src/pat/ajax/ajax.js
@@ -10,7 +10,7 @@ define([
     "pat-parser",
     "pat-registry",
     "jquery.form"
-], function($, logger, Parser, registry) {
+], function($, logger, Parser, registry, jqform) {
     var log = logger.getLogger("pat.ajax"),
         parser = new Parser("ajax");
     parser.addArgument("url", function($el) {


### PR DESCRIPTION
It seems this is needed for `quaive.resources.star` compiled bundle to properly initialize the jquery form.

The bundle compiled without this patch was failing in submitting ajax form:
![image](https://user-images.githubusercontent.com/1300763/34672657-9f46c25e-f47f-11e7-8fd8-60bb6594a479.png)
