### PR TITLE
pat-inject: default selector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 Features
 ~~~~~~~~
 
+- pat-inject: Fix typo in docs for the ``source`` property.
 - pat-scroll: To define the scrollable target search also for `overflow-x` and `overflow-y` declarations.
 - Rework push message support for the STOMP message protocoll instead of backends instead of WAMP.
   We are using the RabbitMQ message broker for push support instead of crossbar.io.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 Features
 ~~~~~~~~
 
+- pat-inject: Rename undocumented ``selector`` property to ``defaultSelector``.
 - pat-inject: Fix typo in docs for the ``source`` property.
 - pat-scroll: To define the scrollable target search also for `overflow-x` and `overflow-y` declarations.
 - Rework push message support for the STOMP message protocoll instead of backends instead of WAMP.

--- a/src/pat/inject/documentation.md
+++ b/src/pat/inject/documentation.md
@@ -337,7 +337,7 @@ You can customise the behaviour of injection through options in the `data-pat-in
 | ----- | --------| -------- | ------- | ----------- |
 | `confirm` | `class` | class, always, never, form-data | Should a confirmation prompt be shown to the user before injection happens? Setting this to `form-data` means a prompt will be shown if there are form fields with values that will be replaced with the injected content. A value of `class` means that the pattern will check for the `is-dirty` CSS class on the target element. If the class is there, a confirmation prompt will be shown. | One of the allowable values. |
 | `confirm-message` | `Are you sure you want to leave this page?` | | What message should be shown to the user in the confirmation prompt? | |
-| `selector` | `body` | | Selector identifying which section of the loaded document to inject. | Selector string|
+| `source` | `body` | | Selector identifying which section of the loaded document to inject. | Selector string|
 | `target` | `body` | | Selector identifying where to inject the loaded content. | Selector string |
 | `data-type` | `html` | `html` `markdown`| The type of content that is loaded. This is normally detected automatically. | One of the mutually exclusive string values. |
 | `next-href` | | | For anchors, you can specify an href to point to after injection was triggered. If that element exists already during initialisation, the injection is not initialised and the href changed to next-href. | |

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -15,7 +15,7 @@ define([
         TEXT_NODE = 3,
         COMMENT_NODE = 8;
 
-    parser.addArgument("selector");
+    parser.addArgument("default-selector");
     parser.addArgument("target");
     parser.addArgument("data-type", "html");
     parser.addArgument("next-href");
@@ -235,7 +235,7 @@ define([
                     log.warn("Ignoring additional source ids:", urlparts.slice(2));
                 }
 
-                cfg.selector = cfg.selector || defaultSelector;
+                cfg.defaultSelector = cfg.defaultSelector || defaultSelector;
                 if (cfg.delay) {
                     try {
                         cfg.delay = utils.parseTime(cfg.delay);
@@ -323,8 +323,8 @@ define([
                 return false;
             }
             // defaults
-            cfg.source = cfg.source || cfg.selector;
-            cfg.target = cfg.target || cfg.selector;
+            cfg.source = cfg.source || cfg.defaultSelector;
+            cfg.target = cfg.target || cfg.defaultSelector;
 
             if (!inject.extractModifiers(cfg)) {
                 return false;
@@ -908,7 +908,7 @@ define([
                         return false;
                     }
                     // check if the target element still exists. Otherwise halt and catch fire
-                    var target = ($el.data("pat-inject")[0].target || cfgs[0].selector).replace(/::element/, '');
+                    var target = ($el.data("pat-inject")[0].target || cfgs[0].defaultSelector).replace(/::element/, '');
                     if (target && target !== 'self' && $(target).length === 0) {
                         return false;
                     }
@@ -948,7 +948,7 @@ define([
                         return false;
                     }
                     // check if the target element still exists. Otherwise halt and catch fire
-                    var target = ($el.data("pat-inject")[0].target || cfgs[0].selector).replace(/::element/, '');
+                    var target = ($el.data("pat-inject")[0].target || cfgs[0].defaultSelector).replace(/::element/, '');
                     if (target && target !== 'self' && $(target).length === 0) {
                         return false;
                     }


### PR DESCRIPTION
- pat-inject: Rename undocumented ``selector`` property to ``defaultSelector``.
- pat-inject: Fix typo in docs for the ``source`` property.