### PR TITLE
Fix an issue where the autioload would still trigger an inject after …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Fixes
 ~~~~~
 
 - Enable babel transpiler
+- Interim condition to trigger: autoload-visible to abort injection in case the tartget element is no longer present.
+
 
 
 ## 3.0.0a1 - unreleased

--- a/package-lock.json
+++ b/package-lock.json
@@ -10301,7 +10301,7 @@
     },
     "rxjs": {
       "version": "5.0.0-beta.11",
-      "resolved": "http://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.11.tgz",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.0-beta.11.tgz",
       "integrity": "sha1-q6xEfW+AHBvwZrfw5Jxl0v7jbKI=",
       "requires": {
         "symbol-observable": "^1.0.1"

--- a/src/pat/equaliser/tests.js
+++ b/src/pat/equaliser/tests.js
@@ -23,7 +23,7 @@ define(["pat-equaliser"], function(pattern) {
                 var style,
                     head = document.head || document.getElementsByTagName("head")[0],
                     css = ".small { height: 50px; }\n" +
-                          ".large {height: 100px; }";
+                          ".large { height: 100px; }";
 
                 style = document.createElement("style");
                 style.id="pat-equaliser-style";
@@ -49,7 +49,7 @@ define(["pat-equaliser"], function(pattern) {
                 expect($container.find(".large").height()).toBe(100);
                 expect($container.find(".large").hasClass("equalised")).toBeTruthy();
                 expect($container.find(".small").height()).toBe(100);
-                expect($container.find(".large").hasClass("equalised")).toBeTruthy();
+                expect($container.find(".small").hasClass("equalised")).toBeTruthy();
             });
 
             it("Ignore inline styles", function() {
@@ -61,8 +61,8 @@ define(["pat-equaliser"], function(pattern) {
                 $container.appendTo("#lab");
                 $container.data("pat-equaliser", {transition: "none"});
                 pattern._update($container[0]);
-                expect($container.find(".large").height()).toBe(100);
                 expect($container.find(".small").height()).toBe(100);
+                expect($container.find(".large").height()).toBe(100);
             });
         });
     });

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -784,6 +784,11 @@ define([
                     if (!$el.is(":visible")) {
                         return false;
                     }
+                    // check if the target element still exists. Otherwise halt and catch fire
+                    var target = $el.data("pat-inject")[0].target.replace(/::element/, '');
+                    if ($(target).length === 0) {
+                        return false;                        
+                    }                    
                     var reltop = $el.offset().top - $scrollable.offset().top - 1000,
                         doTrigger = reltop <= $scrollable.innerHeight();
                     if (doTrigger) {
@@ -815,6 +820,11 @@ define([
                     }
                     if (!utils.elementInViewport($el[0])) {
                         return false;
+                    }
+                    // check if the target element still exists. Otherwise halt and catch fire
+                    var target = $el.data("pat-inject")[0].target.replace(/::element/, '');
+                    if ($(target).length === 0) {
+                        return false;                        
                     }
                     $(window).off(".pat-autoload", checkVisibility);
                     return trigger();


### PR DESCRIPTION
…leaving the page with pat-inject, because that triggers a scroll event and pat-inject appends to body if it can't find the target.

I have learned that the injection triggers a scroll event on the window object and the autoload-visible mechanics are listening for scroll. Therefore it gets triggered

Ok, so one way to fix this is to check if the target element exists and to abort if not.
And the reason is that line: defaultSelector = urlparts[1] && "#" + urlparts[1] || "body";
which defaults hard to „body“.

I guess we definitely want to keep the ability to inject by default to the end of the body? Then a solution to this must lie in the scope of the autoload-visible code which must only inject if there is a target and not fall back. either we built in a „strict mode“ which aborts, if no target is given. Or we just catch that case in the autoload-visible code.  I have the latter working in a branch ready to test. 
Your pick.