### PR TITLE
pat forward: Add `delay` parameter and `self` for `selector`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,8 @@
     Can be disabled by adding ``pat-inject-errorhandler.off`` to the URL's query string.
 -   core utils: Add ``jqToNode`` to return a DOM node if a jQuery node was passed.
 -   pat inject: Rebase URLs in pattern configuration attributes. This avoids URLs in pattern configuration to point to unreachable paths in the context where the result is injected into.
+-   pat forward: Add `delay` option for delaying the click action forwarding for a given number of milliseconds.
+-   pat forward: Add `self` as possible value for the `selector` option to trigger the event on itself.
 
 ### Technical
 

--- a/src/pat/forward/documentation.md
+++ b/src/pat/forward/documentation.md
@@ -21,7 +21,10 @@ immediately after the page is loaded.
 
 ### Option reference
 
-| Property   | Description                                               | Default | Allowed Values | Type         |
-| ---------- | --------------------------------------------------------- | ------- | -------------- | ------------ |
-| `selector` | The element to which the click event should be forwarded. |         |                | CSS Selector |
-| `trigger`  | When the forward action should be fired                   | `click` | `click         | auto`        | One of the mutually exclusive string values |
+| Property   | Description                                                          | Default | Allowed Values         | Type         |
+| ---------- | -------------------------------------------------------------------- | ------- | ---------------------- | ------------ |
+| `selector` | The element to which the click event should be forwarded.            |         | CSS Selector or `self` | CSS Selector |
+| `trigger`  | When the forward action should be fired                              | `click` | `click | auto`         | One of the mutually exclusive string values |
+| `delay`    | Defines time in milliseconds for which the action should be deferred | null    | integer                | ms           |
+
+Note: If the selector is `self` the handler gets unregistered after it has been run once.

--- a/src/pat/forward/forward.js
+++ b/src/pat/forward/forward.js
@@ -1,41 +1,32 @@
-/**
- * Patterns forward - Forward click events
- *
- * Copyright 2013 Simplon B.V. - Wichert Akkerman
- */
-
+// Patterns forward - Forward click events
 import $ from "jquery";
+import Base from "../../core/base";
 import Parser from "../../core/parser";
-import registry from "../../core/registry";
 
-var parser = new Parser("forward");
+const parser = new Parser("forward");
 
 parser.addArgument("selector");
 parser.addArgument("trigger", "click", ["click", "auto"]);
 
