### PR TITLE
Don't rebase for some additional known prefixes to avoid that the lin…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -130,6 +130,7 @@
 
 ### Features
 
+-   pat-inject:  Don't rebase for some additional known prefixes to avoid that the links break when contained in an injected page snippet.
 -   pat-gallery: Allow adding images directly to the gallery.
 -   pat-validation: Allow for HTML5 style `required` attributes without a value.
 -   pat-validation: Added the possibility to check for fields equality

--- a/src/pat/inject/index.html
+++ b/src/pat/inject/index.html
@@ -420,7 +420,7 @@
                 class="pat-inject"
                 data-pat-inject="url:./index.html#rebase-url-demo; target: self::element"
             >
-              injection happens here!
+              injection happens here! <a href="tel:3632347">Call for help</a>
             </button>
           </div>
         </section>

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -911,6 +911,11 @@ const inject = {
                     value.slice(0, 2) !== "@@" &&
                     value[0] !== "#" &&
                     value.slice(0, 7) !== "mailto:" &&
+                    value.slice(0, 4) !== "tel:" &&
+                    value.slice(0, 4) !== "fax:" &&
+                    value.slice(0, 7) !== "callto:" &&
+                    value.slice(0, 10) !== "ts3server:" &&
+                    value.slice(0, 6) !== "teams:" &&
                     value.slice(0, 11) !== "javascript:"
                 ) {
                     value = utils.rebaseURL(base, value);


### PR DESCRIPTION
…ks break when contained in an injected page snippet. This can certainly be made more generic, but for now, it hurts only for the tel links and is a good enough fix for me
Fixes #980