### PR TITLE
Fix siblings selection

### DIFF
--- a/src/pat/checklist/checklist.js
+++ b/src/pat/checklist/checklist.js
@@ -61,7 +61,24 @@ define([
         },
 
         _findSiblings: function(elem, sel) {
-            return $(elem).closest('.pat-checklist').find(sel);
+            // Looks for the closest elements that match the `sel` selector
+            var checkbox_children, $parent;
+            var parents = $(elem).parents();
+            for (var i=0; i<parents.length; i++) {
+                $parent = $(parents[i]);
+                checkbox_children = $(parents[i]).find(sel);
+                if (checkbox_children.length != 0) {
+                    return checkbox_children;
+                }
+                if ($parent.hasClass('pat-checklist')) {
+                    // we reached the top node and did not find any match,
+                    // return an empty match
+                    return $([]);
+                }
+            }
+            // This should not happen because because we expect `elem` to have
+            // a .pat-checklist parent
+            return $([]);
         },
         onChange: function(event) {
             var $trigger = event.data.trigger,


### PR DESCRIPTION
This fixes the checkbox listing selection modified in #584.

Without this patch, clicking any button in a hierarchy of checkboxes would select all the checkboxes.
![image](https://user-images.githubusercontent.com/1300763/41216576-3cea51bc-6d55-11e8-8e2c-83096dc450ff.png)
