### PR TITLE
Fix heisenbug with pat-scroll on testruns.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,18 @@
 
 ## 4.0.0 - unreleased
 
-- Runs now on jQuery 3
+Features
+~~~~~~~~
+
+- Runs now on jQuery 3.
 - Integrated pat-display-time from https://github.com/ploneintranet/pat-display-time
-- fix minimum input length default so that you can display select results already on click
+
+Fixes
+~~~~~
+
+- Fix heisenbug with pat-scroll on testruns.
+- Fix minimum input length default so that you can display select results already on click.
+
 
 ## 3.0.0a5 - unreleased
 

--- a/src/pat/scroll/tests.js
+++ b/src/pat/scroll/tests.js
@@ -1,4 +1,4 @@
-define(["pat-scroll", "imagesloaded"], function(Pattern, imagesLoaded) {
+define(["pat-scroll"], function(Pattern) {
 
     describe("pat-scroll", function() {
 
@@ -17,7 +17,6 @@ define(["pat-scroll", "imagesloaded"], function(Pattern, imagesLoaded) {
                     ].join("\n"));
                 var spy_animate = spyOn($.fn, 'animate');
                 Pattern.init($(".pat-scroll"));
-                imagesLoaded($("body"));
                 setTimeout(function () {
                     expect(spy_animate).toHaveBeenCalled();
                     done();
@@ -41,11 +40,13 @@ define(["pat-scroll", "imagesloaded"], function(Pattern, imagesLoaded) {
                 var $el = $(".pat-scroll");
                 var spy_animate = spyOn($.fn, 'animate');
                 Pattern.init($el);
-                imagesLoaded($("body"));
                 setTimeout(function() {
                     $el.click();
-                    expect(spy_animate).toHaveBeenCalled();
-                    done();
+                    setTimeout(function() {
+                        // wait for scrolling via click to be done.
+                        expect(spy_animate).toHaveBeenCalled();
+                        done();
+                    }, 2000);
                 }, 2000);
 
             });
@@ -58,7 +59,6 @@ define(["pat-scroll", "imagesloaded"], function(Pattern, imagesLoaded) {
                 var $el = $(".pat-scroll");
                 var spy_animate = spyOn($.fn, 'animate');
                 Pattern.init($el);
-                imagesLoaded($("body"));
                 $el.trigger("pat-update", {
                     'pattern': "stacks",
                     'originalEvent': {


### PR DESCRIPTION
Attempt 1: Wait for scrolling to be done.
Also remove imagesloaded, as we do not need to wait for images (was
called incorrectly without a callback anyways).