### PR TITLE
end date should update when changing start date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,8 @@
 -   core dom: Add ``querySelectorAllAndMe`` to do a querySelectorAll including the starter element.
 -   core dom: Add ``wrap`` wrap an element with a wrapper element.
 -   core dom: Add ``hide`` and ``show`` for DOM elements which retain the original display value.
+-   pat date picker: Support updating a date if it is before another dependent date.
+
 
 ### Technical
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,9 @@
 -   Remove outdated pre IE9 browser compatibility polyfill `core/compat`.
 -   Remove unused `lib/htmlparser`.
 -   Remove obsolete library `prefixfree`.
+-   pat date picker: Remove ``format`` argument and just use the ISO 8601 standard "YYYY-MM-DD", like the specification of date inputs defines it.
+    Format would have submitted a formatted value where the ISO standard is expected.
+    This also allows for removing the dependency of ``pat-date-picker`` on MomentJS.
 
 ### Features
 

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -7,11 +7,9 @@ import utils from "../../core/utils";
 
 // Lazy loading modules.
 let Pikaday;
-let Moment;
 
 const parser = new Parser("date-picker");
 parser.addArgument("behavior", "styled", ["native", "styled"]);
-parser.addArgument("format", "YYYY-MM-DD");
 parser.addArgument("week-numbers", [], ["show", "hide"]);
 parser.addArgument("i18n"); // URL pointing to JSON resource with i18n values
 parser.addArgument("first-day", 0);
