### PR TITLE
[WIP] pat-gallery: Add feature to auto-wrap <img> tags within pat-gallery.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 Features
 ~~~~~~~~
+- pat-gallery: Add feature to auto-wrap <img> tags within pat-gallery.
 - pat-validation: Allow for HTML5 style ``required`` attributes without a value.
 - pat-validation: Added the possibility to check for fields equality
 - pat-validation: Dont use :input jquery extension for better performance

--- a/src/pat/gallery/documentation.md
+++ b/src/pat/gallery/documentation.md
@@ -47,6 +47,15 @@ If you just want individual images to be opened in the gallery overlay but want 
       <a class="pat-gallery" href="images/full/2.jpg"><img src="images/thumb/2.jpg"/></a>
     </nav>
 
+Sometimes it's not possible to modify content with images to fullfill pat-gallery's markup requirements.
+In this case you can auto-add these images and also change the ``src`` value via search/replace.
+
+    <nav class="pat-gallery" data-pat-gallery="item-selector: a.add-to-gallery; autoadd-enabled: true; autoadd-src-replace-from: thumb-; autoadd-src-replace-to: full-;">
+      <a href="full-1.jpg" class="add-to-gallery"><img src="thumb-1.jpg"/></a>
+      <img src="thumb-2.jpg"/>
+      <img src="thumb-3.jpg"/>
+    </nav>
+
 
 ### Option reference
 
@@ -60,6 +69,9 @@ You can customise the behaviour of a gallery through options in the
 | Property | Default value | Values | Description | Type |
 | ----- | --------| -------- | ------- | ----------- |
 | `item-selector` | `a` | | The selector for the link element, which contains the images to be added to the gallery. For example, you can set the `item-selector` to `a.add-to-gallery` and have only images wrapped in an anchor element with the class `add-to-gallery` added to the gallery.
+| `autoadd-enabled` | false | `true` `false` | Automatically add img elements to the gallery. |Mutually exclusive|
+| `autoadd-src-replace-from` | null | | For automatically added images search the ``src`` attributes's value for ... |String (RegEx)|
+| `autoadd-src-replace-to` | '' | | and replace it with this value. |String|
 | `loop` | true | `true` `false` | Indicates if a slideshow should loop back to the beginning.|Mutually exclusive|
 | `scale-method` | `fit` | `fit` `fitNoUpscale` `zoom` | How images will fit onto the screen. `fit` ensures the image always fits the screen. `fitNoUpscale` works like `fit` but will never upscale the image. `zoom` the image will always fill the full screen, this may cause the image to be "zoomed" in and cropped.|Mutually exclusive |
 | `delay` | `30000` | | The delay, in milliseconds, an image is shown in a slideshow.|Number|

--- a/src/pat/gallery/index.html
+++ b/src/pat/gallery/index.html
@@ -15,6 +15,7 @@
       <a href="full-2.jpg"><img src="thumb-2.jpg" title="Photo by Doug88888"/></a>
       <a href="full-3.jpg"><img src="thumb-3.jpg" title="Photy by Paulo Brandao"/></a>
     </nav>
+
     <h1>Gallery with mixed content</h1>
     <p>Only items which match the selecor ``a.add-to-gallery`` are added.</p>
     <nav class="pat-gallery" data-pat-gallery="item-selector: a.add-to-gallery">
@@ -23,12 +24,21 @@
       <a href="">Link only</a>
       <a href="full-3.jpg" class="add-to-gallery"><img src="thumb-3.jpg" title="Photy by Paulo Brandao"/></a>
     </nav>
+
     <h1>Image popups, not collected in a gallery</h1>
     <nav>
       <a href="full-1.jpg" class="pat-gallery"><img src="thumb-1.jpg" title="Aurora Borealis. Photo by Beverly &amp; Pack"/></a>
       <a href="full-2.jpg" class="pat-gallery"><img src="thumb-2.jpg" title="Photo by Doug88888"/></a>
       <a href="full-3.jpg" class="pat-gallery"><img src="thumb-3.jpg" title="Photy by Paulo Brandao"/></a>
     </nav>
+
+    <h1>Gallery with auto wrapped content</h1>
+    <nav class="pat-gallery" data-pat-gallery="item-selector: a.add-to-gallery; autoadd-enabled: true; autoadd-src-replace-from: thumb-; autoadd-src-replace-to: full-;">
+      <a href="full-1.jpg" class="add-to-gallery"><img src="thumb-1.jpg" title="Aurora Borealis. Photo by Beverly &amp; Pack"/></a>
+      <img src="thumb-2.jpg" title="Photo by Doug88888"/>
+      <img src="thumb-3.jpg" title="Photy by Paulo Brandao"/>
+    </nav>
+
 (Timestamp to see if page has reloaded: <script>document.write(Math.round(new Date().getTime()/1000));</script>)
   </body>
 </html>


### PR DESCRIPTION
From the docs:

Sometimes it's not possible to modify content with images to fullfill pat-gallery's markup requirements.
In this case you can auto-add these images and also change the ``src`` value via search/replace.

```
    <nav class="pat-gallery" data-pat-gallery="item-selector: a.add-to-gallery; autoadd-enabled: true; autoadd-src-replace-from: thumb-; autoadd-src-replace-to: full-;">
      <a href="full-1.jpg" class="add-to-gallery"><img src="thumb-1.jpg"/></a>
      <img src="thumb-2.jpg"/>
      <img src="thumb-3.jpg"/>
    </nav>
```

This will result in:
```
    <nav class="pat-gallery" data-pat-gallery="item-selector: a.add-to-gallery; autoadd-enabled: true; autoadd-src-replace-from: thumb-; autoadd-src-replace-to: full-;">
      <a href="full-1.jpg" class="add-to-gallery"><img src="thumb-1.jpg"/></a>
      <a href="full-2.jpg" class="autoadd-gallery-selector"><img src="thumb-2.jpg"/></a>
      <a href="full-3.jpg" class="autoadd-gallery-selector"><img src="thumb-3.jpg"/></a>
    </nav>
```

Please note the usage of the special class ``autoadd-gallery-selector`` to mark images to be added to the gallery. This is because we cannot determine the class from the pat-gallery configuration (the selector can also include id and element selectors).