### PR TITLE
Tooltip fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 -   pat calendar: Store view, date and active categories per URL, allowing to individually customize the calendar per page.
 -   pat tooltip: Use tippy v6 based implementation.
 -   pat tooltip: Introduce new option ``arrowPadding`` to define the padding of the box arrow from the corners of the tooltip.
+-   pat tooltip: set content when mounting to avoid positioning problems.
 -   Allow overriding the public path from outside via the definition of a ``window.__patternslib_public_path__`` global variable.
 -   Introduce new ``core/dom`` module for DOM manipulation and traversing.
     ``core/dom`` includes methods which help transition from jQuery to the JavaScript DOM API.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@
 -   pat calendar: Support injection of events when clicking on and event rather than redirecting to them.
 -   pat calendar: Store view, date and active categories per URL, allowing to individually customize the calendar per page.
 -   pat tooltip: Use tippy v6 based implementation.
+-   pat tooltip: Introduce new option ``arrowPadding`` to define the padding of the box arrow from the corners of the tooltip.
 -   Allow overriding the public path from outside via the definition of a ``window.__patternslib_public_path__`` global variable.
 -   Introduce new ``core/dom`` module for DOM manipulation and traversing.
     ``core/dom`` includes methods which help transition from jQuery to the JavaScript DOM API.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "slides": "git+https://github.com/Patternslib/slides.git",
     "spectrum-colorpicker": "^1.8.0",
     "stickyfilljs": "git+https://github.com/syslabcom/stickyfill.git",
-    "tippy.js": "^6.2.6",
+    "tippy.js": "^6.2.7",
     "underscore": "^1.11.0",
     "url-polyfill": "^1.1.9",
     "validate.js": "^0.13.1",

--- a/src/pat/tooltip/index.html
+++ b/src/pat/tooltip/index.html
@@ -83,6 +83,17 @@
                     >click here</a
                 >.
             </p>
+            <h4>arrow padding</h4>
+            <p>
+                <code>arrow-padding: 60</code>. The tooltip arrow gets a padding from the edges of 60 pixel.
+                <a
+                    href="#"
+                    title="well done!"
+                    class="pat-tooltip"
+                    data-pat-tooltip="arrow-padding: 60"
+                    >element</a
+                >.
+            </p>
             <h4>delay</h4>
             <p>
                 <code>delay: 1000</code>. A tooltip is displayed with a delay of
@@ -531,5 +542,11 @@
                 </ul>
             </div>
         </div>
+
+        <script charset="utf-8">
+          for (const it of document.querySelectorAll("a")) {
+            it.addEventListener("click", e => e.preventDefault());
+          }
+        </script>
     </body>
 </html>

