### PR TITLE
date picker: formatted date

### DIFF
--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -149,10 +149,12 @@ const registry = {
             // - with class ``.cant-touch-this``
             // - wrapped in ``.cant-touch-this`` elements
             // - wrapped in ``<pre>`` elements
+            // - wrapped in ``<template>`` elements
             return (
                 !el.matches(".cant-touch-this") &&
                 !el?.parentNode?.closest?.(".cant-touch-this") &&
-                !el?.parentNode?.closest?.("pre")
+                !el?.parentNode?.closest?.("pre") &&
+                !el?.parentNode?.closest?.("template") // NOTE: not strictly necessary. Template is a DocumentFragment and not reachable except for IE.
             );
         });
 

--- a/src/core/registry.test.js
+++ b/src/core/registry.test.js
@@ -80,6 +80,11 @@ describe("pat-registry: The registry for patterns", function () {
                     <div class="e4 pat-example"></div>
                 </div>
             </pre>
+            <template class="e5">
+                <div>
+                    <div class="pat-example"></div>
+                </div>
+            </template>
         `;
         registry.scan(tree);
 
@@ -87,5 +92,11 @@ describe("pat-registry: The registry for patterns", function () {
         expect(tree.querySelector(".e2").textContent).toBe("");
         expect(tree.querySelector(".e3").textContent).toBe("");
         expect(tree.querySelector(".e4").textContent).toBe("");
+        expect(
+            tree
+                .querySelector(".e5")
+                .content.firstElementChild.querySelector(".pat-example")
+                .textContent
+        ).toBe("");
     });
 });

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -556,6 +556,11 @@ const jqToNode = (el) => {
     return el;
 };
 
+const ensureArray = (it) => {
+    // Ensure to return always an array
+    return Array.isArray(it) || it.jquery ? it : [it];
+};
+
 var utils = {
     // pattern pimping - own module?
     jqueryPlugin: jqueryPlugin,
@@ -581,6 +586,7 @@ var utils = {
     debounce: debounce,
     isIE: isIE,
     jqToNode: jqToNode,
+    ensureArray: ensureArray,
 };
 
 export default utils;

--- a/src/core/utils.test.js
+++ b/src/core/utils.test.js
@@ -614,4 +614,27 @@ describe("core.utils tests", () => {
             done();
         });
     });
+
+    describe("ensureArray tests", () => {
+        it("returns the passed value as is if it is an array.", (done) => {
+            const val = [1, 2, 3];
+            expect(utils.ensureArray(val)).toBe(val);
+
+            done();
+        });
+
+        it("returns jQuery object as is, as it is array-like.", (done) => {
+            const val = $();
+            expect(utils.ensureArray(val)).toBe(val);
+
+            done();
+        });
+
+        it("returns an array, if the passed value is not an array.", (done) => {
+            const val = "1, 2, 3";
+            expect(utils.ensureArray(val)[0]).toBe(val);
+
+            done();
+        });
+    });
 });

--- a/src/pat/auto-submit/index.html
+++ b/src/pat/auto-submit/index.html
@@ -9,6 +9,28 @@
             type="text/javascript"
             charset="utf-8"
         ></script>
+        <style type="text/css" media="screen">
+          label {
+            display: block;
+          }
+          time.output-field {
+            min-width: 6em;
+            height: 2em;
+            margin: 0 0.5em;
+            padding: 0 0.5em;
+            background: lightgrey;
+            cursor: pointer;
+            box-sizing: border-box;
+            display: inline-block;
+          }
+          .cancel-button {
+            display: inline-block;
+            width: 1em;
+            height: 1em;
+            margin-left: 0.2em;
+            background-color: red;
+          }
+        </style>
     </head>
     <body class="home">
         <h1>pat-autosubmit demo</h1>
@@ -79,6 +101,19 @@
                           type="text"
                       />
                     </label>
+
+                    <fieldset class="group">
+                        <legend>date picker with depending input</legend>
+                        <label>
+                            <input name="start" class="pat-date-picker" type="date"/>
+                            Start
+                        </label>
+                        <label>
+                            <input name="end"   class="pat-date-picker" type="date" data-pat-date-picker="after: input[name=start]; offset-days: 2;"/>
+                            End after start, automatically updated.
+                        </label>
+                    </fieldset>
+
                 </fieldset>
             </form>
 

--- a/src/pat/clone/clone.test.js
+++ b/src/pat/clone/clone.test.js
@@ -34,6 +34,7 @@ describe("pat-clone", function () {
                 "    </div>" +
                 "</div>"
         );
+
         registry.scan($lab);
         expect($("div.item").length).toBe(1);
         $lab.find(".add-clone").click();
@@ -325,6 +326,73 @@ describe("pat-clone", function () {
                 document.body.querySelector(".pat-clone .pat-example")
                     .textContent
             ).toBe("initialized");
+        });
+
+        it("will not initialize patterns wrapped in <template> tags.", function () {
+            Base.extend({
+                name: "example",
+                trigger: ".pat-example",
+                init: function () {
+                    this.el.innerHTML += "initialized";
+                },
+            });
+
+            document.body.innerHTML = `
+                <template id="template">
+                    <div class="pat-example"></div>
+                </template>
+                <div class="pat-clone" data-pat-clone="template: #template">
+                  <button type="button" class="add-clone">clone</button>
+                </div>
+            `;
+            registry.scan(document.body);
+
+            // The template-pattern isn't initialized.
+            expect(
+                document.querySelector("#template").content.firstElementChild
+                    .textContent
+            ).toBe("");
+
+            document.querySelector("button").click();
+
+            // The cloned pattern is only initialized once.
+            expect(
+                document.querySelector(".pat-clone .pat-example").textContent
+            ).toBe("initialized");
+        });
+
+        it("can clone <template> with multiple first-level childs.", function () {
+            document.body.innerHTML = `
+                <template id="template">
+                    <label>first
+                        <input type="text" name="first" />
+                    </label>
+                    <label>second
+                        <input type="text" name="second" />
+                    </label>
+                    <button type="button" class="remove-clone" />
+                </template>
+                <div class="pat-clone" data-pat-clone="template: #template; remove-behavior: none">
+                  <button type="button" class="add-clone">clone</button>
+                </div>
+            `;
+            registry.scan(document.body);
+
+            document.querySelector(".add-clone").click();
+
+            expect(document.querySelectorAll(".pat-clone label").length).toBe(2); // prettier-ignore
+
+            document.querySelector(".add-clone").click();
+
+            expect(document.querySelectorAll(".pat-clone label").length).toBe(4); // prettier-ignore
+
+            document.querySelector(".remove-clone").click();
+
+            expect(document.querySelectorAll(".pat-clone label").length).toBe(2); // prettier-ignore
+
+            document.querySelector(".remove-clone").click();
+
+            expect(document.querySelectorAll(".pat-clone label").length).toBe(0); // prettier-ignore
         });
     });
 });

--- a/src/pat/clone/index.html
+++ b/src/pat/clone/index.html
@@ -11,6 +11,8 @@
         ></script>
     </head>
     <body>
+
+        <h1>Example 1 with hidden template</h1>
         <form action=""
               class="pat-form"
               novalidate>
@@ -62,7 +64,6 @@
                         </button>
                     </fieldset>
                 </div>
-
                 <div class="button-bar">
                     <!-- Clone trigger -->
                     <button type="button" class="pat-button clone-trigger">
@@ -74,6 +75,34 @@
                 </div>
             </fieldset>
         </form>
+
+        <h1>Example 2 with template tag</h1>
+
+        <template id="clone-template-2">
+            <br/>
+            <label>Manufactor #{1}
+                <input type="text" name="manufactor-#{1}" />
+            </label>
+            <label>Model #{1}
+                <input type="text" name="model-#{1}" />
+            </label>
+            <button type="button" class="remove-clone">Remove</button>
+        </template>
+
+        <form
+            class="pat-clone"
+            data-pat-clone="template: #clone-template-2; trigger-element: .clone-trigger-2">
+          <button type="button" class="clone-trigger-2">Add new row</button>
+        </form>
+
+        <h1>Example 3</h1>
+
+        <div class="pat-clone">
+            <div class="item">
+                okay!
+                <button class="add-clone">Clone!</button>
+            </div>
+         </div>
 
     </body>
 </html>

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -46,7 +46,7 @@ export default Base.extend({
             // date.
             const befores = document.querySelectorAll(this.options.after);
             for (const b_el of befores) {
-                b_el.addEventListener("input", (e) => {
+                b_el.addEventListener("change", (e) => {
                     let b_date = e.target.value; // the "before-date"
                     b_date = b_date ? new Date(b_date) : null;
                     if (!b_date) {
@@ -58,12 +58,7 @@ export default Base.extend({
                         const offset = this.options.offsetDays || 0;
                         b_date.setDate(b_date.getDate() + offset);
                         this.el.value = b_date.toISOString().substring(0, 10);
-                        this.el.dispatchEvent(
-                            new Event("input", {
-                                bubbles: true,
-                                cancelable: true,
-                            })
-                        );
+                        this.dispatch_change_event();
                     }
                 });
             }
@@ -96,7 +91,7 @@ export default Base.extend({
                 display_time_config
             );
 
-            this.el.addEventListener("input", () => {
+            this.el.addEventListener("change", () => {
                 display_el.setAttribute("datetime", this.el.value);
                 display_el_pat.format();
                 this.add_clear_button(display_el);
@@ -125,9 +120,7 @@ export default Base.extend({
                 $(this.pikaday._o.field.form).trigger("input-change");
                 /* Also trigger input change on date field to support pat-autosubmit. */
                 $(this.pikaday._o.field).trigger("input-change");
-                this.pikaday._o.field.dispatchEvent(
-                    new Event("input", { bubbles: true, cancelable: true })
-                );
+                this.dispatch_change_event();
             },
         };
 
@@ -156,14 +149,10 @@ export default Base.extend({
             // Add clear button
             const clear_button = document.createElement("span");
             clear_button.setAttribute("class", "cancel-button");
-            clear_button.addEventListener("click", () => {
+            clear_button.addEventListener("click", (e) => {
+                e.stopPropagation();
                 this.el.value = null;
-                this.el.dispatchEvent(
-                    new Event("input", {
-                        bubbles: true,
-                        cancelable: true,
-                    })
-                );
+                this.dispatch_change_event();
 
                 //// Also trigger input change on date field to support pat-autosubmit.
                 //$(this.el.form).dispatchEvent("input-change
@@ -171,5 +160,16 @@ export default Base.extend({
             });
             el_append_to.appendChild(clear_button);
         }
+    },
+
+    dispatch_change_event() {
+        const event = new Event("change", {
+            bubbles: true,
+            cancelable: true,
+        });
+        // Set ``firedBy` to prevent pikaday to call it's own handler and land
+        // in an infinite loop.
+        event.firedBy = this.pikaday;
+        this.el.dispatchEvent(event);
     },
 });

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -121,11 +121,11 @@ export default Base.extend({
             format: this.format,
             firstDay: this.options.firstDay,
             showWeekNumber: this.options.weekNumbers === "show",
-            onSelect() {
-                $(this._o.field).closest("form").trigger("input-change");
+            onSelect: () => {
+                $(this.pikaday._o.field.form).trigger("input-change");
                 /* Also trigger input change on date field to support pat-autosubmit. */
-                $(this._o.field).trigger("input-change");
-                this._o.field.dispatchEvent(
+                $(this.pikaday._o.field).trigger("input-change");
+                this.pikaday._o.field.dispatchEvent(
                     new Event("input", { bubbles: true, cancelable: true })
                 );
             },
@@ -139,24 +139,16 @@ export default Base.extend({
         }
 
         if (this.options.i18n) {
-            $.getJSON(this.options.i18n)
-                .done((data) => {
-                    config.i18n = data;
-                })
-                .fail(
-                    $.proxy(() => {
-                        console.error(
-                            "date-picker could not load i18n: " +
-                                this.options.i18n
-                        );
-                    }, this)
-                )
-                .always(() => {
-                    new Pikaday(config);
-                });
-        } else {
-            new Pikaday(config);
+            try {
+                const response = await fetch(this.options.i18n);
+                config.i18n = await response.json();
+            } catch {
+                console.error(
+                    `date-picker could not load i18n for ${this.options.i18n}`
+                );
+            }
         }
+        this.pikaday = new Pikaday(config);
     },
 
     add_clear_button(el_append_to) {

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -35,6 +35,7 @@ export default Base.extend({
 
     async init() {
         const el = this.el;
+
         //TODO: make parser with options extend missing options.
         //this.options = parser.parse(el, opts);
         this.options = $.extend(parser.parse(el), this.options);
@@ -87,6 +88,9 @@ export default Base.extend({
             }
             el.insertAdjacentElement("beforebegin", display_el);
 
+            $(display_el).on("init.display-time.patterns", () =>
+                this.add_clear_button(display_el)
+            );
             const display_el_pat = new PatDisplayTime(
                 display_el,
                 display_time_config
@@ -95,6 +99,7 @@ export default Base.extend({
             this.el.addEventListener("input", () => {
                 display_el.setAttribute("datetime", this.el.value);
                 display_el_pat.format();
+                this.add_clear_button(display_el);
             });
         } else if (utils.checkInputSupport("date", "invalid date")) {
             // behavior native with native support.
@@ -151,6 +156,28 @@ export default Base.extend({
                 });
         } else {
             new Pikaday(config);
+        }
+    },
+
+    add_clear_button(el_append_to) {
+        if (!this.el.required && this.el.value) {
+            // Add clear button
+            const clear_button = document.createElement("span");
+            clear_button.setAttribute("class", "cancel-button");
+            clear_button.addEventListener("click", () => {
+                this.el.value = null;
+                this.el.dispatchEvent(
+                    new Event("input", {
+                        bubbles: true,
+                        cancelable: true,
+                    })
+                );
+
+                //// Also trigger input change on date field to support pat-autosubmit.
+                //$(this.el.form).dispatchEvent("input-change
+                //$(this.el).dispatchEvent("input-change
+            });
+            el_append_to.appendChild(clear_button);
         }
     },
 });

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -116,12 +116,7 @@ export default Base.extend({
             format: this.format,
             firstDay: this.options.firstDay,
             showWeekNumber: this.options.weekNumbers === "show",
-            onSelect: () => {
-                $(this.pikaday._o.field.form).trigger("input-change");
-                /* Also trigger input change on date field to support pat-autosubmit. */
-                $(this.pikaday._o.field).trigger("input-change");
-                this.dispatch_change_event();
-            },
+            onSelect: () => this.dispatch_change_event(),
         };
 
         if (el.getAttribute("min")) {
@@ -153,10 +148,6 @@ export default Base.extend({
                 e.stopPropagation();
                 this.el.value = null;
                 this.dispatch_change_event();
-
-                //// Also trigger input change on date field to support pat-autosubmit.
-                //$(this.el.form).dispatchEvent("input-change
-                //$(this.el).dispatchEvent("input-change
             });
             el_append_to.appendChild(clear_button);
         }
@@ -171,5 +162,9 @@ export default Base.extend({
         // in an infinite loop.
         event.firedBy = this.pikaday;
         this.el.dispatchEvent(event);
+
+        // Also trigger input-change
+        $(this.el).trigger("input-change");
+        $(this.el.form).trigger("input-change");
     },
 });

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -3,6 +3,7 @@ import "regenerator-runtime/runtime"; // needed for ``await`` support
 import $ from "jquery";
 import Base from "../../core/base";
 import Parser from "../../core/parser";
+import PatDisplayTime from "../display-time/display-time";
 import utils from "../../core/utils";
 
 export const parser = new Parser("date-picker");
@@ -12,6 +13,9 @@ parser.addArgument("i18n"); // URL pointing to JSON resource with i18n values
 parser.addArgument("first-day", 0);
 parser.addArgument("after");
 parser.addArgument("offset-days", 0);
+
+parser.add_argument("output-format", null);
+parser.add_argument("locale", null);
 
 parser.addAlias("behaviour", "behavior");
 
@@ -27,6 +31,7 @@ export default Base.extend({
     name: "date-picker",
     trigger: ".pat-date-picker",
     parser: parser,
+    format: "YYYY-MM-DD",
 
     async init() {
         const el = this.el;
@@ -40,7 +45,7 @@ export default Base.extend({
             // date.
             const befores = document.querySelectorAll(this.options.after);
             for (const b_el of befores) {
-                b_el.addEventListener("change", (e) => {
+                b_el.addEventListener("input", (e) => {
                     let b_date = e.target.value; // the "before-date"
                     b_date = b_date ? new Date(b_date) : null;
                     if (!b_date) {
@@ -52,16 +57,52 @@ export default Base.extend({
                         const offset = this.options.offsetDays || 0;
                         b_date.setDate(b_date.getDate() + offset);
                         this.el.value = b_date.toISOString().substring(0, 10);
+                        this.el.dispatchEvent(
+                            new Event("input", {
+                                bubbles: true,
+                                cancelable: true,
+                            })
+                        );
                     }
                 });
             }
         }
 
-        if (
-            this.options.behavior === "native" &&
-            utils.checkInputSupport("date", "invalid date")
-        ) {
+        let display_el;
+        if (this.options.behavior === "styled") {
+            el.setAttribute("type", "hidden");
+
+            display_el = document.createElement("time");
+            display_el.setAttribute("class", "output-field");
+            display_el.setAttribute("datetime", el.value);
+
+            const display_time_config = { format: this.format };
+            if (this.options.outputFormat) {
+                display_time_config[
+                    "output-format"
+                ] = this.options.outputFormat;
+            }
+            if (this.options.locale) {
+                display_time_config.locale = this.options.locale;
+            }
+            el.insertAdjacentElement("beforebegin", display_el);
+
+            const display_el_pat = new PatDisplayTime(
+                display_el,
+                display_time_config
+            );
+
+            this.el.addEventListener("input", () => {
+                display_el.setAttribute("datetime", this.el.value);
+                display_el_pat.format();
+            });
+        } else if (utils.checkInputSupport("date", "invalid date")) {
+            // behavior native with native support.
             return;
+        } else if (el.getAttribute("type") === "date") {
+            // behavior native but no native support.
+            // Fallback JS date picker with a text input field.
+            el.setAttribute("type", "text");
         }
 
         if (window.__patternslib_import_styles) {
@@ -69,19 +110,19 @@ export default Base.extend({
         }
         const Pikaday = (await import("pikaday")).default;
 
-        if (el.getAttribute("type") === "date") {
-            el.setAttribute("type", "text");
-        }
-
         const config = {
             field: el,
-            format: "YYYY-MM-DD",
+            trigger: display_el || el,
+            format: this.format,
             firstDay: this.options.firstDay,
             showWeekNumber: this.options.weekNumbers === "show",
             onSelect() {
                 $(this._o.field).closest("form").trigger("input-change");
                 /* Also trigger input change on date field to support pat-autosubmit. */
                 $(this._o.field).trigger("input-change");
+                this._o.field.dispatchEvent(
+                    new Event("input", { bubbles: true, cancelable: true })
+                );
             },
         };
 

--- a/src/pat/date-picker/date-picker.test.js
+++ b/src/pat/date-picker/date-picker.test.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import pattern from "./date-picker";
+import pattern_auto_submit from "../auto-submit/auto-submit";
 import utils from "../../core/utils";
 
 const mock_fetch_i18n = () =>
@@ -477,5 +478,30 @@ describe("pat-date-picker", function () {
         cur_day.dispatchEvent(new Event("mousedown"));
         // input element contains iso date
         expect(el.value).toBe(isodate);
+    });
+
+    it("works with pat-autosubmit", async function (done) {
+        document.body.innerHTML = `
+            <form class="pat-autosubmit">
+                <input name="date" type="date" class="pat-date-picker"/>
+            </form>
+        `;
+
+        pattern_auto_submit.init(document.querySelector("form"));
+        pattern.init(document.querySelector("input"));
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        const handle_submit = jest.fn();
+        $(document.querySelector("form")).on("submit", handle_submit);
+
+        document.querySelector("time").click();
+
+        let btn = document.querySelector(".pika-single .pika-table button");
+        btn.dispatchEvent(new Event("mousedown"));
+
+        await utils.timeout(500); // wait for delay
+        expect(handle_submit).toHaveBeenCalled();
+
+        done();
     });
 });

--- a/src/pat/date-picker/date-picker.test.js
+++ b/src/pat/date-picker/date-picker.test.js
@@ -323,13 +323,105 @@ describe("pat-date-picker", function () {
         display_el.click();
 
         // <time> element should contains the pre-set date in iso format
+        expect(display_el.getAttribute("datetime")).toBe("2021-03-09");
         expect(display_el.textContent).toBe("9. März 2021");
 
         const day = document.querySelector(".pika-lendar td[data-day='12'] button"); // prettier-ignore
         day.dispatchEvent(new Event("mousedown"));
 
         expect(display_el.textContent).toBe("12. März 2021");
+        expect(display_el.getAttribute("datetime")).toBe("2021-03-12");
         expect(el.value).toBe("2021-03-12");
+    });
+
+    it("Formatted date with clear button.", async function (done) {
+        document.body.innerHTML =
+            '<input type="date" class="pat-date-picker" value="2021-03-09"/>';
+        const el = document.querySelector("input[type=date]");
+        pattern.init(el);
+        await utils.timeout(1); // wait a tick for async to settle.
+        const display_el = document.querySelector("time");
+
+        // Initial values on input field and time element
+        expect(display_el.getAttribute("datetime")).toBe("2021-03-09");
+        expect(display_el.textContent).toBe("2021-03-09");
+        expect(el.value).toBe("2021-03-09");
+
+        // Clear button is available
+        let clear_button = display_el.querySelector(".cancel-button");
+        expect(clear_button).toBeTruthy();
+
+        clear_button.click();
+
+        // Clear button clears input field value and time element content
+        expect(display_el.getAttribute("datetime")).toBe("");
+        expect(display_el.textContent).toBe("");
+        expect(el.value).toBe("");
+
+        // Clear button is removed when no value is present.
+        clear_button = display_el.querySelector(".cancel-button");
+        expect(clear_button).toBeFalsy();
+
+        display_el.click();
+
+        const day = document.querySelector(".pika-lendar td[data-day='12'] button"); // prettier-ignore
+        day.dispatchEvent(new Event("mousedown"));
+
+        // After selecting in calendar overlay, the values are set
+        expect(display_el.getAttribute("datetime")).toBe("2021-03-12");
+        expect(display_el.textContent).toBe("2021-03-12");
+        expect(el.value).toBe("2021-03-12");
+
+        // ... and clear button available again
+        clear_button = display_el.querySelector(".cancel-button");
+        expect(clear_button).toBeTruthy();
+
+        clear_button.click();
+
+        // Activating the clear button again clears the values as before
+        expect(display_el.getAttribute("datetime")).toBe("");
+        expect(display_el.textContent).toBe("");
+        expect(el.value).toBe("");
+
+        // ... and the cancel button isn't available anymore.
+        clear_button = display_el.querySelector(".cancel-button");
+        expect(clear_button).toBeFalsy();
+
+        done();
+    });
+
+    it("Required formatted date - no clear button available.", async function (done) {
+        document.body.innerHTML =
+            '<input type="date" class="pat-date-picker" value="2021-03-01" required/>';
+        const el = document.querySelector("input[type=date]");
+        pattern.init(el);
+        await utils.timeout(1); // wait a tick for async to settle.
+        const display_el = document.querySelector("time");
+
+        // Initial values on input field and time element
+        expect(display_el.getAttribute("datetime")).toBe("2021-03-01");
+        expect(display_el.textContent).toBe("2021-03-01");
+        expect(el.value).toBe("2021-03-01");
+
+        // Clear button is not available when field is required
+        let clear_button = display_el.querySelector(".cancel-button");
+        expect(clear_button).toBeFalsy();
+
+        display_el.click();
+
+        const day = document.querySelector(".pika-lendar td[data-day='12'] button"); // prettier-ignore
+        day.dispatchEvent(new Event("mousedown"));
+
+        // After selecting in calendar overlay, the values are set
+        expect(display_el.getAttribute("datetime")).toBe("2021-03-12");
+        expect(display_el.textContent).toBe("2021-03-12");
+        expect(el.value).toBe("2021-03-12");
+
+        // ... and clear button is still not available
+        clear_button = display_el.querySelector(".cancel-button");
+        expect(clear_button).toBeFalsy();
+
+        done();
     });
 
     it("Native behavior with fallback to pika", async function () {

--- a/src/pat/date-picker/date-picker.test.js
+++ b/src/pat/date-picker/date-picker.test.js
@@ -4,118 +4,102 @@ import pattern from "./date-picker";
 import utils from "../../core/utils";
 
 describe("pat-date-picker", function () {
-    beforeEach(function () {
-        $(
-            '<link href="src/pat/date-picker/date-picker.css" rel="stylesheet"/>'
-        ).appendTo(document.head);
-    });
     afterEach(function () {
-        //$('head link[href$="date-picker.css"').remove();
-        $("input.pat-date-picker").remove();
-        $(".pika-single, .pika-lendar").remove();
+        document.body.innerHTML = "";
         jest.restoreAllMocks();
     });
 
     it("Default date picker.", async function () {
-        var $pika = $('<input type="date" class="pat-date-picker"/>').appendTo(
-            document.body
-        );
-        pattern.init($pika);
+        document.body.innerHTML =
+            '<input type="date" class="pat-date-picker"/>';
+        const el = document.querySelector("input[type=date]");
+
+        pattern.init(el);
         await utils.timeout(1); // wait a tick for async to settle.
-        $pika.click();
 
-        var date = new Date();
-        var day = date.getDate().toString();
-        var month = date.getMonth().toString(); // remember, month-count starts from 0
-        var year = date.getFullYear().toString();
+        const display_el = document.querySelector("time");
+        expect(display_el).toBeTruthy();
+        expect(display_el.textContent).toBeFalsy();
 
-        // TODO: I'd love to set the date via the UI but I  can't get day.click() to have any effect...
+        display_el.click();
 
-        expect(
-            document.querySelector(
-                '.pika-lendar .pika-select-year option[selected="selected"]'
-            ).textContent
-        ).toBe(year);
+        const date = new Date();
+        const day = date.getDate().toString();
+        const month = date.getMonth().toString(); // remember, month-count starts from 0
+        const year = date.getFullYear().toString();
+        const isodate = date.toISOString().split("T")[0];
 
-        expect(
-            document.querySelector(
-                '.pika-lendar .pika-select-month option[selected="selected"]'
-            ).value
-        ).toBe(month);
+        const cur_year = document.querySelector('.pika-lendar .pika-select-year option[selected="selected"]'); // prettier-ignore
+        expect(cur_year.textContent).toBe(year);
 
-        expect(
-            document
-                .querySelector(".pika-lendar td.is-today button")
-                .getAttribute("data-pika-day")
-        ).toBe(day);
+        const cur_month = document.querySelector('.pika-lendar .pika-select-month option[selected="selected"]'); // prettier-ignore
+        expect(cur_month.value).toBe(month);
 
-        expect(
-            document.querySelector(".pika-lendar th:first-child abbr")
-                .textContent
-        ).toBe("Sun");
+        const cur_day = document.querySelector(".pika-lendar td.is-today button"); // prettier-ignore
+        expect(cur_day.getAttribute("data-pika-day")).toBe(day);
+
+        const cur_wkday = document.querySelector(".pika-lendar th:first-child abbr"); // prettier-ignore
+        expect(cur_wkday.textContent).toBe("Sun");
+
+        // select current day.
+        cur_day.dispatchEvent(new Event("mousedown"));
+        // <time> element should contains the current date in iso format
+        expect(display_el.textContent).toBe(isodate);
+        // input element contains iso date
+        expect(el.value).toBe(isodate);
     });
 
     it("Date picker starts at Monday.", async function () {
-        var $pika = $(
-            '<input type="date" class="pat-date-picker" data-pat-date-picker="first-day: 1" />'
-        ).appendTo(document.body);
-        pattern.init($pika);
+        document.body.innerHTML =
+            '<input type="date" class="pat-date-picker" data-pat-date-picker="first-day: 1" />';
+        const el = document.querySelector("input[type=date]");
+        pattern.init(el);
         await utils.timeout(1); // wait a tick for async to settle.
-        $pika.click();
+        const display_el = document.querySelector("time");
+        display_el.click();
 
-        expect(
-            document.querySelector(".pika-lendar th:first-child abbr")
-                .textContent
-        ).toBe("Mon");
+        const first_day = document.querySelector(".pika-lendar th:first-child abbr"); // prettier-ignore
+        expect(first_day.textContent).toBe("Mon");
     });
 
     it("Date picker with pre-set value.", async function () {
-        var $pika = $(
-            '<input type="date" class="pat-date-picker" value="1900-01-01"/>'
-        ).appendTo(document.body);
-        pattern.init($pika);
+        document.body.innerHTML =
+            '<input type="date" class="pat-date-picker" value="1900-01-01"/>';
+        const el = document.querySelector("input[type=date]");
+        pattern.init(el);
         await utils.timeout(1); // wait a tick for async to settle.
-        $pika.click();
+        const display_el = document.querySelector("time");
+        display_el.click();
 
-        expect(
-            document.querySelector(
-                '.pika-lendar .pika-select-year option[selected="selected"]'
-            ).textContent
-        ).toBe("1900");
+        const cur_year = document.querySelector('.pika-lendar .pika-select-year option[selected="selected"]'); // prettier-ignore
+        expect(cur_year.textContent).toBe("1900");
 
-        expect(
-            document.querySelector(
-                '.pika-lendar .pika-select-month option[selected="selected"]'
-            ).value
-        ).toBe("0");
+        const cur_month = document.querySelector('.pika-lendar .pika-select-month option[selected="selected"]'); // prettier-ignore
+        expect(cur_month.value).toBe("0");
 
-        expect(
-            document
-                .querySelector(".pika-lendar td.is-selected button")
-                .getAttribute("data-pika-day")
-        ).toBe("1");
+        const cur_day = document.querySelector(".pika-lendar td.is-selected button"); // prettier-ignore
+        expect(cur_day.getAttribute("data-pika-day")).toBe("1");
+
+        // <time> element should contains the pre-set date in iso format
+        expect(display_el.textContent).toBe("1900-01-01");
     });
 
     it("Date picker with week numbers.", async function () {
-        var $pika = $(
-            '<input type="date" class="pat-date-picker" data-pat-date-picker="week-numbers: show;" value="2017-09-18"/>'
-        ).appendTo(document.body);
-        pattern.init($pika);
+        document.body.innerHTML =
+            '<input type="date" class="pat-date-picker" data-pat-date-picker="week-numbers: show" value="2017-09-18"/>';
+        const el = document.querySelector("input[type=date]");
+        pattern.init(el);
         await utils.timeout(1); // wait a tick for async to settle.
-        $pika.click();
+        const display_el = document.querySelector("time");
+        display_el.click();
 
-        expect(
-            document.querySelectorAll(".pika-lendar .pika-week")[0].textContent
-        ).toBe("35");
+        const week_num = document.querySelectorAll(".pika-lendar .pika-week")[0]; // prettier-ignore
+        expect(week_num.textContent).toBe("35");
     });
 
     describe("Date picker with i18n", function () {
         describe("with proper json URL", function () {
             it("properly localizes the months and weekdays", async function () {
-                var $pika = $(
-                    '<input type="date" class="pat-date-picker" value="2018-10-21" data-pat-date-picker="i18n:/path/to/i18njson" />'
-                ).appendTo(document.body);
-                // Simulate successful getJSON call
                 jest.spyOn($, "getJSON").mockImplementation(() => {
                     return {
                         done: function (cb) {
@@ -131,24 +115,22 @@ describe("pat-date-picker", function () {
                         },
                     };
                 });
-                pattern.init($pika);
-                await utils.timeout(1); // wait a tick for async to settle.
-                $pika.click();
 
-                expect(
-                    document.querySelector(
-                        '.pika-lendar .pika-select-month option[selected="selected"]'
-                    ).textContent
-                ).toBe("Oktober");
+                document.body.innerHTML =
+                    '<input type="date" class="pat-date-picker" value="2018-10-21" data-pat-date-picker="i18n:/path/to/i18njson" />';
+                const el = document.querySelector("input[type=date]");
+                pattern.init(el);
+                await utils.timeout(1); // wait a tick for async to settle.
+                const display_el = document.querySelector("time");
+                display_el.click();
+
+                const month = document.querySelector('.pika-lendar .pika-select-month option[selected="selected"]'); // prettier-ignore
+                expect(month.textContent).toBe("Oktober");
             });
         });
 
         describe("with bogus json URL", function () {
             it("falls back to default (english) month and weekday labels ", async function () {
-                var $pika = $(
-                    '<input type="date" class="pat-date-picker" value="2018-10-21" data-pat-date-picker="i18n:/path/to/i18njson" />'
-                ).appendTo(document.body);
-                console.error = jest.fn(); // do not output error messages
                 // Simulate failing getJSON call
                 jest.spyOn($, "getJSON").mockImplementation(() => {
                     return {
@@ -165,14 +147,17 @@ describe("pat-date-picker", function () {
                         },
                     };
                 });
-                pattern.init($pika);
+
+                document.body.innerHTML =
+                    '<input type="date" class="pat-date-picker" value="2018-10-21" data-pat-date-picker="i18n:/path/to/i18njson" />';
+                const el = document.querySelector("input[type=date]");
+                pattern.init(el);
                 await utils.timeout(1); // wait a tick for async to settle.
-                $pika.click();
-                expect(
-                    document.querySelector(
-                        '.pika-lendar .pika-select-month option[selected="selected"]'
-                    ).textContent
-                ).toBe("October");
+                const display_el = document.querySelector("time");
+                display_el.click();
+
+                const month = document.querySelector('.pika-lendar .pika-select-month option[selected="selected"]'); // prettier-ignore
+                expect(month.textContent).toBe("October");
             });
         });
     });
@@ -192,6 +177,9 @@ describe("pat-date-picker", function () {
             pattern.init(end);
             await utils.timeout(1); // wait a tick for async to settle.
 
+            const start_display = document.querySelectorAll("time")[0];
+            const end_display = document.querySelectorAll("time")[1];
+
             const cal1 = document.querySelectorAll(".pika-single")[0];
             const cal2 = document.querySelectorAll(".pika-single")[1];
 
@@ -200,7 +188,7 @@ describe("pat-date-picker", function () {
             expect(end.value).toBeFalsy();
 
             // Set start value
-            start.click();
+            start_display.click();
 
             let btn = cal1.querySelectorAll(".pika-table button")[0];
             btn.dispatchEvent(new Event("mousedown"));
@@ -214,7 +202,7 @@ describe("pat-date-picker", function () {
 
             // Setting it again to a date after the end date will change the end
             // date again.
-            start.click();
+            start_display.click();
 
             btn = cal1.querySelectorAll(".pika-table button")[10];
             btn.dispatchEvent(new Event("mousedown"));
@@ -229,7 +217,7 @@ describe("pat-date-picker", function () {
             expect(start.value).toBe(end.value);
 
             // Setting it to an earlier value will not change the end date again.
-            start.click();
+            start_display.click();
 
             btn = cal1.querySelectorAll(".pika-table button")[5];
             btn.dispatchEvent(new Event("mousedown"));
@@ -247,7 +235,7 @@ describe("pat-date-picker", function () {
 
             // Setting end to an earlier value than start is possible.
             // Use pat-validation to prevent submitting it.
-            end.click();
+            end_display.click();
 
             btn = cal2.querySelectorAll(".pika-table button")[0];
             btn.dispatchEvent(new Event("mousedown"));
@@ -285,6 +273,8 @@ describe("pat-date-picker", function () {
             pattern.init(end);
             await utils.timeout(1); // wait a tick for async to settle.
 
+            const start_display = document.querySelectorAll("time")[0];
+
             const cal1 = document.querySelectorAll(".pika-single")[0];
 
             // Check initial values
@@ -292,28 +282,28 @@ describe("pat-date-picker", function () {
             expect(end.value).toBeFalsy();
 
             // Set start value
-            start.click();
+            start_display.click();
             let btn = cal1.querySelectorAll(".pika-table button")[0];
             btn.dispatchEvent(new Event("mousedown"));
             // end date is set +2 days in advance of start date.
             expect(diff_days(start.value, end.value)).toBe(-2);
 
             // Change start value +1day
-            start.click();
+            start_display.click();
             btn = cal1.querySelectorAll(".pika-table button")[1];
             btn.dispatchEvent(new Event("mousedown"));
             // end date doesn't change.
             expect(diff_days(start.value, end.value)).toBe(-1);
 
             // Change start value +1day = same day
-            start.click();
+            start_display.click();
             btn = cal1.querySelectorAll(".pika-table button")[2];
             btn.dispatchEvent(new Event("mousedown"));
             // end date doesn't change.
             expect(diff_days(start.value, end.value)).toBe(0);
 
             // Change start value +1day = 1 day after end date
-            start.click();
+            start_display.click();
             btn = cal1.querySelectorAll(".pika-table button")[3];
             btn.dispatchEvent(new Event("mousedown"));
             // end is set 2 days after start date
@@ -321,5 +311,66 @@ describe("pat-date-picker", function () {
 
             done();
         });
+    });
+
+    it("Formatted date.", async function () {
+        document.body.innerHTML =
+            '<input type="date" class="pat-date-picker" value="2021-03-09" data-pat-date-picker="output-format: Do MMMM YYYY; locale: de"/>';
+        const el = document.querySelector("input[type=date]");
+        pattern.init(el);
+        await utils.timeout(1); // wait a tick for async to settle.
+        const display_el = document.querySelector("time");
+        display_el.click();
+
+        // <time> element should contains the pre-set date in iso format
+        expect(display_el.textContent).toBe("9. März 2021");
+
+        const day = document.querySelector(".pika-lendar td[data-day='12'] button"); // prettier-ignore
+        day.dispatchEvent(new Event("mousedown"));
+
+        expect(display_el.textContent).toBe("12. März 2021");
+        expect(el.value).toBe("2021-03-12");
+    });
+
+    it("Native behavior with fallback to pika", async function () {
+        // We mocking as if we're not supporting input type date.
+        jest.spyOn(utils, "checkInputSupport").mockImplementation(() => false);
+
+        document.body.innerHTML =
+            '<input type="date" class="pat-date-picker" data-pat-date-picker="behavior: native"/>';
+        const el = document.querySelector("input[type=date]");
+
+        pattern.init(el);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        const display_el = document.querySelector("time");
+        // In native move with styled fallback we do not use the <time> element.
+        // We display the input and let it be editable.
+        expect(display_el).toBeFalsy();
+
+        el.click();
+
+        const date = new Date();
+        const day = date.getDate().toString();
+        const month = date.getMonth().toString(); // remember, month-count starts from 0
+        const year = date.getFullYear().toString();
+        const isodate = date.toISOString().split("T")[0];
+
+        const cur_year = document.querySelector('.pika-lendar .pika-select-year option[selected="selected"]'); // prettier-ignore
+        expect(cur_year.textContent).toBe(year);
+
+        const cur_month = document.querySelector('.pika-lendar .pika-select-month option[selected="selected"]'); // prettier-ignore
+        expect(cur_month.value).toBe(month);
+
+        const cur_day = document.querySelector(".pika-lendar td.is-today button"); // prettier-ignore
+        expect(cur_day.getAttribute("data-pika-day")).toBe(day);
+
+        const cur_wkday = document.querySelector(".pika-lendar th:first-child abbr"); // prettier-ignore
+        expect(cur_wkday.textContent).toBe("Sun");
+
+        // select current day.
+        cur_day.dispatchEvent(new Event("mousedown"));
+        // input element contains iso date
+        expect(el.value).toBe(isodate);
     });
 });

--- a/src/pat/date-picker/documentation.md
+++ b/src/pat/date-picker/documentation.md
@@ -55,6 +55,15 @@ Here are all the i18n values in JSON format:
        "weekdaysShort": ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
      }
 
+####Automatically update one date when changing another
+
+You can define one date input to be after another date with the ``after`` option.
+The the other date is changed after the first, it will be automatically updated to be offset days after the first.
+
+    <input name="start" class="pat-date-picker" type="date"/>
+    <input name="end"   class="pat-date-picker" type="date" data-pat-date-picker="after: input[name=start]; offset-days: 2;"/>
+
+
 ### Why did we base this library on Pikaday?
 
 When looking for the underlying library to use for this pattern, we compared

--- a/src/pat/date-picker/documentation.md
+++ b/src/pat/date-picker/documentation.md
@@ -63,6 +63,15 @@ The the other date is changed after the first, it will be automatically updated 
     <input name="start" class="pat-date-picker" type="date"/>
     <input name="end"   class="pat-date-picker" type="date" data-pat-date-picker="after: input[name=start]; offset-days: 2;"/>
 
+####Format the displayed date
+
+In the default ``styled`` behavior mode, you can format the displayed date.
+The date input will be hidden and updated with an ISO8601 date to submit values which are machine-readable.
+The formating options are those from MomentJS: https://momentjs.com/docs/#/displaying/format/
+The locale option allows you to define the language in which the formatted date is displayed.
+
+    <input class="pat-date-picker" data-pat-date-picker="output-format: Do MMMM YYYY; locale: de" type="date" />
+
 
 ### Why did we base this library on Pikaday?
 
@@ -104,3 +113,5 @@ In addition, the following options can be passed to `data-pat-date-picker`:
 | **first-day**               | Integer | 0             |                  | Set the first day of the week (0 -> Sunday, 1-> Monday, ...). |
 | **after**                   | string  |               |                  | CSS selector of another date input. If this date is before the other, it will be updated to the oder date plus offset-days. |
 | **offset-days**             | Integer | 0             |                  | Number of days added to the **after** reference date which will be used to update this date value. |
+| **output-format**           | String  | null          |                  | MomentJS compatible formatting option. If not given, the date will be displayed in ISO 8601 format. |
+| **locale**                  | String  | null          |                  | Define the language in which the formatted date should be displayed. |

--- a/src/pat/date-picker/index.html
+++ b/src/pat/date-picker/index.html
@@ -10,10 +10,23 @@
             charset="utf-8"
         ></script>
         <link rel="stylesheet" href="date-picker.css" type="text/css" />
+        <style type="text/css" media="screen">
+          time.output-field {
+            min-width: 6em;
+            height: 2em;
+            margin: 0 0.5em;
+            padding: 0 0.5em;
+            background: lightgrey;
+            cursor: pointer;
+            box-sizing: border-box;
+            display: inline-block;
+          }
+        </style>
     </head>
     <body>
         <form action="">
             <fieldset class="vertical">
+
                 <label
                     >Falling back to the browser's HTML5 picker if available.
                     <input
@@ -22,10 +35,12 @@
                         data-pat-date-picker="behavior: native"
                     /> </label
                 ><br />
+
                 <label
                     >Enforcing the styled non-HTML5 picker universally.
                     <input class="pat-date-picker" type="date" /> </label
                 ><br />
+
                 <label
                     >Default value
                     <input
@@ -34,6 +49,7 @@
                         value="2015-01-01"
                     /> </label
                 ><br />
+
                 <label
                     >First day on Monday
                     <input
@@ -43,15 +59,27 @@
                         data-pat-date-picker="first-day: 1"
                     /> </label
                 ><br />
+
                 <label
-                    >Specifying the "min" and "max" attributes. <small>+/- 2 months from today</small>
+                    >Show the week number.
+                    <input
+                        class="pat-date-picker"
+                        data-pat-date-picker="week-numbers: show;"
+                        type="date"
+                    /> </label
+                ><br />
+
+                <label
+                    >Specifying the "min" and "max" attributes.
                     <input
                         class="pat-date-picker demo-minmax"
                         min="2015-01-01"
                         max="2015-12-31"
                         type="date"
-                    /> </label
-                ><br />
+                    />
+                    <small>+/- 2 months from today</small>
+                </label>
+                <br />
                 <script charset="utf-8">
                   var date_arithmetics = function (addsub) {
                     return new Date(
@@ -64,22 +92,29 @@
                   input_minmax.setAttribute("min", date_arithmetics(-2));
                   input_minmax.setAttribute("max", date_arithmetics(+2));
                 </script>
+
                 <label
-                    >Show the week number.
+                    >Formatted
+
                     <input
                         class="pat-date-picker"
-                        data-pat-date-picker="week-numbers: show;"
                         type="date"
-                    /> </label
-                ><br />
+                        value="2015-01-01"
+                        data-pat-date-picker="output-format: MMMM Do YYYY"
+                    />
+                    <small>hide &lt;input&gt; and show formatted &lt;time&gt;. Still use iso format for &lt;input&gt;.</small>
+                </label>
+                <br />
+
                 <label
                     >Multilingual support with German translations
                     <input
                         class="pat-date-picker"
-                        data-pat-date-picker="i18n: ./i18n.json;"
+                        data-pat-date-picker="i18n: ./i18n.json; output-format: Do MMMM YYYY; locale: de"
                         type="date"
                     />
                 </label>
+                <br />
 
                 <label>Start
                     <input name="start" class="pat-date-picker" type="date"/>
@@ -87,7 +122,18 @@
                 <label>End after start, automatically updated.
                     <input name="end"   class="pat-date-picker" type="date" data-pat-date-picker="after: input[name=start]; offset-days: 2;"/>
                 </label>
+                <br />
 
+                <label>Start, formatted
+                    <input name="startf" class="pat-date-picker" type="date"
+                        data-pat-date-picker="output-format: MMMM Do YYYY"
+                    />
+                </label>
+                <label>End after start, automatically updated and formatted.
+                    <input name="endf"   class="pat-date-picker" type="date"
+                        data-pat-date-picker="after: input[name=startf]; offset-days: 2; output-format: MMMM Do YYYY"
+                        />
+                </label>
                 <br />
 
 

--- a/src/pat/date-picker/index.html
+++ b/src/pat/date-picker/index.html
@@ -135,7 +135,42 @@
                         />
                 </label>
                 <br />
+                <div
+                    class="pat-clone"
+                    data-pat-clone="template: #clone-template; trigger-element: .clone-trigger; max: 5">
+                    <fieldset id="clone-template" hidden>
+                        <legend>Measure #{1}</legend>
+                        <input
+                            name="name-#{1}"
+                            size="20"
+                            type="text"
+                            placeholder="Name"
+                            required="required"
+                        />
+                        <label>To be implemented by
+                            <input
+                                name="date-#{1}"
+                                type="date"
+                                class="pat-date-picker"
+                                data-pat-date-picker="output-format: Do MMMM YYYY;"
+                                placeholder="Completion date"
+                            />
+                        </label>
+                        <button
+                            type="button"
+                            class="small pat-button remove-clone icon-trash"
+                        >
+                            Remove
+                        </button>
+                    </fieldset>
+                </div>
+                <div class="button-bar">
+                    <!-- Clone trigger -->
+                    <button type="button" class="pat-button clone-trigger">
+                        Add an extra measure
+                    </button>
 
+                </div>
 
             </fieldset>
         </form>

--- a/src/pat/date-picker/index.html
+++ b/src/pat/date-picker/index.html
@@ -21,6 +21,13 @@
             box-sizing: border-box;
             display: inline-block;
           }
+          .cancel-button {
+            display: inline-block;
+            width: 1em;
+            height: 1em;
+            margin-left: 0.2em;
+            background-color: red;
+          }
         </style>
     </head>
     <body>
@@ -47,6 +54,7 @@
                         class="pat-date-picker"
                         type="date"
                         value="2015-01-01"
+                        required
                     /> </label
                 ><br />
 
@@ -57,8 +65,19 @@
                         type="date"
                         value="2015-01-01"
                         data-pat-date-picker="first-day: 1"
+                        required
                     /> </label
                 ><br />
+
+                <label>Not required, allows for deletion of value.
+                    <input
+                        class="pat-date-picker"
+                        type="date"
+                        value="2021-03-29"
+                    />
+                </label>
+                <br />
+
 
                 <label
                     >Show the week number.
@@ -135,19 +154,12 @@
                         />
                 </label>
                 <br />
+                <hr />
                 <div
                     class="pat-clone"
                     data-pat-clone="template: #clone-template; trigger-element: .clone-trigger; max: 5">
                     <fieldset id="clone-template" hidden>
-                        <legend>Measure #{1}</legend>
-                        <input
-                            name="name-#{1}"
-                            size="20"
-                            type="text"
-                            placeholder="Name"
-                            required="required"
-                        />
-                        <label>To be implemented by
+                        <label>Copied field #{1}
                             <input
                                 name="date-#{1}"
                                 type="date"
@@ -156,21 +168,14 @@
                                 placeholder="Completion date"
                             />
                         </label>
-                        <button
-                            type="button"
-                            class="small pat-button remove-clone icon-trash"
-                        >
+                        <button type="button" class="remove-clone">
                             Remove
                         </button>
                     </fieldset>
                 </div>
-                <div class="button-bar">
-                    <!-- Clone trigger -->
-                    <button type="button" class="pat-button clone-trigger">
-                        Add an extra measure
-                    </button>
-
-                </div>
+                <button type="button" class="clone-trigger">
+                    Add an extra measure
+                </button>
 
             </fieldset>
         </form>

--- a/src/pat/datetime-picker/datetime-picker.js
+++ b/src/pat/datetime-picker/datetime-picker.js
@@ -6,8 +6,6 @@ import utils from "../../core/utils";
 import dom from "../../core/dom";
 
 export const parser = new Parser("datetime-picker");
-parser.addArgument("behavior", "styled", ["native", "styled"]);
-
 parser.addArgument("format", "YYYY-MM-DD");
 parser.addArgument("week-numbers", [], ["show", "hide"]);
 parser.addArgument("i18n"); // URL pointing to JSON resource with i18n values
@@ -26,10 +24,7 @@ export default Base.extend({
         const el = this.el;
         this.options = parser.parse(this.el, this.options);
 
-        if (
-            this.options.behavior === "native" &&
-            utils.checkInputSupport("datetime-local", "invalid date")
-        ) {
+        if (utils.checkInputSupport("datetime-local", "invalid date")) {
             return;
         }
 
@@ -79,7 +74,8 @@ export default Base.extend({
         });
 
         const date_options = {
-            behavior: this.options.behavior,
+            behavior: "native",
+            format: this.options.format,
             weekNumbers: this.options.weekNumbers,
             firstDay: this.options.firstDay,
         };

--- a/src/pat/datetime-picker/datetime-picker.test.js
+++ b/src/pat/datetime-picker/datetime-picker.test.js
@@ -16,6 +16,9 @@ describe("pat-datetime-picker", function () {
     });
 
     it("Default datetime picker.", async function () {
+        // We mocking as if we're not supporting input type date.
+        jest.spyOn(utils, "checkInputSupport").mockImplementation(() => false);
+
         document.body.innerHTML = `
             <input
                 type="datetime-local"
@@ -55,6 +58,9 @@ describe("pat-datetime-picker", function () {
     });
 
     it("Date/Time picker starts at Monday.", async function () {
+        // We mocking as if we're not supporting input type date.
+        jest.spyOn(utils, "checkInputSupport").mockImplementation(() => false);
+
         document.body.innerHTML = `
             <input
                 type="datetime-local"
@@ -72,6 +78,9 @@ describe("pat-datetime-picker", function () {
     });
 
     it("Date/Time picker with pre-set value.", async function () {
+        // We mocking as if we're not supporting input type date.
+        jest.spyOn(utils, "checkInputSupport").mockImplementation(() => false);
+
         document.body.innerHTML = `
             <input
                 type="datetime-local"
@@ -102,6 +111,9 @@ describe("pat-datetime-picker", function () {
     });
 
     it("Date/Time picker with week numbers.", async function () {
+        // We mocking as if we're not supporting input type date.
+        jest.spyOn(utils, "checkInputSupport").mockImplementation(() => false);
+
         document.body.innerHTML = `
             <input
                 type="datetime-local"
@@ -118,6 +130,9 @@ describe("pat-datetime-picker", function () {
     });
 
     it("Test today and clear buttons.", async function () {
+        // We mocking as if we're not supporting input type date.
+        jest.spyOn(utils, "checkInputSupport").mockImplementation(() => false);
+
         Date.prototype.toISOString = jest.fn(() => "2021-05-01T10:10:10");
         Date.prototype.toTimeString = jest.fn(() => "10:10:10 GMT+0200");
 

--- a/src/pat/datetime-picker/documentation.md
+++ b/src/pat/datetime-picker/documentation.md
@@ -9,13 +9,6 @@ for browsers which don't yet support the HTML5 date input.
 
 ### Examples
 
-####Falling back to the browser's HTML5 picker if available.
-
-Set the `behavior` option to `native` to use the browser's HTML5 date input
-rendering when available.
-
-    <input class="pat-date-picker" type="date" data-pat-date-picker="behavior: native">
-
 ####Enforcing the styled non-HTML5 picker universally.
 
 By default this pattern will NOT defer to the browser's HTML5 picker.
@@ -85,7 +78,6 @@ In addition, the following options can be passed to `data-pat-date-picker`:
 
 | Property                    | Type    | Default Value | Available values | Description                                                  |
 | --------------------------- | ------- | ------------- | ---------------- | ------------------------------------------------------------ |
-| **behavior** (or behaviour) | string  | styled        | native, styled   | Styled will always show the styled date picker. Native will use the system native date picker, provided the browser supports this. |
 | **week-numbers**            | string  | hide          | show, hide       | "show" will show the weeks' numbers in a leftmost column.    |
 | **i18n**                    | URL     |               |                  | Provide a URL to a JSON resource which gives the i18n values. |
 | **first-day**               | Integer | 0             |                  | Set the first day of the week (0 -> Sunday, 1-> Monday, ...). |

--- a/src/pat/display-time/display-time.js
+++ b/src/pat/display-time/display-time.js
@@ -11,12 +11,12 @@ const log = logging.getLogger("pat-display-time");
 export const parser = new Parser("display-time");
 // input datetime options
 parser.add_argument("format", "");
-parser.add_argument("locale", "");
+parser.add_argument("locale", null);
 parser.add_argument("strict", false);
 // output options
 parser.add_argument("from-now", false);
 parser.add_argument("no-suffix", false);
-parser.add_argument("output-format", "");
+parser.add_argument("output-format", null);
 
 export default Base.extend({
     name: "display-time",
@@ -25,7 +25,7 @@ export default Base.extend({
     async init() {
         Moment = (await import("moment")).default;
 
-        this.options = parser.parse(this.$el);
+        this.options = parser.parse(this.el, this.options);
 
         let lang =
             this.options.locale || document.querySelector("html").lang || "en";
@@ -38,15 +38,19 @@ export default Base.extend({
             Moment.locale("en");
         }
         log.info("Moment.js language used: " + lang);
+        this.format();
+    },
 
-        const date_str = this.$el.attr("datetime");
-        const date = Moment(date_str, this.options.format, this.options.strict);
-        let out;
-        if (this.options.fromNow === true) {
-            out = date.fromNow(this.options.noSuffix);
-        } else if (this.options.outputFormat.length) {
-            out = date.format(this.options.outputFormat);
+    format() {
+        let out = this.el.getAttribute("datetime");
+        if (out && this.options.outputFormat) {
+            const date = Moment(out, this.options.format, this.options.strict);
+            if (this.options.fromNow === true) {
+                out = date.fromNow(this.options.noSuffix);
+            } else {
+                out = date.format(this.options.outputFormat || undefined);
+            }
         }
-        this.$el.text(out);
+        this.el.textContent = out;
     },
 });

--- a/src/pat/validation/index.html
+++ b/src/pat/validation/index.html
@@ -9,6 +9,24 @@
             type="text/javascript"
             charset="utf-8"
         ></script>
+        <style type="text/css" media="screen">
+          time.output-field {
+            min-width: 6em;
+            height: 2em;
+            padding: 0 0.5em;
+            background: lightgrey;
+            cursor: pointer;
+            box-sizing: border-box;
+            display: inline-block;
+          }
+          .cancel-button {
+            display: inline-block;
+            width: 1em;
+            height: 1em;
+            margin-left: 0.2em;
+            background-color: red;
+          }
+        </style>
     </head>
     <body>
         <form
@@ -79,7 +97,6 @@
                         type="date"
                         class="pat-date-picker"
                         name="measure.planning_start:records"
-                        data-pat-date-picker="behavior: native"
                         data-pat-validation="type: date; not-after: #planning-end; message-date: This date must be on or before the end date."
                         id="planning-start"
                         value="2015-10-10"
@@ -92,7 +109,7 @@
                         type="date"
                         class="pat-date-picker"
                         name="measure.planning_end:records"
-                        data-pat-date-picker="behavior: native; after: #planning-start"
+                        data-pat-date-picker="after: #planning-start"
                         data-pat-validation="type: date; not-before: #planning-start; message-date: This date must be on or after the start date."
                         id="planning-end"
                         value="2015-09-10"

--- a/src/patterns.js
+++ b/src/patterns.js
@@ -37,7 +37,7 @@ import "./pat/fullscreen/fullscreen";
 import "./pat/gallery/gallery";
 import "./pat/image-crop/image-crop";
 import "./pat/inject/inject";
-import "./pat/legend/legend";
+import "./pat/legend/legend"; // NOTE: Transforms <legend> tags to <p class="legend"> for styling reasons.
 import "./pat/markdown/markdown";
 import "./pat/masonry/masonry";
 import "./pat/menu/menu";

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -43,4 +43,25 @@ if (!document.currentScript) {
     document.currentScript = scripts.length && scripts[scripts.length - 1];
 }
 
+// Node.remove polyfill
+// From: https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove#polyfill
+// From: https://github.com/jserz/js_piece/blob/master/DOM/ChildNode/remove()/remove().md
+(function (arr) {
+    arr.forEach(function (item) {
+        // eslint-disable-next-line no-prototype-builtins
+        if (item.hasOwnProperty("remove")) {
+            return;
+        }
+        Object.defineProperty(item, "remove", {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            value: function remove() {
+                this.parentNode.removeChild(this);
+            },
+        });
+    });
+})([Element.prototype, CharacterData.prototype, DocumentType.prototype]);
+// END Node.remove polyfill
+
 // input.labels polyfill


### PR DESCRIPTION
pat date picker: Change styled behavior so that it can be formatted and localized while still submitting iso values.

Example:
- Example: https://github.com/Patternslib/Patterns/blob/scr-905/src/pat/date-picker/index.html#L109
- Doc in: https://github.com/Patternslib/Patterns/blob/scr-905/src/pat/date-picker/documentation.md
- Formatting options: https://momentjs.com/docs/#/displaying/format/

PRs:
- https://github.com/Patternslib/Patterns/pull/815
- https://github.com/quaive/ploneintranet.prototype/pull/1241
- https://github.com/syslabcom/oira.prototype/pull/246

Ref:
- https://github.com/quaive/ploneintranet.prototype/issues/1205
- https://jira.syslab.com/browse/SCR-905


Looks like so:
![Screenshot from 2021-03-09 20-39-50](https://user-images.githubusercontent.com/170891/110527764-a5279e00-8117-11eb-8f02-6f05e595cd66.png)

@pysailor the standard behavior - when no ``output-format`` is given, is to show ISO dates.
Note, there would be an option to automatically format the date in a localized version via this API (no IE support, though):
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat
Something like:
```console.log(new Intl.DateTimeFormat('de', { dateStyle: 'long' }).format(date));```
We could actually make this variant a fallback - not sure if it's a good idea.



