### PR TITLE
pat-calendar: language fix, de/select categories button fix

### DIFF
--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -1,4 +1,5 @@
 import "regenerator-runtime/runtime"; // needed for ``await`` support
+import $ from "jquery";
 import Base from "../../core/base";
 import logging from "../../core/logging";
 import Modal from "../modal/modal";
@@ -413,7 +414,7 @@ export default Base.extend({
             } else {
                 ctrl.checked = false;
             }
-            ctrl.dispatchEvent(new Event("change"));
+            $(ctrl).trigger("change");
         }
     },
 

--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -45,7 +45,7 @@ parser.addArgument("first-day", null);
 parser.addArgument("first-hour", "6");
 parser.addArgument("height", "auto");
 parser.addArgument("ignore-url", false);
-parser.addArgument("lang", "en");
+parser.addArgument("lang", null); // If not set, use "en" (See below)
 parser.addArgument("store", "none", ["none", "session", "local"]);
 parser.addArgument("time-format", "h(:mm)t");
 parser.addArgument("timezone", null);


### PR DESCRIPTION
- Do not set a language default as it would always override the fallbacks.
- Fix pat-checklist not initializing de/select buttons due to jQuery not listening to raw JavaScript event.