--- a/src/pat/tooltip/tooltip.js
+++ b/src/pat/tooltip/tooltip.js
@@ -235,7 +235,13 @@ export default Base.extend({
         registry.scan(this.tippy.popper);
     },
 
-    _onMount() {
+    async _onMount() {
+        if (this.options.source === "ajax") {
+            await this._getContent();
+        }
+
+        this._initializeContent();
+
         // Notify parent patterns about injected content.
         // Do not call pat-inject's handler, because all necessary
         // initialization after injection is done here.
@@ -246,17 +252,13 @@ export default Base.extend({
         ]);
     },
 
-    async _onShow() {
+    _onShow() {
         if (
             this.options.closing !== "auto" &&
             this.options.trigger === "hover"
         ) {
             // no auto-close when hovering when closing mode is "sticky" or "close-button".
             this.tippy.setProps({ trigger: "click" });
-        }
-
-        if (this.options.source === "ajax") {
-            await this._getContent();
         }
 
         if (this.options.closing === "close-button") {
@@ -282,8 +284,6 @@ export default Base.extend({
 
         // Add a generic non-tippy related class to identify the tooltip container
         this.tippy.popper.classList.add("tooltip-container");
-
-        this._initializeContent();
     },
 
     _onHide() {

--- a/src/pat/tooltip/tooltip.js
+++ b/src/pat/tooltip/tooltip.js
@@ -36,6 +36,7 @@ parser.addArgument("delay");
 parser.addArgument("mark-inactive", true);
 parser.addArgument("class");
 parser.addArgument("target", "body");
+parser.addArgument("arrow-padding", null);
 
 export default Base.extend({
     name: "tooltip",
@@ -120,7 +121,16 @@ export default Base.extend({
             return `${primary(pos[0])}${secondary(pos[1])}`;
         };
 
-        const tippy_options = {};
+        const tippy_options = { popperOptions: { modifiers: [] } };
+
+        if (opts.arrowPadding !== null) {
+            tippy_options.popperOptions.modifiers.push({
+                name: "arrow",
+                options: {
+                    padding: parseInt(opts.arrowPadding, 10),
+                },
+            });
+        }
 
         const parsers = {
             position: () => {
@@ -129,33 +139,21 @@ export default Base.extend({
                 }
                 tippy_options.placement = placement(opts.position.list[0]); // main position
 
-                if (opts.position.policy !== "force") {
-                    tippy_options.popperOptions = {
-                        modifiers: [
-                            {
-                                name: "flip",
-                                enabled: true,
-                            },
-                        ],
-                    };
-                    if (opts.position.length > 1) {
-                        const fallbacks = opts.position.list
-                            .slice(1)
-                            .map(placement);
-                        tippy_options.popperOptions.modifiers[0].options = {
-                            fallbackPlacements: fallbacks,
-                        };
-                    }
-                } else {
-                    tippy_options.popperOptions = {
-                        modifiers: [
-                            {
-                                name: "flip",
-                                enabled: false,
-                            },
-                        ],
-                    };
+                const flip_options = {
+                    name: "flip",
+                    enabled: true,
+                };
+
+                if (opts.position.policy === "force") {
+                    flip_options.enabled = false;
+                } else if (opts.position.length > 1) {
+                    const fallbacks = opts.position.list
+                        .slice(1)
+                        .map(placement);
+                    flip_options.fallbackPlacements = fallbacks;
                 }
+
+                tippy_options.popperOptions.modifiers.push(flip_options);
             },
 
             trigger() {
@@ -341,6 +339,7 @@ export default Base.extend({
         }
         if (content) {
             this.tippy.setContent(content);
+            this.tippy.popperInstance.forceUpdate(); // re-position tippy after content is known.
         }
     },
 

--- a/src/pat/tooltip/tooltip.test.js
+++ b/src/pat/tooltip/tooltip.test.js
@@ -1056,7 +1056,7 @@ describe("pat-tooltip", () => {
     });
 
     describe(`if the 'source' parameter is 'ajax'`, () => {
-        it("the default click action is prevented", async (done) => {
+        it("multiple clicks only fetches once AND the default click action is prevented", async (done) => {
             global.fetch = jest.fn().mockImplementation(mockFetch());
 
             const $el = testutils.createTooltip({
@@ -1078,12 +1078,14 @@ describe("pat-tooltip", () => {
             );
 
             $el[0].dispatchEvent(click);
+            await utils.timeout(1); // wait a tick for async fetch
             $el[0].dispatchEvent(click);
+            await utils.timeout(1); // wait a tick for async fetch
             $el[0].dispatchEvent(click);
+            await utils.timeout(1); // wait a tick for async fetch
 
-            //expect(spy_ajax).toHaveBeenCalledBefore(spy_prevented);
-            expect(call_order.indexOf("_getContent")).toEqual(0);
-            expect(call_order.includes("preventDefault")).toBeTruthy();
+            expect(call_order.filter(it => it === "_getContent").length).toEqual(1); // prettier-ignore
+            expect(call_order.filter(it => it === "preventDefault").length).toEqual(3); // prettier-ignore
 
             global.fetch.mockClear();
             delete global.fetch;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7701,10 +7701,10 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tippy.js@^6.2.6:
-  version "6.2.6"
-  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.2.6.tgz#4991bbe8f75e741fb92b5ccfeebcd072d71f8345"
-  integrity sha512-0tTL3WQNT0nWmpslhDryRahoBm6PT9fh1xXyDfOsvZpDzq52by2rF2nvsW0WX2j9nUZP/jSGDqfKJGjCtoGFKg==
+tippy.js@^6.2.7:
+  version "6.2.7"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.2.7.tgz#62fb34eda23f7d78151ddca922b62818c1ab9869"
+  integrity sha512-k+kWF9AJz5xLQHBi3K/XlmJiyu+p9gsCyc5qZhxxGaJWIW8SMjw1R+C7saUnP33IM8gUhDA2xX//ejRSwqR0tA==
   dependencies:
     "@popperjs/core" "^2.4.4"
 


### PR DESCRIPTION
Ref: https://jira.syslab.com/browse/SCR-660

1)  Introduce new option ``arrow-padding`` to define the padding of the box arrow from the corners of the tooltip.

2) Set content when mounting to avoid positioning problems.

@cornae the second point should fix the problem with the misplaced tooltip when opening the personal menu.

Regarding mentions tooltips in the activities stream comments box, which reaches far below the fold: I want to re-mention the already discussed fix, because I think this one would make the situation better than it is without me adding any functionality.
If we set the following in CSS (or something similar):
```
.tippy-box .tippy-content {
    max-height: calc(50vh - 50px);
    min-height: 20em;
}
```
We get this result:
![Screenshot from 2020-11-05 21-42-40](https://user-images.githubusercontent.com/170891/98295038-30015c00-1fb1-11eb-90df-203a77058740.png)

You can even restrict it to specific tooltips if, for example, the tags should open bigger: ```.tags .tippy-box .tippy-content { ...```

Of restrict it for specific screen sizes with media queries.

There is still the option of calculating the max-height based on the scroll position but I doubt that this would give us much better results.