### PR TITLE
Fix scrolling behavior, add getCSSValue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Features
 - Integrated pat-display-time from https://github.com/ploneintranet/pat-display-time
 - Fixed an issue with pat-scroll when placed on an item without a href
 - Fixed an issue with pat-autofocus that would set focus on hidden items
+- Fixed an issue with pat-inject scroll that would scroll too much (#694)
 
 Fixes
 ~~~~~

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 Features
 ~~~~~~~~
 
+- Add ``utils.getCSSValue`` for retrieving CSS property values for DOM nodes.
 - Add configurable scrolling behavior to pat-inject.
 - Add ``webpack-visualizer-plugin`` for analyzation of generated bundles.
 - Add ``pat-fullscreen`` pattern to allow any element to be displayed in fullscreen-mode.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8202,9 +8202,9 @@
       }
     },
     "moment": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
-      "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
       "version": "0.5.13",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "logging": "https://github.com/Patternslib/logging.git",
     "masonry-layout": "4.2.0",
     "modernizr": "^3.7.1",
-    "moment": "2.23.0",
+    "moment": "2.24.0",
     "moment-timezone": "0.5.13",
     "parsleyjs": "2.7.2",
     "photoswipe": "4.1.3",

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -459,6 +459,17 @@ define([
         return $relatives;
     }
 
+    function getCSSValue(el, property, asFloat) {
+        /* Return a CSS property value for a given DOM node.
+         * Optionally parse as float.
+        */
+        var value = window.getComputedStyle(el).getPropertyValue(property);
+        if (asFloat) {
+            value = parseFloat(value) || 0.0;
+        }
+        return value;
+    }
+
     var utils = {
         // pattern pimping - own module?
         jqueryPlugin: jqueryPlugin,
@@ -477,8 +488,8 @@ define([
         isElementInViewport: isElementInViewport,
         hasValue: hasValue,
         parseTime: parseTime,
-        findRelatives: findRelatives
-
+        findRelatives: findRelatives,
+        getCSSValue: getCSSValue
     };
     return utils;
 });

--- a/src/pat/inject/index.html
+++ b/src/pat/inject/index.html
@@ -11,7 +11,8 @@
 </head>
 
 <body>
-  <article>
+
+  <section>
     <p>
       In this example, a <a href="inject-sources.html" target="new">Single HTML source</a> is used for various injections.
     </p>
@@ -62,86 +63,94 @@
         </span>
       </li>
     </ul>
-  </article>
 
+    <div class="poems">
+      <article class="poem" id="pos-1">
+        <p>
+          <strong class="placeholder">?</strong>
+        </p>
+      </article>
+      <article class="poem" id="pos-2">
+        <p>
+          <strong class="placeholder">?</strong>
+        </p>
+      </article>
+      <article class="poem" id="pos-3">
+        <p>
+          <strong class="placeholder">?</strong>
+        </p>
+      </article>
+    </div>
 
-  <div class="poems">
-    <article class="poem" id="pos-1">
-      <p>
-        <strong class="placeholder">?</strong>
-      </p>
-    </article>
-    <article class="poem" id="pos-2">
-      <p>
-        <strong class="placeholder">?</strong>
-      </p>
-    </article>
-    <article class="poem" id="pos-3">
-      <p>
-        <strong class="placeholder">?</strong>
-      </p>
-    </article>
-  </div>
+  </section>
 
-  <article>
+  <section>
     <h2>Inject and scroll demos</h2>
     <ul>
       <li>
-        <a href="inject-text.html" class="pat-inject" data-pat-inject="scroll:#scroll-target">1a) "scroll:#scroll-target": Load text into body and scoll to #scroll-target</a>
-        <em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">
-        &lt;a href=&quot;inject-text.html&quot; class=&quot;pat-inject&quot; data-pat-inject=&quot;scroll:#scroll-target&quot;&gt;
-        </code></em>
-      </li>
-      <li>
-        <a href="inject-sources.html" class="pat-inject" data-pat-inject="target:#pos-4; scroll: #dieu-nu-p-1">1b) Inject 'Cocteau' in the frame below and scroll directly to the first paragraph.</a>
-        <em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">
-        &lt;a href=&quot;inject-sources.html&quot; class=&quot;pat-inject&quot; data-pat-inject=&quot;target:#pos-4; scroll: #dieu-nu-p-1&quot;&gt;
-        </code></em>
-      </li>
-      <li>
-        <a href="index.html" class="pat-inject" data-pat-inject="scroll:#demo-history">1c) "scroll:#demo-history" Re-inject this entire page and scroll to the history example</a>
+        <a href="index.html" class="pat-inject" data-pat-inject="scroll:#demo-history">1) Re-inject this entire page and scroll to the history example</a>
         <em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">
         &lt;a href=&quot;index.html&quot; class=&quot;pat-inject&quot; data-pat-inject=&quot;scroll:#demo-history&quot;&gt;
         </code></em>
       </li>
       <li>
