### PR TITLE
fix rebaseURL to work only with correct base URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 Features
 ~~~~~~~~
 
+- core/utils rebaseURL: Do not rebase if the base URL isn't absolute or doesn't start with an URL scheme.
 - pat-push: New pattern for replacing html content on push events.
 - pat-scroll-box: New pattern for scrolling detection. Replaces the previous "scroll detection" module.
 - pat-inject: Rename undocumented ``selector`` property to ``defaultSelector``.

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -182,8 +182,13 @@ define([
     // END: Taken from Underscore.js until here.
 
     function rebaseURL(base, url) {
-        if (url.indexOf("://")!==-1 || url[0]==="/" || url.indexOf("data:")===0)
+        if (
+            (base.indexOf("://") === -1 && base[0] !== "/") ||
+            url.indexOf("://") !== -1 ||
+            url[0] === "/" ||
+            url.indexOf("data:") === 0) {
             return url;
+        }
         return base.slice(0, base.lastIndexOf("/")+1) + url;
     }
 

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -827,17 +827,22 @@ define([
                 "$1src=\"\" data-pat-inject-rebase-$2="
             ).trim()).wrapAll("<div>").parent();
 
-            $page.find(Object.keys(inject._rebaseAttrs).join(",")).each(function() {
-                var $this = $(this),
-                    attrName = inject._rebaseAttrs[this.tagName],
-                    value = $this.attr(attrName);
+            if (
+                base.indexOf("://") !== -1 ||
+                base[0] === "/"
+            ) {
+                $page.find(Object.keys(inject._rebaseAttrs).join(",")).each(function() {
+                    var $this = $(this),
+                        attrName = inject._rebaseAttrs[this.tagName],
+                        value = $this.attr(attrName);
 
-                if (value && value.slice(0, 2) !== "@@" && value[0] !== "#" &&
-                    value.slice(0, 7) !== "mailto:" && value.slice(0, 11) !== "javascript:") {
-                    value = utils.rebaseURL(base, value);
-                    $this.attr(attrName, value);
-                }
-            });
+                    if (value && value.slice(0, 2) !== "@@" && value[0] !== "#" &&
+                        value.slice(0, 7) !== "mailto:" && value.slice(0, 11) !== "javascript:") {
+                        value = utils.rebaseURL(base, value);
+                        $this.attr(attrName, value);
+                    }
+                });
+            }
             // XXX: IE8 changes the order of attributes in html. The following
             // lines move data-pat-inject-rebase-src to src.
             $page.find("[data-pat-inject-rebase-src]").each(function() {

--- a/src/pat/inject/tests.js
+++ b/src/pat/inject/tests.js
@@ -317,40 +317,32 @@ define(["pat-inject", "pat-utils"], function(pattern, utils) {
             });
 
             it("Element with link attribute", function() {
-                var spy_rebaseURL = spyOn(utils, "rebaseURL").and.returnValue(
-                    "REBASED"
-                );
                 expect(
                     pattern._rebaseHTML(
-                        "base",
-                        '<a href="example.com">This is a test</a>'
+                        "http://example.com/test/",
+                        '<a href="subsite/page.html">This is a test</a>'
                     )
-                ).toBe('<a href="REBASED">This is a test</a>');
-                expect(spy_rebaseURL).toHaveBeenCalledWith(
-                    "base",
-                    "example.com"
-                );
+                ).toBe('<a href="http://example.com/test/subsite/page.html">This is a test</a>');
             });
 
             it("Automatically fix casing of attribute", function() {
-                spyOn(utils, "rebaseURL").and.returnValue("REBASED");
                 expect(
                     pattern._rebaseHTML(
-                        "base",
-                        '<a HrEf="example.com">This is a test</a>'
+                        "http://example.com/test/",
+                        '<a HrEF="subsite/page.html">This is a test</a>'
                     )
-                ).toBe('<a href="REBASED">This is a test</a>');
+                ).toBe('<a href="http://example.com/test/subsite/page.html">This is a test</a>');
             });
 
             it("Check if image is rebased correctly", function() {
-                spyOn(utils, "rebaseURL").and.returnValue("REBASED");
                 expect(
-                    pattern._rebaseHTML("base", '<img src="example.com">')
-                ).toBe('<img src="REBASED">');
+                    pattern._rebaseHTML(
+                        "http://example.com/test/",
+                        '<img src="image.png">')
+                ).toBe('<img src="http://example.com/test/image.png">');
             });
 
             it("Leave non attribute occurences of src intact", function() {
-                spyOn(utils, "rebaseURL").and.returnValue("REBASED");
                 expect(
                     pattern._rebaseHTML(
                         "base",

--- a/tests/specs/core/utils.js
+++ b/tests/specs/core/utils.js
@@ -24,6 +24,19 @@ define(["underscore", "pat-utils"], function(_, utils) {
                     utils.rebaseURL("http://example.com/foo/", "me/page.html"))
                     .toBe("http://example.com/foo/me/page.html");
             });
+
+            it("Rebase with absolute base url", function() {
+                expect(
+                    utils.rebaseURL("/foo/", "me/page.html"))
+                    .toBe("/foo/me/page.html");
+            });
+
+            it("Don't rebase with wrong base url", function() {
+                expect(
+                    utils.rebaseURL("example.com/foo/", "me/page.html"))
+                    .toBe("me/page.html");
+            });
+
             it("Doesn't rebase data: urls", function() {
                 expect(
                     utils.rebaseURL("http://example.com/foo/", "data:image-base64gibberish"))


### PR DESCRIPTION
core/utils rebaseURL: Do not rebase if the base URL isn't absolute or doesn't start with an URL scheme.

Note: the method ``_rebaseHTML_via_HTMLParser`` is unused.
I will remove this method and ``lib/htmlparser`` in https://github.com/Patternslib/Patterns/pull/731