### PR TITLE
pat-tooltip: Remove ::element modifier for references to tooltip content

### DIFF
--- a/src/pat/tooltip/documentation.md
+++ b/src/pat/tooltip/documentation.md
@@ -104,12 +104,6 @@ option:
 This will load the contents of the `#myTip` element of
 balloon-contents.html and display it in a tooltip.
 
-You can also use the `::element` modifier after a document fragment to select
-the element itself instead of it's contents. E.g.:
-
-    <a href="balloon-contents.html#myTip::element" class="pat-tooltip" data-pat-tooltip="source: ajax">
-     …
-    </a>
 
 ### Generated markup
 

--- a/src/pat/tooltip/index.html
+++ b/src/pat/tooltip/index.html
@@ -449,73 +449,11 @@
                     Like
                 </button>
             </form>
-
-            <h4>works with other patterns / pt2</h4>
-            This opens a
-            <a
-                href="#tooltip-source-form::element"
-                class="pat-tooltip"
-                data-pat-tooltip="trigger: click; closing: close-button; source: content"
-                >Tooltip form with other patterns</a
-            >.
         </div>
 
         <div style="display: none">
             <!-- Tooltip content elements -->
             <section id="test-tooltip-w-submit--content">Liked</section>
-            <form id="tooltip-source-form">
-                <fieldset
-                    class="vertical"
-                    data-pat-inject="source: #listing; target: #listing;"
-                >
-                    <fieldset
-                        class="pat-checklist checked has-value"
-                        data-value="on"
-                    >
-                        <label class="checked has-value" data-value="on">
-                            <input
-                                type="checkbox"
-                                name="display-previews"
-                                checked=""
-                                class="has-value"
-                                data-value="on"
-                            />
-                            Display previews
-                        </label>
-                    </fieldset>
-                    <fieldset
-                        class="pat-checklist radio has-value checked"
-                        data-value="relevancy"
-                    >
-                        <label class="has-value checked" data-value="relevancy">
-                            <input
-                                type="radio"
-                                name="results-sorting"
-                                checked=""
-                                value="relevancy"
-                                class="has-value"
-                                data-value="relevancy"
-                            />
-                            Sort by relevancy
-                        </label>
-                        <label class="unchecked">
-                            <input
-                                type="radio"
-                                name="results-sorting"
-                                value="date"
-                            />
-                            Sort by date
-                        </label>
-                    </fieldset>
-                </fieldset>
-                <li>
-                    <a
-                        class="close-panel pat-modal"
-                        href="./pattern-test-response.html#message"
-                        >Open a modal.</a
-                    >
-                </li>
-            </form>
             <div id="tooltip-source" class="sources">
                 <strong>Hello there</strong>
             </div>

--- a/src/pat/tooltip/tooltip.test.js
+++ b/src/pat/tooltip/tooltip.test.js
@@ -1409,150 +1409,23 @@ this will be extracted.
         });
     });
 