-        <a href="index.html" class="pat-inject" data-pat-inject="scroll:top">2) "scroll:top" Re-inject this entire page and scroll to the top</a>
+        <a href="index.html" class="pat-inject" data-pat-inject="scroll:top">2) Re-inject this entire page and scroll to the top</a>
         <em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">
         &lt;a href=&quot;index.html&quot; class=&quot;pat-inject&quot; data-pat-inject=&quot;scroll:top&quot;&gt;
         </code></em>
       </li>
+
       <li>
-        <a href="inject-text.html#pos-4" class="pat-inject" data-pat-inject="scroll:target">3) "scroll:target" Scroll to the target defined in the URL part as anchor-reference</a>
+        <a href="inject-text.html" class="pat-inject" data-pat-inject="scroll:#scroll-target">3) Load text into body and scoll to #scroll-target</a>
+        <em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">
+        &lt;a href=&quot;inject-text.html&quot; class=&quot;pat-inject&quot; data-pat-inject=&quot;scroll:#scroll-target&quot;&gt;
+        </code></em>
+      </li>
+      <li>
+        <a href="inject-text.html#scroll-target" class="pat-inject" data-pat-inject="scroll:target">4) Scroll to the target defined in the URL part as anchor-reference</a>
         <em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">
         &lt;a href=&quot;inject-text.html#pos-4&quot; class=&quot;pat-inject&quot; data-pat-inject=&quot;scroll:target&quot;&gt;
         </code></em>
       </li>
       <li>
-        <a href="inject-text.html" class="pat-inject" data-pat-inject="scroll:none">4) "scroll:none" Do not scroll (default behavior)</a>
+        <a href="inject-text.html" class="pat-inject" data-pat-inject="scroll:none">5) "scroll:none" Do not scroll (default behavior)</a>
         <em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">
         &lt;a href=&quot;inject-text.html&quot; class=&quot;pat-inject&quot; data-pat-inject=&quot;scroll:none&quot;&gt;
         </code></em>
       </li>
+
+
+      <li>
+        <a href="inject-sources.html#pos-3" class="pat-inject" data-pat-inject="target:#pos-4; scroll: #dieu-nu-p-1">6) Inject 'Cocteau' in the frame below and scroll to the first paragraph.</a>
+        <em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">
+        &lt;a href=&quot;inject-sources.html#pos-3&quot; class=&quot;pat-inject&quot; data-pat-inject=&quot;target:#pos-4; scroll: #dieu-nu-p-1&quot;&gt;
+        </code></em>
+      </li>
+      <li>
+        <a href="inject-sources.html" class="pat-inject" data-pat-inject="target:#pos-4; scroll: #pos-2">7) Inject all content from source in the frame below and scroll to the second article.</a>
+        <em class="iconified icon-info-circle pat-tooltip" data-pat-tooltip="trigger: click; source: content; class: large code"><code class="pat-syntax-highlight">
+        &lt;a href=&quot;inject-sources.html&quot; class=&quot;pat-inject&quot; data-pat-inject=&quot;target:#pos-4; scroll: #pos-2&quot;&gt;
+        </code></em>
+      </li>
+
     </ul>
-  </article>
 
-  <div class="poems">
-    <article class="poem cols-full" id="pos-4">
-      <p>
-        <strong class="placeholder">?</strong>
-      </p>
-    </article>
-  </div>
+    <div class="poems">
+      <article class="poem cols-full" id="pos-4">
+        <p>
+          <strong class="placeholder">?</strong>
+        </p>
+      </article>
+    </div>
 
-  <div class="poems">
-    <article class="poem cols-full" id="pos-5">
-      <p>
-        <strong class="placeholder">?</strong>
-      </p>
-    </article>
-  </div>
+    <div class="poems">
+      <article class="poem cols-full" id="pos-5">
+        <p>
+          <strong class="placeholder">?</strong>
+        </p>
+      </article>
+    </div>
 
-  <article>
     <ul>
       <li>
         Place "Wilde in the frame above when <a href="inject-sources.html#pos-2" class="pat-inject" data-pat-inject="trigger: autoload-visible; target: #pos-5">this link</a> appears in view.
