### PR TITLE
Couple of fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
 -   pat calendar: Store view, date and active categories per URL, allowing to individually customize the calendar per page.
 -   pat tooltip: Use tippy v6 based implementation.
 -   Allow overriding the public path from outside via the definition of a ``window.__patternslib_public_path__`` global variable.
+-   Introduce new ``core/dom`` module for DOM manipulation and traversing.
+    ``core/dom`` includes methods which help transition from jQuery to the JavaScript DOM API.
 
 ### Technical
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -68,6 +68,7 @@
 -   pat depends, pat auto suggest: Fix a problem with initialization of ``pat-auto-suggest`` which occurred after the lazy loading changes.
 -   pat checklist: Also dispatch standard ``change`` event when de/selecting all items.
 -   pat select: Add missing ``<span>`` element around the select element itself. Fixes: https://github.com/quaive/ploneintranet.prototype/issues/1087
+-   pat depends/core utils: Do not set inline styles when showing elements in transition mode ``none``. Fixes #719.
 
 
 ## 3.0.0-dev - unreleased

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,7 @@
 -   pat calendar: Fix language loading error "Error: Cannot find module './en.js'"
 -   pat depends, pat auto suggest: Fix a problem with initialization of ``pat-auto-suggest`` which occurred after the lazy loading changes.
 -   pat checklist: Also dispatch standard ``change`` event when de/selecting all items.
+-   pat select: Add missing ``<span>`` element around the select element itself. Fixes: https://github.com/quaive/ploneintranet.prototype/issues/1087
 
 
 ## 3.0.0-dev - unreleased

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 -   Allow overriding the public path from outside via the definition of a ``window.__patternslib_public_path__`` global variable.
 -   Introduce new ``core/dom`` module for DOM manipulation and traversing.
     ``core/dom`` includes methods which help transition from jQuery to the JavaScript DOM API.
+-   core dom: Add ``jqToNode`` to return a DOM node if a jQuery node was passed.
 
 ### Technical
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@
     ``core/dom`` includes methods which help transition from jQuery to the JavaScript DOM API.
 -   core dom: Add ``jqToNode`` to return a DOM node if a jQuery node was passed.
 -   core dom: Add ``querySelectorAllAndMe`` to do a querySelectorAll including the starter element.
+-   core dom: Add ``wrap`` wrap an element with a wrapper element.
 
 ### Technical
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 -   Introduce new ``core/dom`` module for DOM manipulation and traversing.
     ``core/dom`` includes methods which help transition from jQuery to the JavaScript DOM API.
 -   core dom: Add ``jqToNode`` to return a DOM node if a jQuery node was passed.
+-   core dom: Add ``querySelectorAllAndMe`` to do a querySelectorAll including the starter element.
 
 ### Technical
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@
 -   core dom: Add ``jqToNode`` to return a DOM node if a jQuery node was passed.
 -   core dom: Add ``querySelectorAllAndMe`` to do a querySelectorAll including the starter element.
 -   core dom: Add ``wrap`` wrap an element with a wrapper element.
+-   core dom: Add ``hide`` and ``show`` for DOM elements which retain the original display value.
 
 ### Technical
 

--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -1,5 +1,15 @@
 /* Utilities for DOM traversal or navigation */
 
-const dom = {};
+const jqToNode = (el) => {
+    // Return a DOM node if a jQuery node was passed.
+    if (el.jquery) {
+        el = el[0];
+    }
+    return el;
+};
+
+const dom = {
+    jqToNode: jqToNode,
+};
 
 export default dom;

--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -21,9 +21,20 @@ const querySelectorAllAndMe = (el, selector) => {
     return all;
 };
 
+const wrap = (el, wrapper) => {
+    // Wrap a element with a wrapper element.
+    // See: https://stackoverflow.com/a/13169465/1337474
+    el = jqToNode(el); // Ensure real DOM node.
+    wrapper = jqToNode(wrapper); // Ensure real DOM node.
+
+    el.parentNode.insertBefore(wrapper, el);
+    wrapper.appendChild(el);
+};
+
 const dom = {
     jqToNode: jqToNode,
     querySelectorAllAndMe: querySelectorAllAndMe,
+    wrap: wrap,
 };
 
 export default dom;

