### PR TITLE
bump to 4.2.2 to fix .ajaxSubmit not a fucntion in form injections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5701,9 +5701,9 @@
       "integrity": "sha1-xnzu4ZtANlDWgq3POdXJAJgU2Uk="
     },
     "jquery-form": {
-      "version": "3.50.0",
-      "resolved": "https://registry.npmjs.org/jquery-form/-/jquery-form-3.50.0.tgz",
-      "integrity": "sha1-18lptR4JThLaaZHrYf9a8l9ZeY8=",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/jquery-form/-/jquery-form-4.2.2.tgz",
+      "integrity": "sha512-HJTef7DRBSg8ge/RNUw8rUTTtB3l8ozO0OhD16AzDl+eIXp4skgCqRTd9fYPsOzL+pN6+1B9wvbTLGjgikz8Tg==",
       "requires": {
         "jquery": "1.11.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "google-code-prettify": "1.0.4",
     "imagesloaded": "4.1.1",
     "jquery": "1.11.0",
-    "jquery-form": "3.50.0",
+    "jquery-form": "4.2.2",
     "jquery-jcrop": "",
     "jquery-placeholder": "2.0.7",
     "jquery.browser": "0.1.0",


### PR DESCRIPTION
@wichert Cornelis reports this is broken since before christmas, but I didnt identify what broke it. 
Submitting a form through injection resulted in the following error

![bildschirmfoto 2018-01-10 um 14 53 05](https://user-images.githubusercontent.com/138906/34776815-5a204778-f618-11e7-8871-415f154ae7d2.png)