@@ -150,16 +159,18 @@
         <a href="inject-sources#pos-2" class="pat-inject" data-pat-inject="scroll: target">Place "Cocteau" in the second frame on this page and scroll towards it.</a>
       </li>
     </ul>
-  </article>
 
-  <article id="demo-history">
+  </section>
+
+
+  <section id="demo-history">
     <h3>Inject history example</h3>
     <p><a href="history-inject-source.html#content" class="pat-inject" data-pat-inject="history:record; source: #content; target: #history-inject-target">Inject some text and record the history</a></p>
 
     <p id="history-inject-target"><i>here goes the injection</i></p>
-  </article>
+  </section>
 
-  <article>
+  <section>
     <h3>Inject autosubmit with form using GET and POST</h3>
 
     <form method="post" class="pat-inject pat-autosubmit" data-pat-inject="history:record" action="inject-form.html?approach=questionable#form-submit-target">
@@ -170,9 +181,18 @@
     <p id="form-submit-target">
       <i>here goes the injection</i>
     </p>
-  </article>
+  </section>
 
   <style>
+
+    body {
+      font-size: 16px;
+    }
+
+    section {
+      margin: 0 0 4em 0;
+    }
+
     .poems {
       font-family: georgia;
       margin-bottom: 2em;
@@ -216,7 +236,7 @@
       background-color: #efefef;
       box-shadow: inset 0 0 4em rgba(0, 0, 0, 0.3);
       padding: 55px 20px 55px;
-      font-size: 0.8em;
+      font-size: 1em;
       line-height: 180%;
       height: 310px;
       overflow: auto;
@@ -236,7 +256,11 @@
 
     .poems article * {
       text-align: center;
-      margin-bottom: 1em;
+      margin-bottom: 2em;
+    }
+
+    .poems article {
+      margin-bottom: 4em;
     }
 
     .poems article h3 {

--- a/src/pat/inject/inject-text.html
+++ b/src/pat/inject/inject-text.html
@@ -7,6 +7,9 @@
 </head>
 
 <body>
+  <style type="text/css" media="screen">
+    #pos-1 { margin-top: 60vh; }
+  </style>
   <article id="pos-1">
     <h3>Immer wieder</h3>
     <p>

--- a/tests/specs/core/utils.js
+++ b/tests/specs/core/utils.js
@@ -265,7 +265,7 @@ define(["underscore", "pat-utils"], function(_, utils) {
             setTimeout(function () {
                 expect($slave[0].style.display).toBe("none");
                 expect(Array.prototype.slice.call($slave[0].classList)).toEqual(["hidden"]);
-                
+
             }, 500);
         });
 
@@ -280,7 +280,7 @@ define(["underscore", "pat-utils"], function(_, utils) {
                     "pat-update", {pattern: "depends", transition: "start"});
                 expect($.fn.trigger).toHaveBeenCalledWith(
                     "pat-update", {pattern: "depends", transition: "complete"});
-                
+
             }, 500);
 
         });
@@ -361,6 +361,36 @@ define(["underscore", "pat-utils"], function(_, utils) {
 
         it("treats unknown units as milliseconds", function() {
             expect(utils.parseTime("1000w")).toBe(1000);
+        });
+    });
+
+    describe("getCSSValue", function() {
+        it("returns values for properties of a html node", function() {
+
+            var el1 = document.createElement('div');
+            var el2 = document.createElement('div');
+
+            // Need to attach element to body to make CSS calculation work.
+            document.body.appendChild(el1);
+
+            el1.style['font-size'] = '12px';
+            el1.style['margin-top'] = '26px';
+            el1.style.position = 'relative';
+
+            el2.style['margin-bottom'] = '10px';
+
+            el1.appendChild(el2);
+
+            expect(utils.getCSSValue(el1, 'font-size')).toBe('12px');
+            expect(utils.getCSSValue(el1, 'font-size', true)).toBe(12.0);
+            expect(utils.getCSSValue(el2, 'font-size')).toBe('12px');
+
+            expect(utils.getCSSValue(el1, 'position')).toBe('relative');
+
+            expect(utils.getCSSValue(el1, 'margin-top', true)).toBe(26.0);
+            expect(utils.getCSSValue(el2, 'margin-top', true)).toBe(0.0);
+            expect(utils.getCSSValue(el2, 'margin-bottom', true)).toBe(10.0);
+
         });
     });
 });


### PR DESCRIPTION
Fix scrolling behavior - whole page was scrolling when using Element.scrollIntoView().
Add ``utils.getCSSValue`` for retrieving CSS property values for DOM nodes.
Upgrade moment to avoid duplicate dependencies.