### PR TITLE
Add a "PhantomJS_debug" custom launcher.

### DIFF
--- a/webpack/karma.config.js
+++ b/webpack/karma.config.js
@@ -118,6 +118,13 @@ module.exports = function(config) {
         /*karma-mocha-reporter config*/
         mochaReporter: {
             output: 'full' //full, autowatch, minimal
+        },
+
+        customLaunchers: {
+            'PhantomJS_debug': {
+                base: 'PhantomJS',
+                debug: true
+            }
         }
     })
 }


### PR DESCRIPTION
Now you can run tests and have the browser developer tools actually stop on `debugger;` breakpoints:

    > karma start webpack/karma.config.js --browsers PhantomJS_debug