--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -8,8 +8,22 @@ const jqToNode = (el) => {
     return el;
 };
 
+const querySelectorAllAndMe = (el, selector) => {
+    // Like querySelectorAll but including the element where it starts from.
+    // Returns an Array, not a NodeList
+
+    el = jqToNode(el); // Ensure real DOM node.
+
+    const all = [...el.querySelectorAll(selector)];
+    if (el.matches(selector)) {
+        all.unshift(el); // start element should be first.
+    }
+    return all;
+};
+
 const dom = {
     jqToNode: jqToNode,
+    querySelectorAllAndMe: querySelectorAllAndMe,
 };
 
 export default dom;

--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -1,5 +1,7 @@
 /* Utilities for DOM traversal or navigation */
 
+const DATA_STYLE_DISPLAY = "__patternslib__style__display";
+
 const jqToNode = (el) => {
     // Return a DOM node if a jQuery node was passed.
     if (el.jquery) {
@@ -31,10 +33,34 @@ const wrap = (el, wrapper) => {
     wrapper.appendChild(el);
 };
 
+const hide = (el) => {
+    // Hides the element with ``display: none``
+    el = jqToNode(el); // Ensure real DOM node.
+    if (el.style.display === "none") {
+        // Nothing to do.
+        return;
+    }
+    if (el.style.display) {
+        el[DATA_STYLE_DISPLAY] = el.style.display;
+    }
+    el.style.display = "none";
+};
+
+const show = (el) => {
+    // Shows element by removing ``display: none`` and restoring the display
+    // value to whatever it was before.
+    el = jqToNode(el); // Ensure real DOM node.
+    const val = el[DATA_STYLE_DISPLAY] || null;
+    el.style.display = val;
+    delete el[DATA_STYLE_DISPLAY];
+};
+
 const dom = {
     jqToNode: jqToNode,
     querySelectorAllAndMe: querySelectorAllAndMe,
     wrap: wrap,
+    hide: hide,
+    show: show,
 };
 
 export default dom;

--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -1,0 +1,5 @@
+/* Utilities for DOM traversal or navigation */
+
+const dom = {};
+
+export default dom;

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -1,5 +1,18 @@
+import $ from "jquery";
 import dom from "./dom";
 
 describe("core.dom tests", () => {
     // Tests from the core.dom module
+
+    describe("jqToNode tests", () => {
+        it("always returns a bare DOM node no matter if a jQuery or bare DOM node was passed.", (done) => {
+            const el = document.createElement("div");
+            const $el = $(el);
+
+            expect(dom.jqToNode($el)).toBe(el);
+            expect(dom.jqToNode(el)).toBe(el);
+
+            done();
+        });
+    });
 });

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -42,4 +42,20 @@ describe("core.dom tests", () => {
             done();
         });
     });
+
+    describe("wrap tests", () => {
+        it("wraps an element within another element.", (done) => {
+            const parent = document.createElement("main");
+            const el = document.createElement("div");
+            const wrapper = document.createElement("section");
+            parent.appendChild(el);
+
+            dom.wrap(el, wrapper);
+            expect(parent.outerHTML).toBe(
+                `<main><section><div></div></section></main>`
+            );
+
+            done();
+        });
+    });
 });

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -15,4 +15,31 @@ describe("core.dom tests", () => {
             done();
         });
     });
