### PR TITLE
Modal: allow programmatic initialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 Features
 ~~~~~~~~
 
+- Modal: Allow passing of parameters ``url`` and ``trigger`` to pat-inject. This allows programmatic instantiation of a modal with injected content.
 - Navigation:
   - Do not set the ``.navigation-in-path`` class for elenents already marked with ``.current``.
   - Allow configuration of "in path" and "current" classes via ``in-path-class`` and ``current-class`` configuration options.

--- a/src/pat/modal/index-programmatically.html
+++ b/src/pat/modal/index-programmatically.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<title>Demo page</title>
+  	<link rel="stylesheet" href="/style/common.css" type="text/css">
+    <script src="/bundle.js" type="text/javascript" charset="utf-8"></script>
+    <style type="text/css" media="screen">
+      body > #modal_content { display: none; }
+    </style>
+	</head>
+	<body>
+
+  <script>
+    var modal = new patterns.patterns.modal(
+      $('<span/>'),
+      {
+        url: 'http://0.0.0.0:3001/src/pat/modal/index.html#modal_content',
+        trigger: 'autoload'
+      }
+    );
+  </script>
+
+</html>

--- a/src/pat/modal/index-programmatically.html
+++ b/src/pat/modal/index-programmatically.html
@@ -11,14 +11,29 @@
 	</head>
 	<body>
 
+  <button id="patternlessclicktest">Open Modal</button>
+
+  <a
+      id="modal_opener"
+      class="pat-modal"
+      href="http://0.0.0.0:3001/src/pat/modal/modal-sources.html"
+      style="display:none">
+    really open modal
+  </a>
+
   <script>
-    var modal = new patterns.patterns.modal(
-      $('<span/>'),
-      {
-        url: 'http://0.0.0.0:3001/src/pat/modal/index.html#modal_content',
-        trigger: 'autoload'
-      }
-    );
+    document.querySelector('#patternlessclicktest').addEventListener('click', function (e) {
+      e.preventDefault();
+      document.querySelector('#modal_opener').click();
+    });
+
+    //var modal = new patterns.patterns.modal(
+    //  $('<span/>'),
+    //  {
+    //    url: 'http://0.0.0.0:3001/src/pat/modal/index.html#modal_content',
+    //    trigger: 'autoload'
+    //  }
+    //);
   </script>
 
 </html>

--- a/src/pat/modal/index.html
+++ b/src/pat/modal/index.html
@@ -1,73 +1,117 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-		<title>Demo page</title>
-		<link rel="stylesheet" href="/style/common.css" type="text/css">
-        <script src="/bundle.js" type="text/javascript" charset="utf-8"></script>
-	</head>
-	<body>
-		<form action="#modal-source" method="get" class="pat-modal">
-			<fieldset class="button-bar">
-				<button type="submit" class="pat-button">Open a Modal panel via a form submit</button>
-			</fieldset>
-		</form>
-		<p>
-			Open a <a href="#modal-source" class="pat-modal"> Modal panel via AJAX</a>.
-		</p>
-		<p>
-			Open a <a href="#modal-source" class="pat-modal" data-pat-modal="class: large"> Modal panel with an extra class 'large' on it</a>.
-		</p>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Demo page</title>
+    <link rel="stylesheet" href="/style/common.css" type="text/css" />
+    <script src="/bundle.js" type="text/javascript" charset="utf-8"></script>
+  </head>
+  <body>
+    <form action="#modal-source" method="get" class="pat-modal">
+      <fieldset class="button-bar">
+        <button type="submit" class="pat-button">
+          Open a Modal panel via a form submit
+        </button>
+      </fieldset>
+    </form>
     <p>
-			Open a <a href="#modal-source-headerless" class="pat-modal" data-pat-modal="panel-header-content: none"> Modal with no header</a>.
-		</p>
+      Open a
+      <a href="#modal-source" class="pat-modal"> Modal panel via AJAX</a>.
+    </p>
+    <p>
+      Open a
+      <a href="#modal-source" class="pat-modal" data-pat-modal="class: large">
+        Modal panel with an extra class 'large' on it</a
+      >.
+    </p>
+    <p>
+      Open a
+      <a
+        href="#modal-source-headerless"
+        class="pat-modal"
+        data-pat-modal="panel-header-content: none"
+      >
+        Modal with no header</a
+      >.
+    </p>
 
     <p>
-			Open a <a href="#modal-source-customheader" class="pat-modal" data-pat-modal="panel-header-content: .custom-header"> Modal with a custom header</a>.
-		</p>
+      Open a
+      <a
+        href="#modal-source-customheader"
+        class="pat-modal"
+        data-pat-modal="panel-header-content: .custom-header"
+      >
+        Modal with a custom header</a
+      >.
+    </p>
 
-		<div id="modal-source" hidden>
-			<h3>
-				Modal example
-			</h3>
-			<p>
-				Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
-			</p>
-		</div>
+    <div id="modal-source" hidden>
+      <h3>
+        Modal example
+      </h3>
+      <p>
+        Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+        accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+        illo inventore veritatis et quasi architecto beatae vitae dicta sunt
+        explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut
+        odit aut fugit, sed quia consequuntur magni dolores eos qui ratione
+        voluptatem sequi nesciunt.
+      </p>
+    </div>
 
     <div id="modal-source-headerless" hidden>
       <h3>
