### PR TITLE
Fix version scheme to be semver compatible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 4.0.0 - unreleased
+## 4.0.0-dev - unreleased
 
 Features
 ~~~~~~~~

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "patternslib",
-  "version": "4.0.0dev",
+  "version": "4.0.0-dev",
   "title": "Markup patterns to drive behaviour.",
   "description": "Patternslib is a JavaScript library that enables designers to build rich interactive prototypes without the need for writing any Javascript. All events are triggered by classes and other attributes in the HTML, without abusing the HTML as a programming language. Accessibility, SEO and well structured HTML are core values of Patterns.",
   "author": {


### PR DESCRIPTION
yarn refused to install patternslib with a semantic versioning incompatible version scheme.

Try:
```$ node
> const semver = require('semver');
> semver.valid('4.0.0')
'4.0.0'
> semver.valid('4.0.0dev')
null
> semver.valid('4.0.0.dev')
null
> semver.valid('4.0.0-dev')
'4.0.0-dev'
```