### PR TITLE
Scr 661 fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,7 +47,7 @@
 -   core dom: Add ``hide`` and ``show`` for DOM elements which retain the original display value.
 -   pat date picker: Support updating a date if it is before another dependent date.
 -   pat tabs: Refactor based on ``ResizeObserver`` and fix problems calculating the with with transitions.
--   pat tabs: When clicking on the ``extra-tabs`` element, toggle between ``opened`` and ``closed`` classes to allow opening/closing an extra-tabs menu via CSS.
+-   pat tabs: When clicking on the ``extra-tabs`` element, toggle between ``open`` and ``closed`` classes to allow opening/closing an extra-tabs menu via CSS.
 
 ### Technical
 

--- a/src/pat/tabs/tabs.js
+++ b/src/pat/tabs/tabs.js
@@ -9,15 +9,15 @@ export default Base.extend({
     skip_adjust: false, // do not run into an resize/adjust loop
 
     init() {
-        this.adjust_tabs();
-        const resize_callback = utils.debounce(() => this.adjust_tabs(), 100);
+        const debounced_resize = utils.debounce(() => this.adjust_tabs(), 50);
         const resize_observer = new ResizeObserver(() => {
             if (!this.skip_adjust) {
-                resize_callback();
+                debounced_resize();
             }
             this.skip_adjust = false;
         });
         resize_observer.observe(this.el);
+        debounced_resize();
     },
 
     adjust_tabs() {

--- a/src/pat/tabs/tabs.js
+++ b/src/pat/tabs/tabs.js
@@ -56,15 +56,16 @@ export default Base.extend({
         }
 
         const extra_el = document.createElement("span");
-        extra_el.setAttribute("class", "extra-tabs closed");
+        extra_el.setAttribute("class", "extra-tabs");
+        this.el.classList.add("closed");
         extra_el.addEventListener("click", () => {
             // Toggle opened/closed class on extra-tabs
-            if (extra_el.classList.contains("opened")) {
-                extra_el.classList.remove("opened");
-                extra_el.classList.add("closed");
+            if (this.el.classList.contains("open")) {
+                this.el.classList.remove("open");
+                this.el.classList.add("closed");
             } else {
-                extra_el.classList.remove("closed");
-                extra_el.classList.add("opened");
+                this.el.classList.remove("closed");
+                this.el.classList.add("open");
             }
         });
         this.el.append(extra_el);

--- a/src/pat/tabs/tabs.test.js
+++ b/src/pat/tabs/tabs.test.js
@@ -1,4 +1,5 @@
 import pattern from "./tabs";
+import utils from "../../core/utils";
 
 describe("pat-tabs", function () {
     beforeEach(function () {
@@ -10,7 +11,7 @@ describe("pat-tabs", function () {
         document.body.innerHTML = "";
     });
 
-    it("When the size of all the tabs cannot fit in the pat-tabs div some tabs will be placed in the extra-tabs span, which is a child of the pat-tabs element", (done) => {
+    it("When the size of all the tabs cannot fit in the pat-tabs div some tabs will be placed in the extra-tabs span, which is a child of the pat-tabs element", async (done) => {
         const container = document.querySelector("#lab");
         container.innerHTML = `
             <nav class="navigation tabs pat-tabs" style="width:400px;">
@@ -22,12 +23,13 @@ describe("pat-tabs", function () {
         `;
         const tabs = document.querySelector(".pat-tabs");
         pattern.init(tabs);
+        await utils.timeout(100);
         expect(tabs.querySelectorAll(".extra-tabs").length).toBeTruthy();
 
         done();
     });
 
-    it("When the size of all the tabs (padding included) cannot fit in the pat-tabs div some tabs will be placed in the extra-tabs span, which is a child of the pat-tabs element", (done) => {
+    it("When the size of all the tabs (padding included) cannot fit in the pat-tabs div some tabs will be placed in the extra-tabs span, which is a child of the pat-tabs element", async (done) => {
         const container = document.querySelector("#lab");
         container.innerHTML = `
             <nav class="navigation tabs pat-tabs" style="width:440px;">
@@ -40,12 +42,13 @@ describe("pat-tabs", function () {
 
         const tabs = document.querySelector(".pat-tabs");
         pattern.init(tabs);
+        await utils.timeout(100);
         expect(tabs.querySelectorAll(".extra-tabs").length).toBeTruthy();
 
         done();
     });
 
-    it("When the size of all the tabs can fit in the pat-tabs div the extra-tabs span will not exist as a child of the pat-tabs element", (done) => {
+    it("When the size of all the tabs can fit in the pat-tabs div the extra-tabs span will not exist as a child of the pat-tabs element", async (done) => {
         // XXX: Somehow the browsers doesn't behave so nicely, elements
         // wrap around even though according to our calculations they
         // don't have to. So we now check for 5% less than the
@@ -62,12 +65,13 @@ describe("pat-tabs", function () {
 
         const tabs = document.querySelector(".pat-tabs");
         pattern.init(tabs);
+        await utils.timeout(100);
         expect(tabs.querySelectorAll(".extra-tabs").length).toBeFalsy();
 
         done();
     });
 
-    it("When the size of all the tabs (padding included) can fit in the pat-tabs div the extra-tabs span will not exist as a child of the pat-tabs element", (done) => {
+    it("When the size of all the tabs (padding included) can fit in the pat-tabs div the extra-tabs span will not exist as a child of the pat-tabs element", async (done) => {
         // XXX: Somehow the browsers doesn't behave so nicely, elements
         // wrap around even though according to our calculations they
         // don't have to. So we now check for 5% less than the
@@ -84,12 +88,13 @@ describe("pat-tabs", function () {
 
         const tabs = document.querySelector(".pat-tabs");
         pattern.init(tabs);
+        await utils.timeout(100);
         expect(tabs.querySelectorAll(".extra-tabs").length).toBeFalsy();
 
         done();
     });
 
-    it("Clicking on extra-tabs toggles the ``open`` and ``closed`` classes.", (done) => {
+    it("Clicking on extra-tabs toggles the ``open`` and ``closed`` classes.", async (done) => {
         const container = document.querySelector("#lab");
         container.innerHTML = `
             <nav class="navigation tabs pat-tabs" style="width:120px;">
@@ -99,6 +104,8 @@ describe("pat-tabs", function () {
         `;
         const tabs = document.querySelector(".pat-tabs");
         pattern.init(tabs);
+        await utils.timeout(100);
+
         const extra_tabs = tabs.querySelector(".extra-tabs");
 
         expect(tabs.classList.contains("open")).toBeFalsy();
@@ -115,7 +122,7 @@ describe("pat-tabs", function () {
         done();
     });
 
-    it("If there are no extra-tabs, there is no default ``closed`` class.", (done) => {
+    it("If there are no extra-tabs, there is no default ``closed`` class.", async (done) => {
         const container = document.querySelector("#lab");
         container.innerHTML = `
             <nav class="navigation tabs pat-tabs" style="width:220px;">
@@ -125,6 +132,7 @@ describe("pat-tabs", function () {
         `;
         const tabs = document.querySelector(".pat-tabs");
         pattern.init(tabs);
+        await utils.timeout(100);
 
         const extra_tabs = tabs.querySelector(".extra-tabs");
         expect(extra_tabs).toBeFalsy();

--- a/src/pat/tabs/tabs.test.js
+++ b/src/pat/tabs/tabs.test.js
@@ -89,7 +89,7 @@ describe("pat-tabs", function () {
         done();
     });
 
-    it("Clicking on extra-tabs toggles the ``opened`` and ``closed`` classes.", (done) => {
+    it("Clicking on extra-tabs toggles the ``open`` and ``closed`` classes.", (done) => {
         const container = document.querySelector("#lab");
         container.innerHTML = `
             <nav class="navigation tabs pat-tabs" style="width:120px;">
@@ -100,17 +100,36 @@ describe("pat-tabs", function () {
         const tabs = document.querySelector(".pat-tabs");
         pattern.init(tabs);
         const extra_tabs = tabs.querySelector(".extra-tabs");
-        expect(extra_tabs).toBeTruthy();
-        expect(extra_tabs.classList.contains("opened")).toBeFalsy();
-        expect(extra_tabs.classList.contains("closed")).toBeTruthy();
+
+        expect(tabs.classList.contains("open")).toBeFalsy();
+        expect(tabs.classList.contains("closed")).toBeTruthy();
 
         extra_tabs.click();
-        expect(extra_tabs.classList.contains("opened")).toBeTruthy();
-        expect(extra_tabs.classList.contains("closed")).toBeFalsy();
+        expect(tabs.classList.contains("open")).toBeTruthy();
+        expect(tabs.classList.contains("closed")).toBeFalsy();
 
         extra_tabs.click();
-        expect(extra_tabs.classList.contains("opened")).toBeFalsy();
-        expect(extra_tabs.classList.contains("closed")).toBeTruthy();
+        expect(tabs.classList.contains("open")).toBeFalsy();
+        expect(tabs.classList.contains("closed")).toBeTruthy();
+
+        done();
+    });
+
+    it("If there are no extra-tabs, there is no default ``closed`` class.", (done) => {
+        const container = document.querySelector("#lab");
+        container.innerHTML = `
+            <nav class="navigation tabs pat-tabs" style="width:220px;">
+                <a href="" style="width:100px; display:block;">General</a>
+                <a href="" style="width:100px; display:block;">Members</a>
+            </nav>
+        `;
+        const tabs = document.querySelector(".pat-tabs");
+        pattern.init(tabs);
+
+        const extra_tabs = tabs.querySelector(".extra-tabs");
+        expect(extra_tabs).toBeFalsy();
+
+        expect(tabs.classList.contains("closed")).toBeFalsy();
 
         done();
     });

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -28,6 +28,12 @@ document.fullscreenerror = jest.fn();
 // See https://github.com/jsdom/jsdom/issues/1937#issuecomment-461810980
 window.HTMLFormElement.prototype.submit = () => {};
 
+// resize-observer
+window.ResizeObserver = function () {
+    // Just do nothing for now...
+    return { observe: () => {} };
+};
+
 // Do not output error messages
 import logging from "./core/logging";
 logging.setLevel(50); // level: FATAL


### PR DESCRIPTION
1) Fix classname to "open" and attach it to the ``pat-tabs`` element instead of ``extra-tabs``.

2) Fix to debounce initial tabs adjustment and place it after initialization of the ResizeObserver. This fixes wrong size calculation when pattern is initialized but layout not settled.

Refs:
https://jira.syslab.com/browse/SCR-661
https://github.com/Patternslib/Patterns/issues/752
https://github.com/Patternslib/Patterns/issues/751
https://github.com/quaive/ploneintranet.prototype/issues/1111
https://github.com/quaive/ploneintranet.prototype/issues/1112