-var _ = {
+export default Base.extend({
     name: "forward",
     trigger: ".pat-forward",
 
-    init: function ($el, opts) {
-        return $el.each(function () {
-            var $el = $(this),
-                options = parser.parse($el, opts);
+    init() {
+        this.options = parser.parse(this.el, this.options);
+        if (!this.options.selector) {
+            return;
+        }
 
-            if (!options.selector) return;
-
-            $el.on("click", null, options.selector, _._onClick);
-            if (options.trigger === "auto") {
-                $el.trigger("click");
-            }
-        });
+        this.$el.on("click", this._onClick.bind(this));
+        if (this.options.trigger === "auto") {
+            this.$el.trigger("click");
+        }
     },
 
-    _onClick: function (event) {
-        $(event.data).click();
+    _onClick(event) {
         event.preventDefault();
         event.stopPropagation();
+        $(this.options.selector).click();
     },
-};
-registry.register(_);
-export default _;
+});

--- a/src/pat/forward/forward.js
+++ b/src/pat/forward/forward.js
@@ -1,16 +1,18 @@
 // Patterns forward - Forward click events
-import $ from "jquery";
 import Base from "../../core/base";
 import Parser from "../../core/parser";
+import utils from "../../core/utils";
 
 const parser = new Parser("forward");
 
 parser.addArgument("selector");
 parser.addArgument("trigger", "click", ["click", "auto"]);
+parser.addArgument("delay");
 
 export default Base.extend({
     name: "forward",
     trigger: ".pat-forward",
+    skip: false,
 
     init() {
         this.options = parser.parse(this.el, this.options);
@@ -18,15 +20,44 @@ export default Base.extend({
             return;
         }
 
-        this.$el.on("click", this._onClick.bind(this));
+        this.el.addEventListener("click", this.on_click.bind(this));
         if (this.options.trigger === "auto") {
-            this.$el.trigger("click");
+            this.el.click();
         }
     },
 
-    _onClick(event) {
+    async on_click(event) {
+        if (this.skip) {
+            this.skip = false;
+            return;
+        }
         event.preventDefault();
         event.stopPropagation();
-        $(this.options.selector).click();
+        if (this.options.delay) {
+            await utils.timeout(this.options.delay);
+        }
+        let targets;
+        if (this.options.selector === "self") {
+            this.skip = true;
+            this.el.removeEventListener("click", this.on_click);
+            targets = [this.el];
+        } else {
+            targets = document.querySelectorAll(this.options.selector);
+        }
+        for (const el of targets) {
+            el.click();
+        }
     },
 });
+
+// Notes:
+//
+// 1) We're using `ELEMENT.click()` instead of
+//    `ELEMENT.dispatchEvent(new Event("click"))`.
+//    The latter doesn't get recognized by jQuery and does not invoke the default
+//    action on an <a href> element.
+//
+// 2) `selector: self` case: We're keeping the the `skip` logic as jsDOM tests
+//    fail without them. Although this shouldn't be necessary as the click event
+//    hander was removed before.
+//

--- a/src/pat/forward/forward.test.js
+++ b/src/pat/forward/forward.test.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import pattern from "./forward";
+import utils from "../../core/utils";
 
 describe("pat-forward", function () {
     beforeEach(function () {
@@ -10,7 +11,7 @@ describe("pat-forward", function () {
         $("#lab").remove();
     });
 
-    describe("Clicking on a button sends the click to another element", function () {
+    describe("pat-forward ...", function () {
         it("allows you to forward the click from an element to another one", function () {
             var $lab = $("#lab");
             $lab.append(
@@ -27,10 +28,8 @@ describe("pat-forward", function () {
             $lab.find(".pat-forward").click();
             expect($lab.find("#checkbox").is(":checked")).toBeTruthy();
         });
-    });
 
-    describe("Setting the trigger auto option triggers the click on init", function () {
-        it("allows you to forward the click authomatically when the pattern is initialized", function () {
+        it("set to auto-trigger allows you to forward the click authomatically when the pattern is initialized", function () {
             var $lab = $("#lab");
             $lab.append(
                 $(
@@ -45,6 +44,62 @@ describe("pat-forward", function () {
             expect($lab.find("#checkbox").is(":checked")).toBeTruthy();
             $lab.find(".pat-forward").click();
             expect($lab.find("#checkbox").is(":checked")).toBeFalsy();
+        });
+
+        it("forwards the click event to all targets which match the selector", function () {
+            var $lab = $("#lab");
+            $lab.append(
+                $(
+                    "<form>" +
+                        '    <input id="checkbox1" type="checkbox" />' +
+                        '    <input id="checkbox2" type="checkbox" />' +
+                        '    <button class="pat-forward" data-pat-forward="input[type=checkbox]">Button</button>' +
+                        "</form>"
+                )
+            );
+
+            pattern.init($(pattern.trigger));
+            expect($lab.find("#checkbox1").is(":checked")).toBeFalsy();
+            expect($lab.find("#checkbox2").is(":checked")).toBeFalsy();
+            $lab.find(".pat-forward").click();
+            expect($lab.find("#checkbox1").is(":checked")).toBeTruthy();
+            expect($lab.find("#checkbox2").is(":checked")).toBeTruthy();
+        });
+
+        it("allows to define a delay after which the click event is forwarded.", async function () {
+            var $lab = $("#lab");
+            $lab.append(
+                $(
+                    "<form>" +
+                        '    <input id="checkbox" type="checkbox" />' +
+                        '    <button class="pat-forward" data-pat-forward="#checkbox; delay: 200">Button</button>' +
+                        "</form>"
+                )
+            );
+
+            pattern.init($(pattern.trigger));
+            expect($lab.find("#checkbox").is(":checked")).toBeFalsy();
+            $lab.find(".pat-forward").click();
+            expect($lab.find("#checkbox").is(":checked")).toBeFalsy();
+
+            await utils.timeout(300);
+
+            expect($lab.find("#checkbox").is(":checked")).toBeTruthy();
+        });
+
+        it("allows to define self as target - most useful with delay and/or auto-trigger.", async function () {
+            var $lab = $("#lab");
+            $lab.append(
+                $(
+                    `<a href="#oh" class="pat-forward" data-pat-forward="selector: self; trigger: auto; delay: 200ms">leave</a>`
+                )
+            );
+
+            pattern.init($(pattern.trigger));
+
+            expect(window.location.href.indexOf("#oh") > -1).toBe(false);
+            await utils.timeout(300);
+            expect(window.location.href.indexOf("#oh") > -1).toBe(true);
         });
     });
 });

--- a/src/pat/forward/index.html
+++ b/src/pat/forward/index.html
@@ -33,6 +33,14 @@
                     >
                         Click me…
                     </button>
+
+                    <button
+                        type="button"
+                        class="pat-button pat-forward"
+                        data-pat-forward="input[type=checkbox]"
+                    >
+                        Toggle all...
+                    </button>
                 </fieldset>
                 <a
                     class="pat-forward"
@@ -40,5 +48,12 @@
                 ></a>
             </fieldset>
         </form>
+
+        <div>
+          <a href="."
+              class="pat-forward"
+              data-pat-forward="selector: self; delay: 2000;"
+          >Click to reload in 2s</a>
+        </div>
     </body>
 </html>


### PR DESCRIPTION
-   pat forward: Add `delay` option for delaying the click action forwarding for a given number of milliseconds.
-   pat forward: Add `self` as possible value for the `selector` option to trigger the event on itself.