### PR TITLE
Dispatch DOM events with bubbling, canceling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,6 +101,8 @@
 
 ### Fixes
 
+-   pat calendar, pat checklist, pat datetime-picker: Dispatch DOM events with bubbling and canceling features enabled, as real DOM events do.
+    Fixes a problem where calendar categories did not show their initial state correctly.
 -   pat inject: Make sure that nested pat-inject element have the correct context for target ``self``. Fixes: https://github.com/quaive/ploneintranet.prototype/issues/1164
 -   pat calendar: Fix language loading error "Error: Cannot find module './en.js'"
 -   pat depends, pat auto suggest: Fix a problem with initialization of ``pat-auto-suggest`` which occurred after the lazy loading changes.

--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -1,5 +1,4 @@
 import "regenerator-runtime/runtime"; // needed for ``await`` support
-import $ from "jquery";
 import Base from "../../core/base";
 import logging from "../../core/logging";
 import Modal from "../modal/modal";
@@ -466,7 +465,9 @@ export default Base.extend({
             } else {
                 ctrl.checked = false;
             }
-            $(ctrl).trigger("change");
+            ctrl.dispatchEvent(
+                new Event("change", { bubbles: true, cancelable: true })
+            );
         }
     },
 

--- a/src/pat/checklist/checklist.js
+++ b/src/pat/checklist/checklist.js
@@ -108,7 +108,9 @@ export default Base.extend({
         );
         for (const box of chkbxs) {
             box.checked = true;
-            box.dispatchEvent(new Event("change", { bubbles: true }));
+            box.dispatchEvent(
+                new Event("change", { bubbles: true, cancelable: true })
+            );
         }
     },
 
@@ -120,7 +122,9 @@ export default Base.extend({
         );
         for (const box of chkbxs) {
             box.checked = false;
-            box.dispatchEvent(new Event("change", { bubbles: true }));
+            box.dispatchEvent(
+                new Event("change", { bubbles: true, cancelable: true })
+            );
         }
     },
 

--- a/src/pat/datetime-picker/datetime-picker.js
+++ b/src/pat/datetime-picker/datetime-picker.js
@@ -112,7 +112,9 @@ export default Base.extend({
         } else {
             this.el.value = "";
         }
-        this.el.dispatchEvent(new Event("change"));
+        this.el.dispatchEvent(
+            new Event("change", { bubbles: true, cancelable: true })
+        );
     },
 
     isodate() {


### PR DESCRIPTION
pat calendar, pat checklist, pat datetime-picker: Dispatch DOM events with bubbling and canceling features enabled, as real DOM events do.
Fixes a problem where calendar categories did not show their initial state correctly.