+
+    describe("querySelectorAllAndMe tests", () => {
+        it("return also starting node if query matches.", (done) => {
+            const el = document.createElement("div");
+            el.setAttribute("class", "node1");
+            el.innerHTML = `<span class="node2">hello.</span>`;
+
+            const res1 = dom.querySelectorAllAndMe(el, ".node1");
+            expect(res1.length).toBe(1);
+            expect(res1[0].outerHTML).toBe(
+                `<div class="node1"><span class="node2">hello.</span></div>`
+            );
+
+            const res2 = dom.querySelectorAllAndMe(el, ".node2");
+            expect(res2.length).toBe(1);
+            expect(res2[0].outerHTML).toBe(`<span class="node2">hello.</span>`);
+
+            const res3 = dom.querySelectorAllAndMe(el, "div, span");
+            expect(res3.length).toBe(2);
+            expect(res3[0].outerHTML).toBe(
+                `<div class="node1"><span class="node2">hello.</span></div>`
+            );
+            expect(res3[1].outerHTML).toBe(`<span class="node2">hello.</span>`);
+
+            done();
+        });
+    });
 });

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -1,0 +1,5 @@
+import dom from "./dom";
+
+describe("core.dom tests", () => {
+    // Tests from the core.dom module
+});

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -58,4 +58,51 @@ describe("core.dom tests", () => {
             done();
         });
     });
+
+    describe("show/hide tests", () => {
+        it("shows or hides and does keeps the CSS display rule value.", (done) => {
+            const el = document.createElement("div");
+            el.style.borderTop = "2em";
+            el.style.marginTop = "4em";
+
+            dom.hide(el);
+
+            expect(el.style.borderTop).toBe("2em");
+            expect(el.style.marginTop).toBe("4em");
+            expect(el.style.display).toBe("none");
+            expect(
+                el.getAttribute("style").indexOf("display") >= -1
+            ).toBeTruthy();
+
+            dom.show(el);
+
+            expect(el.style.borderTop).toBe("2em");
+            expect(el.style.marginTop).toBe("4em");
+            expect(el.style.display).toBeFalsy();
+            expect(
+                el.getAttribute("style").indexOf("display") === -1
+            ).toBeTruthy();
+
+            el.style.display = "inline";
+            dom.hide(el);
+
+            expect(el.style.borderTop).toBe("2em");
+            expect(el.style.marginTop).toBe("4em");
+            expect(el.style.display).toBe("none");
+            expect(
+                el.getAttribute("style").indexOf("display") >= -1
+            ).toBeTruthy();
+
+            dom.show(el);
+
+            expect(el.style.borderTop).toBe("2em");
+            expect(el.style.marginTop).toBe("4em");
+            expect(el.style.display).toBe("inline");
+            expect(
+                el.getAttribute("style").indexOf("display") >= -1
+            ).toBeTruthy();
+
+            done();
+        });
+    });
 });

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -321,7 +321,7 @@ const hideOrShow = (el, visible, options, pattern_name) => {
         });
     } else {
         if (options.transition !== "css") {
-            $el[visible ? "show" : "hide"]();
+            dom[visible ? "show" : "hide"](el);
         }
         on_complete();
     }

--- a/src/core/utils.test.js
+++ b/src/core/utils.test.js
@@ -427,6 +427,43 @@ describe("hideOrShow", function () {
             "hidden",
         ]);
     });