-    describe("::element modifier support", () => {
-        it("ajax mode: it fetches the outerHTML with the ::element modifier", async (done) => {
-            global.fetch = jest
-                .fn()
-                .mockImplementation(
-                    mockFetch('<div id="outer">External content</div>')
-                );
-
-            const $el = testutils.createTooltip({
-                data: "source: ajax; trigger: click",
-                href: "http://test.com/#outer::element",
-            });
-            new pattern($el);
-            await utils.timeout(1);
-
-            testutils.click($el);
-            await utils.timeout(1); // wait a tick for async fetch
-
-            expect(
-                document.querySelector(".tippy-box .tippy-content").innerHTML
-            ).toBe('<div id="outer">External content</div>');
-
-            global.fetch.mockClear();
-            delete global.fetch;
-
-            done();
-        });
-
-        it("ajax mode: it fetches the innerHTML without the ::element modifier", async (done) => {
-            global.fetch = jest
-                .fn()
-                .mockImplementation(
-                    mockFetch('<div id="outer">External content</div>')
-                );
-
-            const $el = testutils.createTooltip({
-                data: "source: ajax; trigger: click",
-                href: "http://test.com/#outer",
-            });
-            new pattern($el);
-            await utils.timeout(1);
-
-            testutils.click($el);
-            await utils.timeout(1); // wait a tick for async fetch
-
-            expect(
-                document.querySelector(".tippy-box .tippy-content").innerHTML
-            ).toBe("External content");
-
-            global.fetch.mockClear();
-            delete global.fetch;
-
-            done();
-        });
-
-        it("local content: it uses the outerHTML with the ::element modifier", async (done) => {
-            const content = document.createElement("div");
-            content.setAttribute("id", "local-content");
-            content.innerHTML = '<strong class="testinner">okay</strong>';
-            document.body.appendChild(content);
-
-            const $el = testutils.createTooltip({
-                data: "source: ajax; trigger: click",
-                href: "#local-content::element",
-            });
-            new pattern($el);
-            await utils.timeout(1);
-
-            testutils.click($el);
-            await utils.timeout(1); // wait a tick for async fetch
-
-            expect(
-                document.querySelector(
-                    ".tippy-box .tippy-content #local-content"
-                )
-            ).toBeTruthy();
-
-            done();
-        });
-
-        it("local content: it uses the innerHTML without the ::element modifier", async (done) => {
-            const content = document.createElement("div");
-            content.setAttribute("id", "local-content");
-            content.innerHTML = '<strong class="testinner">okay</strong>';
-            document.body.appendChild(content);
-
-            const $el = testutils.createTooltip({
-                data: "source: ajax; trigger: click",
-                href: "#local-content",
-            });
-            new pattern($el);
-            await utils.timeout(1);
-
-            testutils.click($el);
-            await utils.timeout(1); // wait a tick for async fetch
-
-            expect(
-                document.querySelector(
-                    ".tippy-box .tippy-content #local-content"
-                )
-            ).toBeFalsy();
-
-            expect(
-                document.querySelector(".tippy-box .tippy-content .testinner")
-            ).toBeTruthy();
-
-            done();
-        });
-    });
-
     describe("URL splitting", () => {
         it("it extracts the correct parts from any url", async (done) => {
             const $el = testutils.createTooltip({});
             const instance = new pattern($el);
             await utils.timeout(1);
 
-            let parts = instance.get_url_parts(
-                "https://text.com/#selector::modifier"
-            );
+            let parts = instance.get_url_parts("https://text.com/#selector");
             expect(parts.url === "https://text.com/").toBeTruthy();
             expect(parts.selector === "#selector").toBeTruthy();
-            expect(parts.modifier === "innerHTML").toBeTruthy();
-
-            parts = instance.get_url_parts(
-                "https://text.com/#selector::element"
-            );
-            expect(parts.url === "https://text.com/").toBeTruthy();
-            expect(parts.selector === "#selector").toBeTruthy();
-            expect(parts.modifier === "outerHTML").toBeTruthy();
-
-            parts = instance.get_url_parts("#selector::element");
-            expect(typeof parts.url === "undefined").toBeTruthy();
-            expect(parts.selector === "#selector").toBeTruthy();
-            expect(parts.modifier === "outerHTML").toBeTruthy();
 
             parts = instance.get_url_parts("#selector");
             expect(typeof parts.url === "undefined").toBeTruthy();
             expect(parts.selector === "#selector").toBeTruthy();
-            expect(parts.modifier === "innerHTML").toBeTruthy();
 
             parts = instance.get_url_parts("https://text.com/");
             expect(parts.url === "https://text.com/").toBeTruthy();
             expect(typeof parts.selector === "undefined").toBeTruthy();
-            expect(parts.modifier === "innerHTML").toBeTruthy();
 
             done();
         });


### PR DESCRIPTION
Remove unannounced (not in changelog) feature which allowed for ::element
modifiers in href references to tooltip content.
Likewise as in pat-inject ::element modifiers selected the element itself with el.outerHTML instead of el.innerHTML.
This was problematic with rebasing URLs in pat-inject.