### PR TITLE
pat-validation: Do not trigger on empty dates. Fixes: #711

### DIFF
--- a/.modernizrrc.js
+++ b/.modernizrrc.js
@@ -126,6 +126,7 @@ module.exports = {
     "forms/placeholder",
     "forms/requestautocomplete",
     "forms/validation",
+    "inputtypes",
     "fullscreen-api",
     "hashchange",
     "hiddenscroll",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 Features
 ~~~~~~~~
-
+- Prevent "Modernizr.inputtypes is undefined" error
 - Remove PhantomJS - we're using ChromeHeadless already.
 - Simplify package.json and remove unused.
 - Upgrade moment and moment-timezone.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 Features
 ~~~~~~~~
+- pat-validation: Dont use :input jquery extension for better performance
 - pat-validation: Update validate.js to 0.13.1
 - Prevent "Modernizr.inputtypes is undefined" error
 - Remove PhantomJS - we're using ChromeHeadless already.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 Features
 ~~~~~~~~
+- pat-validation: Update validate.js to 0.13.1
 - Prevent "Modernizr.inputtypes is undefined" error
 - Remove PhantomJS - we're using ChromeHeadless already.
 - Simplify package.json and remove unused.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ Features
 - pat-validation: Dont use :input jquery extension for better performance
 - pat-validation: Update validate.js to 0.13.1
 - Prevent "Modernizr.inputtypes is undefined" error
+
+- pat-validation: Do not trigger on empty dates. Fixes: #711
 - Remove PhantomJS - we're using ChromeHeadless already.
 - Simplify package.json and remove unused.
 - Upgrade moment and moment-timezone.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10441,9 +10441,9 @@
       }
     },
     "validate.js": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.11.1.tgz",
-      "integrity": "sha1-9Rw8bEpW5jgKIKfrEEJFA38qVA0="
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.13.1.tgz",
+      "integrity": "sha512-PnFM3xiZ+kYmLyTiMgTYmU7ZHkjBZz2/+F0DaALc/uUtVzdCt1wAosvYJ5hFQi/hz8O4zb52FQhHZRC+uVkJ+g=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "tippy.js": "5.2.0",
     "underscore": "1.9.1",
     "url-polyfill": "^1.1.9",
-    "validate.js": "0.11.1"
+    "validate.js": "^0.13.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.5",

--- a/src/modernizr-config.json
+++ b/src/modernizr-config.json
@@ -127,6 +127,7 @@
     "forms/placeholder",
     "forms/requestautocomplete",
     "forms/validation",
+    "inputtypes",
     "fullscreen-api",
     "hashchange",
     "hiddenscroll",

--- a/src/pat/validation/index.html
+++ b/src/pat/validation/index.html
@@ -7,10 +7,10 @@
         <script src="/bundle.js" type="text/javascript" charset="utf-8"></script>
   </head>
   <body>
-      <form class="pat-validation vertical" method="get" action="#" novalidate>
+      <form class="pat-validation vertical" data-pat-validation="disable-selector: .pat-button" method="get" action="#" novalidate>
           <fieldset class="horizontal">
             <label>Full name <input type="text" name="name" required="required"/></label>
-            
+
             <label>Age <input type="number" name="age" min="16" max="65" required="required"/></label>
 
             <fieldset class="group pat-checklist radio">
@@ -39,7 +39,24 @@
                     id="planning-end"
                     value="2015-09-10"/>
             </label>
-            
+
+            <label>Required date
+                <input
+                    type="date"
+                    required="required"
+                    name="measure.date-required:records"
+                    id="date-required"
+                    />
+            </label>
+
+            <label>Optional date
+                <input
+                    type="date"
+                    name="measure.date-optional:records"
+                    id="date-optional"
+                    />
+            </label>
+
             <fieldset class="buttons">
               <button class="pat-button">Test</button>
             </fieldset>

--- a/src/pat/validation/tests.js
+++ b/src/pat/validation/tests.js
@@ -127,28 +127,57 @@ define(["pat-registry", "pat-validation"], function(registry, pattern) {
             expect($el.find('em.warning').text()).toBe("Slegs heelgetalle");
         });
 