+
+    it("transition none does not mess up styles", (done) => {
+        const el = document.createElement("div");
+        el.style.borderTop = "2em";
+        el.style.marginTop = "4em";
+
+        utils.hideOrShow(el, false, { transition: "none" }, "noname");
+
+        expect(el.style.borderTop).toBe("2em");
+        expect(el.style.marginTop).toBe("4em");
+        expect(el.style.display).toBe("none");
+        expect(el.getAttribute("style").indexOf("display") >= -1).toBeTruthy();
+
+        utils.hideOrShow(el, true, { transition: "none" }, "noname");
+
+        expect(el.style.borderTop).toBe("2em");
+        expect(el.style.marginTop).toBe("4em");
+        expect(el.style.display).toBeFalsy();
+        expect(el.getAttribute("style").indexOf("display") === -1).toBeTruthy();
+
+        el.style.display = "inline";
+        utils.hideOrShow(el, false, { transition: "none" }, "noname");
+
+        expect(el.style.borderTop).toBe("2em");
+        expect(el.style.marginTop).toBe("4em");
+        expect(el.style.display).toBe("none");
+        expect(el.getAttribute("style").indexOf("display") >= -1).toBeTruthy();
+
+        utils.hideOrShow(el, true, { transition: "none" }, "noname");
+
+        expect(el.style.borderTop).toBe("2em");
+        expect(el.style.marginTop).toBe("4em");
+        expect(el.style.display).toBe("inline");
+        expect(el.getAttribute("style").indexOf("display") >= -1).toBeTruthy();
+
+        done();
+    });
 });
 
 describe("hasValue", function () {

--- a/src/pat/depends/index.html
+++ b/src/pat/depends/index.html
@@ -21,19 +21,19 @@
                     <legend>Flavour</legend>
 
                     <label
-                        ><input type="radio" name="flavour" value="margherita" />
+                        ><input type="radio" name="flavour" value="margherita" autocomplete="off" />
                         Margherita</label
                     >
                     <label
-                        ><input type="radio" name="flavour" value="hawaii" />
+                        ><input type="radio" name="flavour" value="hawaii" autocomplete="off" />
                         Hawaii</label
                     >
                     <label
-                        ><input type="radio" name="flavour" value="bacon" />
+                        ><input type="radio" name="flavour" value="bacon" autocomplete="off" checked />
                         Bacon Supreme</label
                     >
                     <label
-                        ><input type="radio" name="flavour" value="sea" />
+                        ><input type="radio" name="flavour" value="sea" autocomplete="off" />
                         Fruits de mer</label
                     >
                 </fieldset>
@@ -55,7 +55,7 @@
                 <fieldset class="group pat-checklist">
                     <legend>Add extra toppings</legend>
                     <label>
-                        <input type="checkbox" name="custom" /> Add extra
+                        <input type="checkbox" name="custom" autocomplete="off" /> Add extra
                         toppings
                     </label>
                 </fieldset>
@@ -68,18 +68,18 @@
                     <label
                         class="pat-depends"
                         data-pat-depends="flavour!=hawaii"
-                        ><input type="checkbox" name="pineapple" />
+                        ><input type="checkbox" name="pineapple" autocomplete="off"/>
                         Pineapple</label
                     >
                     <label
-                        ><input type="checkbox" name="gorgonzola" />
+                        ><input type="checkbox" name="gorgonzola" autocomplete="off" />
                         Gorgonzola</label
                     >
                     <label
-                        ><input type="checkbox" name="peanuts" /> Peanuts</label
+                        ><input type="checkbox" name="peanuts" autocomplete="off" /> Peanuts</label
                     >
                     <label
-                        ><input type="checkbox" name="redonion" /> Red
+                        ><input type="checkbox" name="redonion" autocomplete="off" /> Red
                         onions</label
                     >
                 </fieldset>

--- a/src/pat/selectbox/documentation.md
+++ b/src/pat/selectbox/documentation.md
@@ -1,0 +1,5 @@
+## Description
+
+the __selectbox__ pattern adds ``data-option`` and ``data-option-value`` attributes on the parent element.
+If the parent element is not a ``<label>`` it wrapts itself within a ``<span>`` element.
+

--- a/src/pat/selectbox/index.html
+++ b/src/pat/selectbox/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>Selectbox demo</title>
+        <script
+            src="/dist/bundle.js"
+            type="text/javascript"
+            charset="utf-8"
+        ></script>
+    </head>
+    <body>
+
+      <form>
+        <select class="pat-select">
+          <option value="true" selected>Bevat</option>
+          <option value="false">Bevat niet</option>
+        </select>
+
+        <br />
+
+        <label>
+        <select class="pat-select">
+          <option value="okay" selected>okay</option>
+          <option value="nicht okay">nicht okay</option>
+        </select>
+        </label>
+
+        <br />
+
+        <label class="pat-select">
+          <select>
+            <option value="ja" selected>ja.</option>
+            <option value="nein">nein.</option>
+          </select>
+        </label>
+
+        <br />
+
+        <input type="reset"/>
+      </form>
+
+    </body>
+</html>

--- a/src/pat/selectbox/selectbox.js
+++ b/src/pat/selectbox/selectbox.js
@@ -18,7 +18,10 @@ export default Base.extend({
             el[KEY_RESET] = true;
         }
 
-        this.all_selects = el.querySelectorAll("select:not([multiple])");
+        this.all_selects = dom.querySelectorAllAndMe(
+            el,
+            "select:not([multiple])"
+        );
         for (const sel of this.all_selects) {
             // create parent span if not direct child of a label
             if (!sel.parentNode.matches("label")) {

--- a/src/pat/selectbox/selectbox.test.js
+++ b/src/pat/selectbox/selectbox.test.js
@@ -1,0 +1,85 @@
+import Pattern from "./selectbox";
+import registry from "../../core/registry";
+import utils from "../../core/utils";
+
+describe("pat selectbox tests", () => {
+    // Tests from the core.dom module
+
+    it("works as indented.", async (done) => {
+        const el = document.createElement("div");
+        el.innerHTML = `
+          <form>
+            <select class="pat-select sel1">
+              <option value="a" selected>A</option>
+              <option value="b">B</option>
+            </select>
+
+            <label>
+            <select class="pat-select sel2">
+              <option value="c" selected>C</option>
+              <option value="d">D</option>
+            </select>
+            </label>
+
+            <label class="pat-select">
+              <select class="sel3">
+                <option value="e" selected>E</option>
+                <option value="f">F</option>
+              </select>
+            </label>
+
+            <input type="reset"/>
+          </form>
+        `;
+
+        registry.scan(el);
+
+        const sel1 = el.querySelector(".sel1");
+        const sel2 = el.querySelector(".sel2");
+        const sel3 = el.querySelector(".sel3");
+
+        expect(sel1.parentNode.tagName).toBe("SPAN");
+        expect(sel2.parentNode.tagName).toBe("LABEL");
+        expect(sel3.parentNode.tagName).toBe("LABEL");
+
+        expect(sel1.parentNode.getAttribute("data-option")).toBe("A");
+        expect(sel1.parentNode.getAttribute("data-option-value")).toBe("a");
+
+        expect(sel2.parentNode.getAttribute("data-option")).toBe("C");
+        expect(sel2.parentNode.getAttribute("data-option-value")).toBe("c");
+
+        expect(sel3.parentNode.getAttribute("data-option")).toBe("E");
+        expect(sel3.parentNode.getAttribute("data-option-value")).toBe("e");
+
+        sel1.options["1"].selected = true;
+        sel1.dispatchEvent(new Event("change"));
+        sel2.options["1"].selected = true;
+        sel2.dispatchEvent(new Event("change"));
+        sel3.options["1"].selected = true;
+        sel3.dispatchEvent(new Event("change"));
+
+        expect(sel1.parentNode.getAttribute("data-option")).toBe("B");
+        expect(sel1.parentNode.getAttribute("data-option-value")).toBe("b");
+
+        expect(sel2.parentNode.getAttribute("data-option")).toBe("D");
+        expect(sel2.parentNode.getAttribute("data-option-value")).toBe("d");
+
+        expect(sel3.parentNode.getAttribute("data-option")).toBe("F");
+        expect(sel3.parentNode.getAttribute("data-option-value")).toBe("f");
+
+        const form = el.querySelector("form");
+        form.reset();
+        await utils.timeout(200); // wait for (timeout in pattern)*3 + a bit
+
+        expect(sel1.parentNode.getAttribute("data-option")).toBe("A");
+        expect(sel1.parentNode.getAttribute("data-option-value")).toBe("a");
+
+        expect(sel2.parentNode.getAttribute("data-option")).toBe("C");
+        expect(sel2.parentNode.getAttribute("data-option-value")).toBe("c");
+
+        expect(sel3.parentNode.getAttribute("data-option")).toBe("E");
+        expect(sel3.parentNode.getAttribute("data-option-value")).toBe("e");
+
+        done();
+    });
+});


### PR DESCRIPTION
- pat select: Add missing ``<span>`` element around the select element itself. Fixes: https://github.com/quaive/ploneintranet.prototype/issues/1087

- pat depends: Do not set inline styles when showing elements in transition mode ``none``. Fixes #719.
