### PR TITLE
Fix autosuggest autosubmit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,8 @@
 -   pat select: Add missing ``<span>`` element around the select element itself. Fixes: https://github.com/quaive/ploneintranet.prototype/issues/1087
 -   pat depends/core utils: Do not set inline styles when showing elements in transition mode ``none``. Fixes #719.
 -   pat scroll: Fix scrolling offset incorrectly applied. Fixes: #763.
+-   Core registry: Fix ``transformPattern`` to also work with patterns which extend from Base.
+    Fixes a problem with pat-auto-suggest not auto submitting.
 
 
 ## 3.0.0-dev - unreleased

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -73,10 +73,12 @@ var registry = {
             log.debug("Skipping disabled pattern:", name);
             return;
         }
-        var pattern = registry.patterns[name];
-        if (pattern.transform) {
+
+        const pattern = registry.patterns[name];
+        const transform = pattern.transform || pattern.prototype?.transform;
+        if (transform) {
             try {
-                pattern.transform($(content));
+                transform($(content));
             } catch (e) {
                 if (dont_catch) {
                     throw e;

--- a/src/pat/auto-submit/auto-submit.js
+++ b/src/pat/auto-submit/auto-submit.js
@@ -1,12 +1,3 @@
-/**
- * Patterns autosubmit - automatic submission of forms
- *
- * Copyright 2012-2013 Florian Friesdorf
- * Copyright 2012 Simplon B.V. - Wichert Akkerman
- * Copyright 2013 Marko Durkovic
- * Copyright 2014-2015 Syslab.com GmbH - JC Brand
- */
-
 import $ from "jquery";
 import logging from "../../core/logging";
 import Base from "../../core/base";
@@ -14,9 +5,9 @@ import Parser from "../../core/parser";
 import input_change_events from "../../lib/input-change-events";
 import utils from "../../core/utils";
 
-var log = logging.getLogger("autosubmit"),
-    parser = new Parser("autosubmit");
+const log = logging.getLogger("autosubmit");
 
+const parser = new Parser("autosubmit");
 // - 400ms -> 400
 // - 400 -> 400
 // - defocus
@@ -26,8 +17,8 @@ export default Base.extend({
     name: "autosubmit",
     trigger: ".pat-autosubmit, .pat-auto-submit",
     parser: {
-        parse: function ($el, opts) {
-            var cfg = parser.parse($el, opts);
+        parse($el, opts) {
+            const cfg = parser.parse($el, opts);
             if (cfg.delay !== "defocus") {
                 cfg.delay = parseInt(cfg.delay.replace(/[^\d]*/g, ""), 10);
             }
@@ -35,46 +26,44 @@ export default Base.extend({
         },
     },
 
-    init: function () {
-        this.options = this.parser.parse(this.$el, arguments[1]);
+    init() {
+        this.options = this.parser.parse(this.$el, this.options);
         input_change_events.setup(this.$el, "autosubmit");
         this.registerListeners();
         this.registerTriggers();
         return this.$el;
     },
 
-    registerListeners: function () {
+    registerListeners() {
         this.$el.on("input-change-delayed.pat-autosubmit", this.onInputChange);
         this.registerSubformListeners();
         this.$el.on("patterns-injected", this.refreshListeners.bind(this));
     },
 
-    registerSubformListeners: function (ev) {
+    registerSubformListeners(ev) {
         /* If there are subforms, we need to listen on them as well, so
          * that only the subform gets submitted if an element inside it
          * changes.
          */
-        var $el = typeof ev !== "undefined" ? $(ev.target) : this.$el;
+        const $el = typeof ev !== "undefined" ? $(ev.target) : this.$el;
         $el.find(".pat-subform")
             .not(".pat-autosubmit")
-            .each(
-                function (idx, el) {
-                    $(el).on(
-                        "input-change-delayed.pat-autosubmit",
-                        this.onInputChange
-                    );
-                }.bind(this)
-            );
+            .each((idx, el) => {
+                $(el).on(
+                    "input-change-delayed.pat-autosubmit",
+                    this.onInputChange
+                );
+            });
     },
 
-    refreshListeners: function (ev, cfg, el, injected) {
+    refreshListeners(ev, cfg, el, injected) {
         this.registerSubformListeners();
         // Register change event handlers for new inputs injected into this form
         input_change_events.setup($(injected), "autosubmit");
     },
 
-    registerTriggers: function () {
-        var isText = this.$el.is("input:text, input[type=search], textarea");
+    registerTriggers() {
+        const isText = this.$el.is("input:text, input[type=search], textarea");
         if (this.options.delay === "defocus" && !isText) {
             log.error(
                 "The defocus delay value makes only sense on text input elements."
@@ -100,13 +89,13 @@ export default Base.extend({
         }
     },
 
-    destroy: function ($el) {
+    destroy($el) {
         input_change_events.remove($el, "autosubmit");
         if (this.$el.is("form")) {
             this.$el
                 .find(".pat-subform")
                 .addBack(this.$el)
-                .each(function (idx, el) {
+                .each((idx, el) => {
                     $(el).off(".pat-autosubmit");
                 });
         } else {
@@ -114,7 +103,7 @@ export default Base.extend({
         }
     },
 
-    onInputChange: function (ev) {
+    onInputChange(ev) {
         ev.stopPropagation();
         $(this).submit();
         log.debug("triggered by " + ev.type);

--- a/src/pat/auto-submit/index.html
+++ b/src/pat/auto-submit/index.html
@@ -81,6 +81,16 @@
                             name="defocus"
                             data-pat-autosubmit="delay: defocus"
                     /></label>
+
+                    <label>Select a item
+                      <input
+                          name="a1"
+                          class="pat-autosuggest"
+                          placeholder="Pick some fruit"
+                          data-pat-autosuggest="words: Apples, Oranges, Pears, Bananas"
+                          type="text"
+                      />
+                    </label>
                 </fieldset>
             </form>
         </div>

--- a/src/pat/auto-suggest/auto-suggest.test.js
+++ b/src/pat/auto-suggest/auto-suggest.test.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import pattern from "./auto-suggest";
 import utils from "../../core/utils";
+import registry from "../../core/registry";
 
 var testutils = {
     createInputElement: function (c) {
@@ -9,6 +10,7 @@ var testutils = {
             "id": cfg.id || "select2",
             "data-pat-autosuggest": "" || cfg.data,
             "class": "pat-autosuggest",
+            "type": "text",
         }).appendTo($("div#lab"));
     },
 
@@ -52,11 +54,16 @@ describe("pat-autosuggest", function () {
 
             expect($(".select2-container").length).toBe(0);
             expect($el.hasClass("select2-offscreen")).toBeFalsy();
-            pattern.init($el);
+
+            registry.scan(document.body);
             await utils.timeout(1); // wait a tick for async to settle.
+
+            $el = $("input.pat-autosuggest"); // element was replaced - re-get it.
             expect($el.hasClass("select2-offscreen")).toBeTruthy();
             expect($(".select2-container").length).toBe(1);
             testutils.removeSelect2();
+
+            expect($el[0].getAttribute("type")).toBe("hidden");
         });
     });
 


### PR DESCRIPTION
Fix a problem where pat-auto-suggest wasn't auto-submitting content.
That was due to pat-auto-suggest extending the base pattern since ES6 and that didn't invoke the transform method.
Basic fix in: https://github.com/Patternslib/Patterns/commit/99b8fa0c7aecd00d634402c11b34a029c75bbef0

Other commits and simplifications are byproducts of analyzing the problem.