### PR TITLE
Fix .pat-modal inside [data-pat-inject]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Fixes
 
 - pat-notification: fix how the close button is rendered (#639)
 - pat-modal: remove an handler after the modal is closed (allows for injection inside modals, see #550)
+- pat-modal: fix .pat-modal inside .pat-inject (allows for modals inside inject elemets, see #303)
 - Enable babel transpiler
 - Interim condition to trigger: autoload-visible to abort injection in case the tartget element is no longer present.
 - pat-inject: autoload-visible now uses the intersection observer

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -385,8 +385,24 @@ define([
             }
             inherit = (inherit!==false);
             var stack = inherit ? [[this._defaults($el)]] : [[{}]];
-            var $possible_config_providers = inherit ? $el.parents().andSelf() : $el,
-                final_length = 1;
+            var $possible_config_providers;
+            var final_length = 1
+            /*
+             * XXX this is a workaround for:
+             * - https://github.com/Patternslib/Patterns/issues/393
+             *
+             * Prevents the parser to pollute the pat-modal configuration
+             * with data-pat-inject elements define in a `.pat-modal` parent element.
+             *
+             *  Probably this function should be completely revisited, see:
+             * - https://github.com/Patternslib/Patterns/issues/627
+             *
+             */
+            if (!inherit || ($el.hasClass('pat-modal') && this.attribute === 'data-pat-inject')) {
+                $possible_config_providers = $el;
+            } else {
+                $possible_config_providers = $el.parents().andSelf();
+            }
 
             _.each($possible_config_providers, function (provider) {
                 var data = $(provider).attr(this.attribute), frame, _parse;


### PR DESCRIPTION
This looks to me a sane workaround for:
- https://github.com/Patternslib/Patterns/issues/393

Prevents the parser to pollute the pat-modal configuration
with data-pat-inject elements define in a `.pat-modal` parent element.

 Probably this function should be completely revisited, see:
- https://github.com/Patternslib/Patterns/issues/627

Fixes #393
Refs #627