### PR TITLE
pat-validation: Allow for HTML5 style required attributes without a value

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,11 +4,11 @@
 
 Features
 ~~~~~~~~
+- pat-validation: Allow for HTML5 style ``required`` attributes without a value.
 - pat-validation: Added the possibility to check for fields equality
 - pat-validation: Dont use :input jquery extension for better performance
 - pat-validation: Update validate.js to 0.13.1
 - Prevent "Modernizr.inputtypes is undefined" error
-
 - pat-validation: Do not trigger on empty dates. Fixes: #711
 - Remove PhantomJS - we're using ChromeHeadless already.
 - Simplify package.json and remove unused.

--- a/src/pat/validation/index.html
+++ b/src/pat/validation/index.html
@@ -9,16 +9,16 @@
   <body>
       <form class="pat-validation vertical" data-pat-validation="disable-selector: .pat-button" method="get" action="#" novalidate>
           <fieldset class="horizontal">
-            <label>Full name <input type="text" name="name" required="required"/></label>
+            <label>Full name <input type="text" name="name" required/></label>
 
-            <label>Age <input type="number" name="age" min="16" max="65" required="required"/></label>
+            <label>Age <input type="number" name="age" min="16" max="65" required/></label>
 
             <fieldset class="group pat-checklist radio">
               <legend>Favourite colour</legend>
-              <label><input name="colour" required="required" type="radio" value="blue"/> Blue</label>
-              <label><input name="colour" required="required" type="radio" value="pink"/> Pink</label>
-              <label><input name="colour" required="required" type="radio" value="red"/> Red</label>
-              <label><input name="colour" required="required" type="radio" value="yellow"/> yellow</label>
+              <label><input name="colour" required type="radio" value="blue"/> Blue</label>
+              <label><input name="colour" required type="radio" value="pink"/> Pink</label>
+              <label><input name="colour" required type="radio" value="red"/> Red</label>
+              <label><input name="colour" required type="radio" value="yellow"/> yellow</label>
             </fieldset>
 
             <label>Planning start
@@ -43,7 +43,7 @@
             <label>Required date
                 <input
                     type="date"
-                    required="required"
+                    required
                     name="measure.date-required:records"
                     id="date-required"
                     />

--- a/src/pat/validation/tests.js
+++ b/src/pat/validation/tests.js
@@ -27,6 +27,16 @@ define(["pat-registry", "pat-validation"], function(registry, pattern) {
             expect($el.find('em.warning').length).toBe(0);
         });
 
+        it("validates required inputs with HTML5 required attribute style", function() {
+            var $el = $(
+                '<form class="pat-validation">'+
+                '<input type="text" name="name" required>'+
+                '</form>');
+            pattern.init($el);
+            $el.find(':input').trigger('change');
+            expect($el.find('em.warning').length).toBe(1);
+        });
+
         it("can show custom validation messages", function() {
             var $el = $(
                 '<form class="pat-validation" data-pat-validation="message-required: I\'m sorry Dave, I can\'t let you do that.">'+

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -197,7 +197,7 @@ define([
                 constraints = {};
             if (!name) { return; }
             constraints[name.replace(/\./g, '\\.')] = {
-                'presence': input.getAttribute('required') ? { 'message': '^'+this.options.message.required, allowEmpty: false } : false,
+                'presence': input.hasAttribute('required') ? { 'message': '^'+this.options.message.required, allowEmpty: false } : false,
                 'email': type === 'email' ? { 'message': '^'+this.options.message.email } : false,
                 'numericality': type === 'number' ? true : false,
                 'datetime': type === 'datetime' && this.doDateCheck(input) ? { 'message': '^'+this.options.message.datetime } : false,


### PR DESCRIPTION
The HTML5 specs allow for an ``required`` attribute without a value. We're not supporting this in pat-validation until now. This PR fixes this.

Now we can use:
```
<input type="text" name="req1" required="required" />
```
as well as 
```
<input type="text" name="req1" required />
```

See:
https://html.spec.whatwg.org/multipage/input.html#attr-input-required
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/required