### PR TITLE
Revert "Do not apply filter, if filter is empty.", as this leads to unexpected UX.

### DIFF
--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -95,7 +95,7 @@ export default Base.extend({
         agendaDay: "timeGridDay",
     },
     dayNames: ["su", "mo", "tu", "we", "th", "fr", "sa"],
-    active_categories: [],
+    active_categories: null,
     parser: parser,
 
     async init($el, opts) {
@@ -386,7 +386,7 @@ export default Base.extend({
 
     filter_event(event) {
         let show = true;
-        if (this.active_categories.length) {
+        if (this.active_categories !== null) {
             // intersection
             show =
                 this.active_categories.filter((it) =>
@@ -402,12 +402,11 @@ export default Base.extend({
 
     reset_active_categories() {
         const ctrls = this.get_category_controls();
-        this.active_categories = [];
+        this.active_categories = null;
         if (ctrls.length) {
             this.active_categories = ctrls
                 .filter((el) => el.checked)
-                .map((el) => el.id)
-                .filter((it) => it); // no empties
+                .map((el) => el.id);
         }
         this.storage &&
             this.storage.set("active_categories", this.active_categories);
@@ -447,7 +446,7 @@ export default Base.extend({
          */
         const ctrls = this.get_category_controls();
         const active_categories =
-            (this.storage && this.storage.get("active_categories")) || [];
+            (this.storage && this.storage.get("active_categories")) || null;
 
         if (!ctrls.length || active_categories === null) {
             // No category controls or never set, use default un/checked status.


### PR DESCRIPTION
Commit was made due to no events shown in a calendar without filters
applied.
The real fix is to not include any filtering controls.
The code already supports showing all events when no filtering controls
are available.

Revert "pat-calendar: Do not apply filter, if filter is empty."

This reverts commit 2acb2c7cf8230b58917363412fa6b81cd05e1eed.