### PR TITLE
pat-calendar: Check for existing categories, not for selected ones.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@ Breaking Changes
 - New carousel pattern based on slick carousel (http://kenwheeler.github.io/slick/)
   The old carousel based on anythingslider is still available as pat-carousel-legacy
 - upgrade moment.js to 2.19.3 to address security vulnerability
+- pat-calendar: Fixed check for categories
 - Improve pat-checklist to allow select/deselect on subset of elements
 - Extend pat-focus to add `has-value` class, `data-placeholder` and `data-value` attributes.
 - Add idle trigger to injection.

--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -472,7 +472,7 @@ define([
                     log.debug("remove due to search-text="+searchText, $event);
                     return false;
                 }
-                if (shownCats.length === 0) {
+                if ($el.$catControls.length === 0) {
                     // In case we don't use filter categories, always return all events
                     return true;
                 }


### PR DESCRIPTION
This check is meant to make sure that we see all events in case there are no category controls. However, it mistakenly checks for any *selected* categories, not for any *existing* category controls. This means that if there are category controls and they are all deselected then all events are shown. This patch fixes the check.