-				Header goes into panel
-			</h3>
-			<p>
-				Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
-			</p>
-		</div>
+        Header goes into panel
+      </h3>
+      <p>
+        Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+        accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+        illo inventore veritatis et quasi architecto beatae vitae dicta sunt
+        explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut
+        odit aut fugit, sed quia consequuntur magni dolores eos qui ratione
+        voluptatem sequi nesciunt.
+      </p>
+    </div>
 
     <div id="modal-source-customheader" hidden>
       <h3>
-				Use the custom one instead of me
-			</h3>
+        Use the custom one instead of me
+      </h3>
       <h3 class="custom-header">
         Custom header
       </h3>
-			<p>
-				Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.
-			</p>
-		</div>
+      <p>
+        Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+        accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab
+        illo inventore veritatis et quasi architecto beatae vitae dicta sunt
+        explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut
+        odit aut fugit, sed quia consequuntur magni dolores eos qui ratione
+        voluptatem sequi nesciunt.
+      </p>
+    </div>
 
-		<div id="modal-on-load" class="pat-modal">
-			<h3>Modal example with auto load</h3>
-			<article class="pat-rich">
-				<p>Frequent uses of modal windows include:</p>
-				<ul>
-					<li>Drawing attention to vital pieces of information. This use has been criticised as ineffective because users are bombarded with too many dialog boxes, and habituate to simply clicking "Close", "Cancel", or "OK" without reading or understanding the message.[3][4][5]</li>
-					<li>Blocking the application flow until information required to continue is entered, as for example a password in a login process. Another example are file dialogs to open and save files in an application.</li>
-				</ul>
-				<p>
-					*Source: Wikipedia
-				</p>
-			</article>
-		</div>
-	</body>
+    <div id="modal-on-load" class="pat-modal">
+      <h3>Modal example with auto load</h3>
+      <article class="pat-rich">
+        <p>Frequent uses of modal windows include:</p>
+        <ul>
+          <li>
+            Drawing attention to vital pieces of information. This use has been
+            criticised as ineffective because users are bombarded with too many
+            dialog boxes, and habituate to simply clicking "Close", "Cancel", or
+            "OK" without reading or understanding the message.[3][4][5]
+          </li>
+          <li>
+            Blocking the application flow until information required to continue
+            is entered, as for example a password in a login process. Another
+            example are file dialogs to open and save files in an application.
+          </li>
+        </ul>
+        <p>
+          *Source: Wikipedia
+        </p>
+      </article>
+    </div>
+  </body>
 </html>

--- a/src/pat/modal/index.html
+++ b/src/pat/modal/index.html
@@ -46,6 +46,18 @@
       >.
     </p>
 
+    <p class="modal_open_button">
+      Open a modal via a Button which redirects the click to a hidden anchor element.
+      <button class="pat-forward" data-pat-forward="selector: .modal_open_button--opener">Open Modal</button>
+      <a
+          id="callbackbutton_modal_opener"
+          class="pat-modal modal_open_button--opener"
+          href="http://0.0.0.0:3001/src/pat/modal/modal-sources.html"
+          style="display:none">
+        really open modal
+      </a>
+    </p>
+
     <div id="modal-source" hidden>
       <h3>
         Modal example

--- a/src/pat/modal/index.html
+++ b/src/pat/modal/index.html
@@ -93,7 +93,7 @@
 
     <div id="modal-on-load" class="pat-modal">
       <h3>Modal example with auto load</h3>
-      <article class="pat-rich">
+      <article id="modal_content" class="pat-rich">
         <p>Frequent uses of modal windows include:</p>
         <ul>
           <li>

--- a/src/pat/modal/modal.js
+++ b/src/pat/modal/modal.js
@@ -11,6 +11,8 @@ define([
     parser.addArgument("closing", ["close-button"], ["close-button", "outside"], true);
     parser.addArgument("close-text", 'Close');
     parser.addArgument("panel-header-content", ":first:not(.header)");
+    parser.addArgument("url", null);  // inject-url
+    parser.addArgument("trigger", null);  // inject-trigger
 
     return Base.extend({
         name: "modal",
@@ -35,6 +37,13 @@ define([
                 target: "#pat-modal",
                 "class": "pat-modal" + (this.options["class"] ? " " + this.options["class"] : "")
             };
+            if (this.options.url) {
+                opts.url = this.options.url;
+            }
+            if (this.options.trigger) {
+                opts.trigger = this.options.trigger;
+            }
+
             // if $el is already inside a modal, do not detach #pat-modal,
             // because this would unnecessarily close the modal itself
             if (!this.$el.closest("#pat-modal")) {

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -99,6 +99,7 @@ define([
     // Since we are in a non-AMD env, register a few useful utilites
     var window = require("window");
     window.jQuery = $;
+    window.patterns = registry;
     require("imports-loader?this=>window!jquery.browser");
 
     $(function () {


### PR DESCRIPTION
Modal: Allow passing of parameters ``url`` and ``trigger`` to pat-inject. This allows programmatic instantiation of a modal with injected content.

I have a usecase where I need to open a modal after clicking on a link of an external JavaScript app (ONLYOFFICE in that case). Therefore, I cannot use the traditional way of invoking the modal by attaching the ``pat-modal`` class on a link including options but I need to programmatically invoke it in an event handler. For that to work, I need to pass the ``url`` and ``trigger`` options to pat-inject. This is an example of how I do it:

```
    var modal = patterns.patterns.modal.init(
      $('<span></span>'),
      {
        url: 'http://0.0.0.0:3001/src/pat/modal/index.html#modal_content',
        trigger: 'autoload'
      }
    );
```
The dummy ``<span>`` is needed - otherwise core patternslib throws an error.