### PR TITLE
Restore IE11 compatibility

### DIFF
--- a/src/pat/checklist/checklist.js
+++ b/src/pat/checklist/checklist.js
@@ -147,7 +147,10 @@ define([
             $result = $related=$related.not(el);
             $result.each(function(item) {result.add($result[item])});
             for (var i=0; i<$related.length; i++) {
-                result = new Set ([...result, ..._._getLabelAndFieldset($related[i]) ] );
+                var label_and_fieldset =  _._getLabelAndFieldset($related[i]);
+                for (var j=0; i<label_and_fieldset.length; i++) {
+                    result.add(label_and_fieldset[j]);
+                }
             }
             return result;
         },
@@ -185,19 +188,22 @@ define([
                 $label = $(utils.findLabel(input)),
                 $fieldset = $el.closest("fieldset"),
                 $siblings = _._getSiblingsWithLabelsAndFieldsets(input);
-
+            var values;
             if ($el.closest("ul.radioList").length) {
                 $label=$label.add($el.closest("li"));
                 var newset = new Set();
-                for (item of $siblings.values()) {
-                    newset.add($(item).closest("li"));
+                values = $siblings.values();
+                for (var i=0; i<values.length; i++) {
+                    newset.add($(values[i]).closest("li"));
                 }
                 $siblings=newset;
             }
 
             if (update_siblings) {
-                for (item of $siblings.values())
-                     $(item).removeClass("checked").addClass("unchecked");
+                values = $siblings.values();
+                for (var i=0; i<values.length; i++) {
+                    $(values[i]).removeClass("checked").addClass("unchecked");
+                }
             }
             if (input.checked) {
                 $label.add($fieldset).removeClass("unchecked").addClass("checked");


### PR DESCRIPTION
IE 11 does not support:
- the spread operator (http://kangax.github.io/compat-table/es6/#test-spread_(...)_operator)
- for item of iterable (http://kangax.github.io/compat-table/es6/#test-for..of_loops)