### PR TITLE
Updates to pat-tooltip

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
   - pat-slideshow-builder
   - simplePlaceholder from jquery-ext.
 - IE11 is not supported by default anymore. There is a ``polyfills`` bundle, which adds IE11 support for the time being.
+- pat tooltip: Remove undocumented "souce: content-html" parameter.
 
 ### Features
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   - simplePlaceholder from jquery-ext.
 - IE11 is not supported by default anymore. There is a ``polyfills`` bundle, which adds IE11 support for the time being.
 - pat tooltip: Remove undocumented "souce: content-html" parameter.
+- pat tooltip: Remove undocumented "souce: auto" parameter. This parameter should not be used as it is not explicit enough and would lead to unintuitive behavior.
 
 ### Features
 

--- a/src/pat/tooltip/tooltip.js
+++ b/src/pat/tooltip/tooltip.js
@@ -30,7 +30,7 @@ const all_positions = [
 parser.addArgument("position-list", [], all_positions, true);
 parser.addArgument("position-policy", "auto", ["auto", "force"]);
 parser.addArgument("trigger", "click", ["click", "hover"]);
-parser.addArgument("source", "title", ["ajax", "content", "title", "auto"]);
+parser.addArgument("source", "title", ["ajax", "content", "title"]);
 parser.addArgument("ajax-data-type", "html", ["html", "markdown"]);
 parser.addArgument("closing", "auto", ["auto", "sticky", "close-button"]);
 parser.addArgument("delay");
@@ -168,20 +168,6 @@ export default Base.extend({
             },
 
             source: () => {
-                if (opts.source === "auto") {
-                    const href = this.el.getAttribute("href");
-                    if (typeof href !== "string") {
-                        log.error(
-                            `href must be specified if 'source' is set to 'auto'`
-                        );
-                        return;
-                    }
-                    if (href.indexOf("#") === 0) {
-                        opts.source = "content";
-                    } else {
-                        opts.source = "ajax";
-                    }
-                }
                 let content;
                 if (opts.source === "title") {
                     // Tooltip content from title attribute

--- a/src/pat/tooltip/tooltip.js
+++ b/src/pat/tooltip/tooltip.js
@@ -30,21 +30,13 @@ const all_positions = [
 parser.addArgument("position-list", [], all_positions, true);
 parser.addArgument("position-policy", "auto", ["auto", "force"]);
 parser.addArgument("trigger", "click", ["click", "hover"]);
-parser.addArgument("source", "title", [
-    "auto",
-    "ajax",
-    "content",
-    "content-html",
-    "title",
-]);
+parser.addArgument("source", "title", ["auto", "ajax", "content", "title"]);
 parser.addArgument("ajax-data-type", "html", ["html", "markdown"]);
 parser.addArgument("closing", "auto", ["auto", "sticky", "close-button"]);
 parser.addArgument("delay");
 parser.addArgument("mark-inactive", true);
 parser.addArgument("class");
 parser.addArgument("target", "body");
-
-// parser.addArgument("height", "auto", ["auto", "max"]);
 
 export default Base.extend({
     name: "tooltip",

--- a/src/pat/tooltip/tooltip.test.js
+++ b/src/pat/tooltip/tooltip.test.js
@@ -834,11 +834,11 @@ describe("pat-tooltip", () => {
                 });
             });
             describe(`if the 'source' parameter is 'content'`, () => {
-                it("and the href-hashtag reference cannot be found, it will show the content of the link", async (done) => {
+                it("it will show the content of the link", async (done) => {
                     const content = "Local content";
                     const $el = testutils.createTooltip({
                         data: "source: content; trigger: hover",
-                        href: "#",
+                        href: "#lab",
                         content: content,
                     });
                     const instance = new pattern($el);
@@ -853,29 +853,6 @@ describe("pat-tooltip", () => {
                     expect(spy_show).toHaveBeenCalled();
                     expect(
                         document.querySelector(".tippy-box").textContent
-                    ).toBe(content);
-
-                    done();
-                });
-                it("and the href-reference can be found, it will show that in the modal", async (done) => {
-                    const content = "Local content";
-                    const $el = testutils.createTooltip({
-                        data: "source: content; trigger: hover",
-                        href: "#tooltip-source",
-                    });
-                    testutils.createTooltipSource();
-                    const instance = new pattern($el);
-                    const spy_show = spyOn(
-                        instance.tippy.props,
-                        "onShow"
-                    ).and.callThrough();
-
-                    testutils.mouseenter($el);
-                    await utils.timeout(1);
-
-                    expect(spy_show).toHaveBeenCalled();
-                    expect(
-                        document.querySelector(".tippy-box strong").textContent
                     ).toBe(content);
 
                     done();
@@ -945,35 +922,146 @@ describe("pat-tooltip", () => {
                 done();
             });
         });
-        describe(`if the "source" parameter is "auto"`, () => {
-            describe(`if the "href" points to a document fragment`, () => {
-                it(`will revert to "content"`, (done) => {
-                    const $el = testutils.createTooltip({
-                        data: "source: auto",
-                        href: "#tooltip-source",
-                    });
-                    testutils.createTooltipSource();
-                    const instance = new pattern($el);
+    });
 
-                    // options.source is changed to "content"
-                    expect(instance.options.source).toEqual("content");
-
-                    done();
-                });
+    describe("test the different `source` parameters", () => {
+        it("source: title will use the title attribute", async (done) => {
+            const $el = testutils.createTooltip({
+                data: "source: title; trigger: click",
             });
-            describe(`if the "href" points to an external URL`, () => {
-                it(`will revert to "ajax"`, (done) => {
-                    const $el = testutils.createTooltip({
-                        data: "source: auto",
-                        href: "/tests/content.html#content",
-                    });
-                    const instance = new pattern($el);
+            const title = $el[0].title;
+            const instance = new pattern($el);
 
-                    // options.source is changed to "ajax"
-                    expect(instance.options.source).toEqual("ajax");
+            testutils.click($el);
+            await utils.timeout(1);
 
-                    done();
+            const expected = document.querySelector(
+                ".tooltip-container .tippy-content"
+            ).textContent;
+            expect(expected).toBe(title);
+
+            done();
+        });
+
+        it("source: content use the content of the link", async (done) => {
+            const content = "Local content";
+            const $el = testutils.createTooltip({
+                data: "source: content; trigger: click",
+                content: content,
+            });
+            const instance = new pattern($el);
+
+            testutils.click($el);
+            await utils.timeout(1);
+
+            expect(document.querySelector(".tippy-box").textContent).toBe(
+                content
+            );
+
+            done();
+        });
+
+        it("source: ajax and an external url will fetch its contents via ajax", async (done) => {
+            global.fetch = jest
+                .fn()
+                .mockImplementation(
+                    mockFetch("External content fetched via an HTTP request.")
+                );
+
+            const $el = testutils.createTooltip({
+                data: "source: ajax",
+                href: "http://test.com",
+            });
+            const instance = new pattern($el);
+
+            const spy_content = spyOn(
+                instance,
+                "_getContent"
+            ).and.callThrough();
+            const spy_show = spyOn(
+                instance.tippy.props,
+                "onShow"
+            ).and.callThrough();
+
+            testutils.click($el);
+            await utils.timeout(1); // wait a tick for async fetch
+
+            expect(global.fetch).toHaveBeenCalled();
+            expect(spy_content).toHaveBeenCalled();
+            expect(spy_show).toHaveBeenCalled();
+            expect(
+                document.querySelector(".tippy-box .tippy-content").textContent
+            ).toBe("External content fetched via an HTTP request.");
+
+            global.fetch.mockClear();
+            delete global.fetch;
+
+            done();
+        });
+
+        it("source: ajax with a local selector will not use ajax but get the contents from the current DOM", async (done) => {
+            global.fetch = jest
+                .fn()
+                .mockImplementation(
+                    mockFetch("External content fetched via an HTTP request.")
+                );
+
+            const $el = testutils.createTooltip({
+                data: "source: ajax",
+                href: "#lab",
+            });
+            const instance = new pattern($el);
+
+            const spy_content = spyOn(
+                instance,
+                "_getContent"
+            ).and.callThrough();
+            const spy_show = spyOn(
+                instance.tippy.props,
+                "onShow"
+            ).and.callThrough();
+
+            testutils.click($el);
+            await utils.timeout(1); // wait a tick for async fetch
+
+            expect(global.fetch).not.toHaveBeenCalled();
+            expect(spy_content).toHaveBeenCalled();
+            expect(spy_show).toHaveBeenCalled();
+            expect(
+                document.querySelector(".tippy-box .tippy-content .pat-tooltip")
+            ).toBeTruthy();
+
+            global.fetch.mockClear();
+            delete global.fetch;
+
+            done();
+        });
+
+        describe("test source:auto", () => {
+            it(`source: auto and a document fragment will revert to "content"`, (done) => {
+                const $el = testutils.createTooltip({
+                    data: "source: auto",
+                    href: "#tooltip-source",
                 });
+                testutils.createTooltipSource();
+                const instance = new pattern($el);
+
+                // options.source is changed to "content"
+                expect(instance.options.source).toEqual("content");
+
+                done();
+            });
+            it(`source: auto and a external url will revert to "ajax"`, (done) => {
+                const $el = testutils.createTooltip({
+                    data: "source: auto",
+                    href: "/tests/content.html#content",
+                });
+                const instance = new pattern($el);
+
+                // options.source is changed to "ajax"
+                expect(instance.options.source).toEqual("ajax");
+
+                done();
             });
         });
     });
@@ -1005,40 +1093,6 @@ describe("pat-tooltip", () => {
             //expect(spy_ajax).toHaveBeenCalledBefore(spy_prevented);
             expect(call_order.indexOf("_getContent")).toEqual(0);
             expect(call_order.includes("preventDefault")).toBeTruthy();
-
-            global.fetch.mockClear();
-            delete global.fetch;
-
-            done();
-        });
-
-        it("will fetch its contents via ajax", async (done) => {
-            global.fetch = jest
-                .fn()
-                .mockImplementation(
-                    mockFetch("External content fetched via an HTTP request.")
-                );
-
-            const $el = testutils.createTooltip({
-                data: "source: ajax",
-                href: "http://test.com",
-            });
-            const instance = new pattern($el);
-
-            const spy_ajax = spyOn(instance, "_getContent").and.callThrough();
-            const spy_show = spyOn(
-                instance.tippy.props,
-                "onShow"
-            ).and.callThrough();
-
-            testutils.click($el);
-            await utils.timeout(1); // wait a tick for async fetch
-
-            expect(spy_ajax).toHaveBeenCalled();
-            expect(spy_show).toHaveBeenCalled();
-            expect(
-                document.querySelector(".tippy-box .tippy-content").textContent
-            ).toBe("External content fetched via an HTTP request.");
 
             global.fetch.mockClear();
             delete global.fetch;
@@ -1417,7 +1471,7 @@ this will be extracted.
             document.body.appendChild(content);
 
             const $el = testutils.createTooltip({
-                data: "source: content; trigger: click",
+                data: "source: ajax; trigger: click",
                 href: "#local-content::element",
             });
             const instance = new pattern($el);
@@ -1441,7 +1495,7 @@ this will be extracted.
             document.body.appendChild(content);
 
             const $el = testutils.createTooltip({
-                data: "source: content; trigger: click",
+                data: "source: ajax; trigger: click",
                 href: "#local-content",
             });
             const instance = new pattern($el);

--- a/src/pat/tooltip/tooltip.test.js
+++ b/src/pat/tooltip/tooltip.test.js
@@ -1262,98 +1262,98 @@ this will be extracted.
                 done();
             });
         });
+    });
 
-        describe("patterns-injected events", () => {
-            it("it throws the ``patterns-injected`` event", async (done) => {
-                global.fetch = jest
-                    .fn()
-                    .mockImplementation(mockFetch("External content"));
+    describe("patterns-injected events", () => {
+        it("it throws the ``patterns-injected`` event", async (done) => {
+            global.fetch = jest
+                .fn()
+                .mockImplementation(mockFetch("External content"));
 
-                let called = false;
-                $(document.body).on("patterns-injected", () => {
-                    called = true;
-                });
-
-                const $el = testutils.createTooltip({
-                    data: "source: ajax; trigger: click",
-                    href: "http://test.com",
-                });
-                const instance = new pattern($el);
-
-                testutils.click($el);
-                await utils.timeout(1); // wait a tick for async fetch
-
-                expect(called).toBeTruthy();
-
-                global.fetch.mockClear();
-                delete global.fetch;
-
-                done();
+            let called = false;
+            $(document.body).on("patterns-injected", () => {
+                called = true;
             });
 
-            it.skip("triggers event handlers in other patterns", async (done) => {
-                // TODO: fix tests
-                global.fetch = jest
-                    .fn()
-                    .mockImplementation(
-                        mockFetch(`<input type="checkbox" name="test"/>`)
-                    );
-
-                const form = document.createElement("form");
-                form.setAttribute("action", "test.html");
-                form.setAttribute("class", "pat-autosubmit");
-                document.body.appendChild(form);
-
-                const $el = testutils.createTooltip({
-                    data: "source: ajax; trigger: click; target: form",
-                    href: "http://test.com",
-                });
-                const instance = new pattern($el);
-
-                const instance2 = new autosubmit($(form));
-                const spy_handler1 = spyOn(
-                    instance2,
-                    "refreshListeners"
-                ).and.callThrough();
-                const spy_handler2 = spyOn(
-                    instance2,
-                    "onInputChange"
-                ).and.callThrough();
-
-                testutils.click($el);
-                await utils.timeout(1); // wait a tick for async fetch
-
-                document.body.querySelector("input[name=test]").click();
-                await utils.timeout(1); // wait a tick for async fetch
-
-                // TODO: check why this isn't called
-                // manual tests show expected behavior.
-                expect(spy_handler1).toHaveBeenCalled();
-                expect(spy_handler2).toHaveBeenCalled();
-
-                global.fetch.mockClear();
-                delete global.fetch;
-
-                done();
+            const $el = testutils.createTooltip({
+                data: "source: ajax; trigger: click",
+                href: "http://test.com",
             });
+            const instance = new pattern($el);
 
-            it("only scans the tooltip content once", async (done) => {
-                const $el = testutils.createTooltip({
-                    data: "source: content; trigger: click",
-                });
-                const instance = new pattern($el);
+            testutils.click($el);
+            await utils.timeout(1); // wait a tick for async fetch
 
-                const spy_scan = spyOn(registry, "scan");
+            expect(called).toBeTruthy();
 
-                testutils.click($el);
-                await utils.timeout(1); // wait a tick for async fetch
+            global.fetch.mockClear();
+            delete global.fetch;
 
-                // Test, if registry.scan isn't invoked twice - another time by
-                // pat-inject.
-                expect(spy_scan).toHaveBeenCalledTimes(1);
+            done();
+        });
 
-                done();
+        it.skip("triggers event handlers in other patterns", async (done) => {
+            // TODO: fix tests
+            global.fetch = jest
+                .fn()
+                .mockImplementation(
+                    mockFetch(`<input type="checkbox" name="test"/>`)
+                );
+
+            const form = document.createElement("form");
+            form.setAttribute("action", "test.html");
+            form.setAttribute("class", "pat-autosubmit");
+            document.body.appendChild(form);
+
+            const $el = testutils.createTooltip({
+                data: "source: ajax; trigger: click; target: form",
+                href: "http://test.com",
             });
+            const instance = new pattern($el);
+
+            const instance2 = new autosubmit($(form));
+            const spy_handler1 = spyOn(
+                instance2,
+                "refreshListeners"
+            ).and.callThrough();
+            const spy_handler2 = spyOn(
+                instance2,
+                "onInputChange"
+            ).and.callThrough();
+
+            testutils.click($el);
+            await utils.timeout(1); // wait a tick for async fetch
+
+            document.body.querySelector("input[name=test]").click();
+            await utils.timeout(1); // wait a tick for async fetch
+
+            // TODO: check why this isn't called
+            // manual tests show expected behavior.
+            expect(spy_handler1).toHaveBeenCalled();
+            expect(spy_handler2).toHaveBeenCalled();
+
+            global.fetch.mockClear();
+            delete global.fetch;
+
+            done();
+        });
+
+        it("only scans the tooltip content once", async (done) => {
+            const $el = testutils.createTooltip({
+                data: "source: content; trigger: click",
+            });
+            const instance = new pattern($el);
+
+            const spy_scan = spyOn(registry, "scan");
+
+            testutils.click($el);
+            await utils.timeout(1); // wait a tick for async fetch
+
+            // Test, if registry.scan isn't invoked twice - another time by
+            // pat-inject.
+            expect(spy_scan).toHaveBeenCalledTimes(1);
+
+            done();
         });
     });
 

--- a/src/pat/tooltip/tooltip.test.js
+++ b/src/pat/tooltip/tooltip.test.js
@@ -1036,34 +1036,6 @@ describe("pat-tooltip", () => {
 
             done();
         });
-
-        describe("test source:auto", () => {
-            it(`source: auto and a document fragment will revert to "content"`, (done) => {
-                const $el = testutils.createTooltip({
-                    data: "source: auto",
-                    href: "#tooltip-source",
-                });
-                testutils.createTooltipSource();
-                const instance = new pattern($el);
-
-                // options.source is changed to "content"
-                expect(instance.options.source).toEqual("content");
-
-                done();
-            });
-            it(`source: auto and a external url will revert to "ajax"`, (done) => {
-                const $el = testutils.createTooltip({
-                    data: "source: auto",
-                    href: "/tests/content.html#content",
-                });
-                const instance = new pattern($el);
-
-                // options.source is changed to "ajax"
-                expect(instance.options.source).toEqual("ajax");
-
-                done();
-            });
-        });
     });
 
     describe(`if the 'source' parameter is 'ajax'`, () => {


### PR DESCRIPTION
- Restore old behavior of "source: content" where it only uses the triggers content and not another DOM structure.
- Remove "source: auto" (See: https://github.com/quaive/ploneintranet.prototype/issues/859#issuecomment-695997028 )