-        it("validates dates", function() {
-            var $el = $(
-                '<form class="pat-validation">'+
-                    '<input type="date" name="date" data-pat-validation="type: date;">'+
-                '</form>');
-            var $input = $el.find(':input');
-            $input.val('2000-02-30');
-            pattern.init($el);
-            $input.trigger('change');
-            expect($el.find('em.warning').length).toBe(1);
-            expect($el.find('em.warning').text()).toBe("This value must be a valid date");
+        // Unfortunately date validation cannot be tested using the Constraints
+        // API. ``ValidityState`` information is not updated after
+        // programmatically setting values.
+        // See whole discussion here: https://twitter.com/thetetet/status/1285239806205755393
+        // and: https://stackoverflow.com/questions/53226031/html-input-validity-not-checked-when-value-is-changed-by-javascript
 
-            $el = $(
-                '<form class="pat-validation">'+
-                    '<input type="date" name="date" data-pat-validation="type: date;">'+
-                '</form>');
-            $input = $el.find(':input');
-            $input.val('2000-02-28');
-            pattern.init($el);
-            $input.trigger('change');
-            expect($el.find('em.warning').length).toBe(0);
-        });
+        //it("validates dates", function() {
+        //    var $el = $(
+        //        '<form class="pat-validation">'+
+        //            '<input type="date" name="date">'+
+        //        '</form>');
+        //    var input = $el[0].querySelector('input');
+        //    input.value = '2000-02-30';
+        //    var pat = pattern.init($el);
+        //    pat.validateForm();
+        //    debugger;
+        //    expect($el.find('em.warning').length).toBe(1);
+        //    expect($el.find('em.warning').text()).toBe("This value must be a valid date");
+
+        //    $el = $(
+        //        '<form class="pat-validation">'+
+        //            '<input type="date" name="date">'+
+        //        '</form>');
+        //    input = $el[0].querySelector('input');
+        //    input.value = '2000-02-28';
+        //    pat = pattern.init($el);
+        //    pat.validateForm();
+        //    expect($el.find('em.warning').length).toBe(0);
+        //});
+
+        //it("doesn't validate empty optional dates", function() {
+        //    var $el = $(
+        //        '<form class="pat-validation">'+
+        //            '<input type="date" name="date">'+
+        //        '</form>');
+        //    var pat = pattern.init($el);
+        //    pat.validateForm();
+        //    expect($el.find('em.warning').length).toBe(0);
+        //});
+
+        //it("do require-validate non-empty required dates", function() {
+        //    var $el = $(
+        //        '<form class="pat-validation">'+
+        //            '<input type="date" name="date" required>'+
+        //            '<button type="submit" name="date" required>'+
+        //        '</form>');
+        //    var pat = pattern.init($el);
+        //    pat.validateForm();
+        //    expect($el.find('em.warning').length).toBe(1);
+        //    expect($el.find('em.warning').text()).toBe("This field is required");
+        //});
 
         it("doesn't validate disabled elements", function() {
             var $el = $(

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -80,6 +80,9 @@ define([
             if (_.contains(['datetime', 'date'], opts.type)) {
                 type = opts.type;
             }
+            if (type === 'datetime-local') {
+                type = 'datetime';
+            }
             return type;
         },
 

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -180,7 +180,7 @@ define([
                 constraints = {};
             if (!name) { return; }
             constraints[name.replace(/\./g, '\\.')] = {
-                'presence': input.getAttribute('required') ? { 'message': '^'+this.options.message.required } : false,
+                'presence': input.getAttribute('required') ? { 'message': '^'+this.options.message.required, allowEmpty: false } : false,
                 'email': type == 'email' ? { 'message': '^'+this.options.message.email } : false,
                 'numericality': type == 'number' ? true : false,
                 'datetime': type == 'datetime' ? { 'message': '^'+this.options.message.datetime } : false,

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -57,8 +57,8 @@ define([
         init: function($el, opts) {
             this.errors = 0;
             this.options = parser.parse(this.$el, opts);
-            this.$inputs = this.$el.find(':input[name]');
-            this.$el.find(":input[type=number]").on('keyup mouseup', _.debounce(function (ev) {
+            this.$inputs = this.$el.find('input[name], select[name], textarea[name]');
+            this.$el.find("input[type=number]").on('keyup mouseup', _.debounce(function (ev) {
                 this.validateElement(ev.target);
             }.bind(this), 500));
             this.$inputs.on('change.pat-validation', function (ev) { this.validateElement(ev.target); }.bind(this));
@@ -282,7 +282,7 @@ define([
         },
 
         validateElement: function (input, no_recurse) {
-            /* Handler which gets called when a single form :input element
+            /* Handler which gets called when a single form input element
              * needs to be validated. Will prevent the event's default action
              * if validation fails.
              */


### PR DESCRIPTION
Fixed by checking if input.validity.badInput is true for date/datetime-local fields. If so, check the date, if not, it might have been empty.
Due to the ``ValidityState`` object only being updated after user input and not on programmatic input it cannot be tested.
See the discussion here: https://twitter.com/thetetet/status/1285239806205755393
and here: https://stackoverflow.com/questions/53226031/html-input-validity-not-checked-when-value-is-changed-by-javascript