### PR TITLE
When an inject fails because the source doesn't contain the intended …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Fixes
 - Fix ``pat-auto-scale`` not correctly rescaling after fullscreen changes. Fixes #673
 - Fix heisenbug with pat-scroll on testruns.
 - Fix minimum input length default so that you can display select results already on click.
-
+- When an inject fails because the source doesn't contain the intended selector, redirect to the target url instead of failing silently. This will show the login form in case an inject fails because the user is no longer authenticated.
 
 ## 3.0.0a5 - unreleased
 

--- a/src/pat/ajax/ajax.js
+++ b/src/pat/ajax/ajax.js
@@ -76,6 +76,8 @@ define([
                         type: "pat-ajax-error",
                         jqxhr: jqxhr
                     });
+                    // Expose the error by redirecting to the url.
+                    window.location.href = cfg.url;
                 },
                 seqNumber = xhrCount.inc(cfg.url),
                 onSuccess = function(data, status, jqxhr) {

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -425,6 +425,7 @@ define([
             /* Called after the XHR has succeeded and we have a new $source
              * element to inject.
              */
+            
             if (cfg.sourceMod === "content") {
                 $source = $source.contents();
             }
@@ -633,10 +634,6 @@ define([
                 $(trigger).trigger("pat-inject-missingSource",
                         {url: cfg.url,
                          selector: cfg.source});
-                // XXX: Actually doing a redirect to the original url
-                // this might be an unauthorized case. Show the target.
-                // This is likely also helping in debugging.
-                window.location.href = cfg.url;
                 return false;
             }
             if ($target.length === 0) {

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -633,6 +633,10 @@ define([
                 $(trigger).trigger("pat-inject-missingSource",
                         {url: cfg.url,
                          selector: cfg.source});
+                // XXX: Actually doing a redirect to the original url
+                // this might be an unauthorized case. Show the target.
+                // This is likely also helping in debugging.
+                window.location.href = cfg.url;
                 return false;
             }
             if ($target.length === 0) {


### PR DESCRIPTION
…selector, redirect to the target url instead of failing silently. This will show the login form in case an inject fails because the user is no longer authenticated.