@@ -47,8 +45,6 @@ export default Base.extend({
 
         Pikaday = await import("pikaday");
         Pikaday = Pikaday.default;
-        Moment = await import("moment");
-        Moment = Moment.default;
 
         if (el.getAttribute("type") === "date") {
             el.setAttribute("type", "text");
@@ -56,12 +52,9 @@ export default Base.extend({
 
         const config = {
             field: el,
-            format: this.options.format,
+            format: "YYYY-MM-DD",
             firstDay: this.options.firstDay,
             showWeekNumber: this.options.weekNumbers === "show",
-            toString(date, format) {
-                return Moment(date).format(format);
-            },
             onSelect() {
                 $(this._o.field).closest("form").trigger("input-change");
                 /* Also trigger input change on date field to support pat-autosubmit. */

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -1,20 +1,24 @@
 /* pat-date-picker  - Polyfill for input type=date */
 import "regenerator-runtime/runtime"; // needed for ``await`` support
 import $ from "jquery";
-import Parser from "../../core/parser";
 import Base from "../../core/base";
+import Parser from "../../core/parser";
 import utils from "../../core/utils";
 
 // Lazy loading modules.
 let Pikaday;
 let Moment;
 
-var parser = new Parser("date-picker");
+const parser = new Parser("date-picker");
 parser.addArgument("behavior", "styled", ["native", "styled"]);
 parser.addArgument("format", "YYYY-MM-DD");
 parser.addArgument("week-numbers", [], ["show", "hide"]);
 parser.addArgument("i18n"); // URL pointing to JSON resource with i18n values
 parser.addArgument("first-day", 0);
+parser.addArgument("after");
+parser.addArgument("offset-days", 0);
+
+parser.addAlias("behaviour", "behavior");
 
 /* JSON format for i18n
  * { "previousMonth": "Previous Month",
@@ -23,15 +27,21 @@ parser.addArgument("first-day", 0);
  *   "weekdays"     : ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],
  *   "weekdaysShort": ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"]
  * } */
-parser.addAlias("behaviour", "behavior");
 
 export default Base.extend({
     name: "date-picker",
     trigger: ".pat-date-picker",
+
     async init() {
-        this.options = $.extend(parser.parse(this.$el), this.options);
-        this.polyfill = this.options.behavior === "native";
-        if (this.polyfill && utils.checkInputSupport("date", "invalid date")) {
+        const el = this.el;
+        //TODO: make parser with options extend missing options.
+        //this.options = parser.parse(el, opts);
+        this.options = $.extend(parser.parse(el), this.options);
+
+        if (
+            this.options.behavior === "native" &&
+            utils.checkInputSupport("date", "invalid date")
+        ) {
             return;
         }
 
@@ -40,56 +50,50 @@ export default Base.extend({
         Moment = await import("moment");
         Moment = Moment.default;
 
-        if (this.$el.attr("type") === "date") {
-            this.$el.attr("type", "text");
+        if (el.getAttribute("type") === "date") {
+            el.setAttribute("type", "text");
         }
 
-        var config = {
-            field: this.$el[0],
+        const config = {
+            field: el,
             format: this.options.format,
             firstDay: this.options.firstDay,
             showWeekNumber: this.options.weekNumbers === "show",
-            toString: function (date, format) {
+            toString(date, format) {
                 return Moment(date).format(format);
             },
-            onSelect: function () {
+            onSelect() {
                 $(this._o.field).closest("form").trigger("input-change");
                 /* Also trigger input change on date field to support pat-autosubmit. */
                 $(this._o.field).trigger("input-change");
             },
         };
 
-        if (this.$el.attr("min")) {
-            config.minDate = Moment(this.$el.attr("min")).toDate();
+        if (el.getAttribute("min")) {
+            config.minDate = Moment(el.getAttribute("min")).toDate();
         }
-        if (this.$el.attr("max")) {
-            config.maxDate = Moment(this.$el.attr("max")).toDate();
+        if (el.getAttribute("max")) {
+            config.maxDate = Moment(el.getAttribute("max")).toDate();
         }
 
         if (this.options.i18n) {
             $.getJSON(this.options.i18n)
-                .done(function (data) {
+                .done((data) => {
                     config.i18n = data;
                 })
                 .fail(
-                    $.proxy(function () {
+                    $.proxy(() => {
                         console.error(
                             "date-picker could not load i18n: " +
                                 this.options.i18n
                         );
                     }, this)
                 )
-                .always(function () {
+                .always(() => {
                     new Pikaday(config);
                 });
         } else {
             new Pikaday(config);
         }
-        return this.$el;
-    },
-
-    isodate: function () {
-        var now = new Date();
-        return now.toISOString().substr(0, 10);
     },
 });

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -36,6 +36,29 @@ export default Base.extend({
         //this.options = parser.parse(el, opts);
         this.options = $.extend(parser.parse(el), this.options);
 
+        if (this.options.after) {
+            // Set the date depending on another date which must be ``offset-days``
+            // BEFORE this date. Only set it, if the other date is AFTER this
+            // date.
+            const befores = document.querySelectorAll(this.options.after);
+            for (const b_el of befores) {
+                b_el.addEventListener("change", (e) => {
+                    let b_date = e.target.value; // the "before-date"
+                    b_date = b_date ? new Date(b_date) : null;
+                    if (!b_date) {
+                        return;
+                    }
+                    let a_date = this.el.value; // the "after-date"
+                    a_date = a_date ? new Date(a_date) : null;
+                    if (!a_date || a_date < b_date) {
+                        const offset = this.options.offsetDays || 0;
+                        b_date.setDate(b_date.getDate() + offset);
+                        this.el.value = b_date.toISOString().substring(0, 10);
+                    }
+                });
+            }
+        }
+
         if (
             this.options.behavior === "native" &&
             utils.checkInputSupport("date", "invalid date")

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -70,10 +70,10 @@ export default Base.extend({
         };
 
         if (el.getAttribute("min")) {
-            config.minDate = Moment(el.getAttribute("min")).toDate();
+            config.minDate = new Date(el.getAttribute("min"));
         }
         if (el.getAttribute("max")) {
-            config.maxDate = Moment(el.getAttribute("max")).toDate();
+            config.maxDate = new Date(el.getAttribute("max"));
         }
 
         if (this.options.i18n) {

--- a/src/pat/date-picker/documentation.md
+++ b/src/pat/date-picker/documentation.md
@@ -93,3 +93,5 @@ In addition, the following options can be passed to `data-pat-date-picker`:
 | **week-numbers**            | string  | hide          | show, hide       | "show" will show the weeks' numbers in a leftmost column.                                                |
 | **i18n**                    | URL     |               |                  | Provide a URL to a JSON resource which gives the i18n values.                                            |
 | **first-day**               | Integer | 0             |                  | Set the first day of the week (0 -> Sunday, 1-> Monday, ...).                                            |
+| **after**                   | string  |               |                  | CSS selector of another date input. If this date is before the other, it will be updated to the oder date plus offset-days. |
+| **offset-days**             | Integer | 0             |                  | Number of days added to the **after** reference date which will be used to update this date value.       |

--- a/src/pat/date-picker/index.html
+++ b/src/pat/date-picker/index.html
@@ -68,6 +68,17 @@
                         type="date"
                     />
                 </label>
+
+                <label>Start
+                    <input name="start" class="pat-date-picker" type="date"/>
+                </label>
+                <label>End after start, automatically updated.
+                    <input name="end"   class="pat-date-picker" type="date" data-pat-date-picker="after: input[name=start]; offset-days: 2;"/>
+                </label>
+
+                <br />
+
+
             </fieldset>
         </form>
     </body>

--- a/src/pat/datetime-picker/datetime-picker.test.js
+++ b/src/pat/datetime-picker/datetime-picker.test.js
@@ -22,7 +22,7 @@ describe("pat-datetime-picker", function () {
         pattern.init($el);
         await utils.timeout(1); // wait a tick for async to settle.
 
-        $("input.date", $el.next()).click();
+        $("input.date", $el.parent()).click();
 
         var date = new Date();
         var day = date.getDate().toString();
@@ -59,7 +59,8 @@ describe("pat-datetime-picker", function () {
         ).appendTo(document.body);
         pattern.init($el);
         await utils.timeout(1); // wait a tick for async to settle.
-        $("input.date", $el.next()).click();
+
+        $("input.date", $el.parent()).click();
 
         expect(
             document.querySelector(".pika-lendar th:first-child abbr")
@@ -74,7 +75,7 @@ describe("pat-datetime-picker", function () {
         pattern.init($el);
         await utils.timeout(1); // wait a tick for async to settle.
 
-        $("input.date", $el.next()).click();
+        $("input.date", $el.parent()).click();
 
         expect(
             document.querySelector(
@@ -102,7 +103,7 @@ describe("pat-datetime-picker", function () {
         pattern.init($el);
         await utils.timeout(1); // wait a tick for async to settle.
 
-        $("input.date", $el.next()).click();
+        $("input.date", $el.parent()).click();
 
         expect(
             document.querySelectorAll(".pika-lendar .pika-week")[0].textContent

--- a/src/pat/validation/index.html
+++ b/src/pat/validation/index.html
@@ -87,7 +87,7 @@
                         type="date"
                         class="pat-date-picker"
                         name="measure.planning_end:records"
-                        data-pat-date-picker="behavior: native"
+                        data-pat-date-picker="behavior: native; after: #planning-start"
                         data-pat-validation="type: date; not-before: #planning-start; message-date: This date must be on or after the start date."
                         id="planning-end"
                         value="2015-09-10"


### PR DESCRIPTION
Ready to review.

Works as we discussed it:
When "date input A" depends on "date input B" via the ``after`` argument the following happens:
- If A is unset but B is set, it will be set to B+offset days
- If B > A, A will be set to B+offset days

@pilz - I have the feeling that my wording in the documentation is a bit clumsy. I'd happy for improvements.
See the example in index.html on how to use it.

Special feature: It should work with multiple "after" dependencies - so if the ``after`` selector matches multiple other input fields, it should update for each of them.

When starting this branch with ``make serve`` there are two new inputs at the end of this page, configured with an offset of 2 days:
http://0.0.0.0:3001/src/pat/date-picker/

![Screenshot from 2020-11-03 13-11-12](https://user-images.githubusercontent.com/170891/97983741-10620c00-1dd6-11eb-845b-a7736c42dba7.png)

Also I've updated the pat-validation demo with this feature:

![Screenshot from 2020-11-03 13-12-30](https://user-images.githubusercontent.com/170891/97983887-40111400-1dd6-11eb-9724-d3ca2160050a.png)

planning-end updates when planning-start > planning-end but can still be set to a wrong date.