### PR TITLE
[WIP] Markdown: fix rendering when source has prepending whitespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Features
 - Fixed an issue with pat-scroll when placed on an item without a href
 - Fixed an issue with pat-autofocus that would set focus on hidden items
 - Fixed an issue with pat-inject scroll that would scroll too much (#694)
+- Fixed an issue with pat-markdown where rendering was not like expected when source has prepending whitespace (#697)
 
 Fixes
 ~~~~~

--- a/src/pat/markdown/markdown.js
+++ b/src/pat/markdown/markdown.js
@@ -28,6 +28,7 @@ define([
         render: function(text) {
             var $rendering = $("<div/>"),
                 converter = new Showdown.Converter({tables: true, extensions: ['prettify']});
+            text = text.trim();
             $rendering.html(converter.makeHtml(text));
             return $rendering;
         },

--- a/src/pat/markdown/tests.js
+++ b/src/pat/markdown/tests.js
@@ -54,6 +54,13 @@ define(["pat-markdown"], function(Pattern) {
                 var $rendering = Pattern.prototype.render("*This is markdown*");
                 expect($rendering.html()).toBe("<p><em>This is markdown</em></p>");
             });
+
+            it("removes whitespace from start and end of text", function() {
+                // If text is not removed, the rendering breaks and ouputs this instead:
+                // '<pre class="pat-syntax-highlight" tabindex="0"><code data-inner="1"> *This is markdown*     </code></pre>'
+                var $rendering = Pattern.prototype.render("     *This is markdown*     ");
+                expect($rendering.html()).toBe("<p><em>This is markdown</em></p>");
+            });
         });
 
         describe("Session extraction", function() {


### PR DESCRIPTION
Fixed an issue with pat-markdown where rendering was not like expected when source has prepending whitespace (#697)
Fixes #697

DO NOT MERGE, this is probably an invalid fix!