### PR TITLE
Calendarcontrols fix

### DIFF
--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -254,7 +254,6 @@ describe("core.dom tests", () => {
         it("don't break with DocumentFragment without a parent.", (done) => {
             const el = new DocumentFragment();
             el.innerHTML = `<div class="starthere"></div>`;
-            console.log(el.parentNode);
             const res = dom.get_parents(el.querySelector(".starthere"));
             expect(res.length).toEqual(0);
 

--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -434,7 +434,7 @@ class ArgumentParser {
 
         for (const provider of $possible_config_providers) {
             let frame;
-            const data = $(provider).attr(this.attribute);
+            const data = ($(provider).attr(this.attribute) || "").trim();
             if (!data) {
                 continue;
             }

--- a/src/core/parser.test.js
+++ b/src/core/parser.test.js
@@ -100,6 +100,32 @@ describe("The Patterns parser", function () {
     });
 
     describe("When parsing", function () {
+        it("allows line breaks and spaces before and after the first and last argument", function (done) {
+            const parser = new ArgumentParser("mypattern");
+            parser.addArgument("selector");
+            parser.addArgument("reflector");
+            parser.addArgument("detector");
+            const content = document.createElement("div");
+            content.innerHTML = `
+                <div data-pat-mypattern="
+
+                    selector: 2;
+
+                    detector: 3;
+
+                    reflector: 4;
+
+                ">
+                </div>
+            `;
+            const opts = parser.parse(content.querySelector("[data-pat-mypattern]"));
+            expect(opts.selector).toBe("2");
+            expect(opts.detector).toBe("3");
+            expect(opts.reflector).toBe("4");
+
+            done();
+        });
+
         it("only the allowed values for an argument are parsed", function () {
             var parser = new ArgumentParser();
             parser.addArgument("color", "red", ["red", "blue"]);

--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -98,55 +98,57 @@ export default Base.extend({
     active_categories: null,
     parser: parser,
 
-    async init($el, opts) {
-        const el = this.el;
+    async init() {
+        this.options = store.updateOptions(this.el, parser.parse(this.el, this.options));
 
         const Calendar = (await import("@fullcalendar/core")).Calendar;
         const fcDayGrid = (await import("@fullcalendar/daygrid")).default;
-        const fcInteraction = (await import("@fullcalendar/interaction")).default; // prettier-ignore
+        const fcInteraction = (await import("@fullcalendar/interaction")).default;
         const fcList = (await import("@fullcalendar/list")).default;
         const fcLuxon = (await import("@fullcalendar/luxon")).default;
         const fcTimeGrid = (await import("@fullcalendar/timegrid")).default;
 
         // Save some UI elements for reuse.
-        this.el_jump_next = el.querySelector(".jump-next");
-        this.el_jump_prev = el.querySelector(".jump-prev");
-        this.el_jump_today = el.querySelector(".jump-today");
-        this.el_view_month = el.querySelector(".view-month");
-        this.el_view_week = el.querySelector(".view-week");
-        this.el_view_day = el.querySelector(".view-day");
-        this.el_view_list_year = el.querySelector(".view-listYear");
-        this.el_view_list_month = el.querySelector(".view-listMonth");
-        this.el_view_list_week = el.querySelector(".view-listWeek");
-        this.el_view_list_day = el.querySelector(".view-listDay");
-        this.el_timezone = el.querySelector("select[name='timezone']");
-        this.el_title = el.querySelector(".cal-title");
-
-        const config = {};
-        opts = this.options = store.updateOptions(el, parser.parse(el, opts));
+        this.el_jump_next = this.el.querySelector(".jump-next");
+        this.el_jump_prev = this.el.querySelector(".jump-prev");
+        this.el_jump_today = this.el.querySelector(".jump-today");
+        this.el_view_month = this.el.querySelector(".view-month");
+        this.el_view_week = this.el.querySelector(".view-week");
+        this.el_view_day = this.el.querySelector(".view-day");
+        this.el_view_list_year = this.el.querySelector(".view-listYear");
+        this.el_view_list_month = this.el.querySelector(".view-listMonth");
+        this.el_view_list_week = this.el.querySelector(".view-listWeek");
+        this.el_view_list_day = this.el.querySelector(".view-listDay");
+        this.el_timezone = this.el.querySelector("select[name='timezone']");
+        this.el_title = this.el.querySelector(".cal-title");
 
         const storage_prefix = `${this.name}-${window.location.pathname}`;
-        const storage = (this.storage =
-            opts.store === "none" ? null : store[opts.store](storage_prefix));
+        this.storage =
+            this.options.store === "none"
+                ? null
+                : store[this.options.store](storage_prefix);
 
         const query_string = new URLSearchParams(window.location.search);
 
+        const config = {};
         config.headerToolbar = false;
         config.initialDate =
             query_string.get("date") ||
-            (storage && storage.get("date")) ||
-            opts.initial.date;
+            this.storage?.get?.("date") ||
+            this.options.initial.date;
         config.initialView =
             query_string.get("view") ||
-            (storage && storage.get("view")) ||
-            opts.initial.view;
+            this.storage?.get?.("view") ||
+            this.options.initial.view;
         config.initialView = this.viewMap[config.initialView] || config.initialView;
-        config.editable = opts.editable || false;
+        config.editable = this.options.editable || false;
         config.plugins = [fcDayGrid, fcInteraction, fcList, fcLuxon, fcTimeGrid];
-        config.eventColor = opts.eventColor;
+        config.eventColor = this.options.eventColor;
 
         let lang =
-            opts.lang || document.querySelector("html").getAttribute("lang") || "en";
+            this.options.lang ||
+            document.querySelector("html").getAttribute("lang") ||
+            "en";
         // we don't support any country-specific language variants, always use first 2 letters
         lang = lang.substr(0, 2).toLowerCase();
         if (lang !== "en") {
@@ -154,23 +156,23 @@ export default Base.extend({
             config.locale = locale.default;
             console.log("loaded cal locale for " + lang);
         }
-        if (opts.first.day !== null) {
-            config.firstDay = opts.first.day;
-            if (this.dayNames.indexOf(opts.first.day) >= 0) {
+        if (this.options.first.day !== null) {
+            config.firstDay = this.options.first.day;
+            if (this.dayNames.indexOf(this.options.first.day) >= 0) {
                 // Set firstDay as string
-                config.firstDay = this.dayNames.indexOf(opts.first.day);
+                config.firstDay = this.dayNames.indexOf(this.options.first.day);
             }
         }
 
-        let timezone = this.el_timezone?.value || opts.timezone || null;
+        let timezone = this.el_timezone?.value || this.options.timezone || null;
         if (timezone) {
             config.timeZone = timezone;
         }
 
-        const sources = [...(opts.event.sources || [])];
-        if (opts.url && !sources.includes(opts.url)) {
+        const sources = [...(this.options.event.sources || [])];
+        if (this.options.url && !sources.includes(this.options.url)) {
             // add, but do not re-add same source twice.
-            sources.push(opts.url);
+            sources.push(this.options.url);
         }
         config.eventSources = [];
         for (const [idx, url] of sources.entries()) {
@@ -188,14 +190,14 @@ export default Base.extend({
         // controls within pat-calendar to not be overwritten.
         const cal_el = document.createElement("div");
         cal_el.setAttribute("class", "pat-calendar__fc");
-        el.appendChild(cal_el);
+        this.el.appendChild(cal_el);
 
-        if (opts.addUrl) {
+        if (this.options.addUrl) {
             config.dateClick = this.addNewEvent.bind(this);
             // Create a element for modals/injections
             this.mod_el = document.createElement("section");
             this.mod_el.setAttribute("class", "pat-calendar__modal");
-            el.appendChild(this.mod_el);
+            this.el.appendChild(this.mod_el);
         }
 
         let calendar = (this.calendar = new Calendar(cal_el, config));

--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -9,8 +9,8 @@ import store from "../../core/store";
 const log = logging.getLogger("calendar");
 export const parser = new Parser("calendar");
 
-parser.addArgument("calendar-controls", ""); // Calendar controls must have "id" attr set
-parser.addArgument("category-controls", "");
+parser.addArgument("calendar-controls", null); // Calendar controls must have "id" attr set
+parser.addArgument("category-controls", null);
 parser.addArgument("column-day", "dddd M/d");
 parser.addArgument("column-month", "ddd");
 parser.addArgument("column-week", "ddd M/d");
@@ -109,18 +109,21 @@ export default Base.extend({
         const fcTimeGrid = (await import("@fullcalendar/timegrid")).default;
 
         // Save some UI elements for reuse.
-        this.el_jump_next = this.el.querySelector(".jump-next");
-        this.el_jump_prev = this.el.querySelector(".jump-prev");
-        this.el_jump_today = this.el.querySelector(".jump-today");
-        this.el_view_month = this.el.querySelector(".view-month");
-        this.el_view_week = this.el.querySelector(".view-week");
-        this.el_view_day = this.el.querySelector(".view-day");
-        this.el_view_list_year = this.el.querySelector(".view-listYear");
-        this.el_view_list_month = this.el.querySelector(".view-listMonth");
-        this.el_view_list_week = this.el.querySelector(".view-listWeek");
-        this.el_view_list_day = this.el.querySelector(".view-listDay");
-        this.el_timezone = this.el.querySelector("select[name='timezone']");
-        this.el_title = this.el.querySelector(".cal-title");
+        const calendar_controls = this.options.calendarControls
+            ? document.querySelector(this.options.calendarControls)
+            : this.el;
+        this.el_jump_next = calendar_controls.querySelector(".jump-next");
+        this.el_jump_prev = calendar_controls.querySelector(".jump-prev");
+        this.el_jump_today = calendar_controls.querySelector(".jump-today");
+        this.el_view_month = calendar_controls.querySelector(".view-month");
+        this.el_view_week = calendar_controls.querySelector(".view-week");
+        this.el_view_day = calendar_controls.querySelector(".view-day");
+        this.el_view_list_year = calendar_controls.querySelector(".view-listYear");
+        this.el_view_list_month = calendar_controls.querySelector(".view-listMonth");
+        this.el_view_list_week = calendar_controls.querySelector(".view-listWeek");
+        this.el_view_list_day = calendar_controls.querySelector(".view-listDay");
+        this.el_timezone = calendar_controls.querySelector("select[name='timezone']");
+        this.el_title = calendar_controls.querySelector(".cal-title");
 
         const storage_prefix = `${this.name}-${window.location.pathname}`;
         this.storage =

--- a/src/pat/calendar/calendar.test.js
+++ b/src/pat/calendar/calendar.test.js
@@ -283,8 +283,6 @@ describe("Calendar tests", () => {
         const event2 = events.filter((it) => it.textContent === "Event 2")[0].closest(".fc-event"); // prettier-ignore
         const event3 = events.filter((it) => it.textContent === "Event 3")[0].closest(".fc-event"); // prettier-ignore
 
-        console.log(event3.outerHTML);
-
         expect(event1.classList.contains("pat-inject")).toBe(false);
         expect(event1.classList.contains("pat-switch")).toBe(true);
         expect(event1.hasAttribute("data-pat-inject")).toBe(false);
@@ -327,8 +325,6 @@ describe("Calendar tests", () => {
         const event2 = events.filter((it) => it.textContent === "Event 2")[0].closest(".fc-event"); // prettier-ignore
         const event3 = events.filter((it) => it.textContent === "Event 3")[0].closest(".fc-event"); // prettier-ignore
 
-        console.log(event3.outerHTML);
-
         expect(event1.classList.contains("pat-modal")).toBe(false);
         expect(event1.hasAttribute("data-pat-modal")).toBe(false);
 
@@ -364,8 +360,6 @@ describe("Calendar tests", () => {
         const event1 = events.filter((it) => it.textContent === "Event 1")[0].closest(".fc-event"); // prettier-ignore
         const event2 = events.filter((it) => it.textContent === "Event 2")[0].closest(".fc-event"); // prettier-ignore
         const event3 = events.filter((it) => it.textContent === "Event 3")[0].closest(".fc-event"); // prettier-ignore
-
-        console.log(event3.outerHTML);
 
         expect(event1.classList.contains("pat-tooltip")).toBe(false);
         expect(event1.hasAttribute("data-pat-tooltip")).toBe(false);

--- a/src/pat/calendar/calendar.test.js
+++ b/src/pat/calendar/calendar.test.js
@@ -398,3 +398,116 @@ describe("Calendar tests", () => {
         done();
     });
 });
+
+describe("Calendar tests with calendar controls outside pat-calendar", () => {
+    beforeEach(() => {
+        // create container
+        const el = document.createElement("div");
+        el.setAttribute("class", "root-element");
+        el.innerHTML = `
+          <div class="calendar-controls">
+              <h1 class="cal-title">title</h1>
+              <div class="cal-toolbar">
+                <fieldset class="cal-nav">
+                  <button class="jump-prev" title="Back" type="button">&lt;</button>
+                  <button class="jump-today" title="Today" type="button">Today</button>
+                  <button class="jump-next" title="Forward" type="button">&gt;</button>
+                </fieldset>
+                <fieldset class="cal-views">
+                  <button class="view-month" type="button">Month</button>
+                  <button class="view-week" type="button">Week</button>
+                  <button class="view-day" type="button">Day</button>
+                </fieldset>
+              </div>
+          </div>
+
+          <div class="pat-calendar"></div>
+        `;
+        document.body.appendChild(el);
+    });
+
+    afterEach(() => {
+        // remove container
+        document.body.removeChild(document.querySelector(".root-element"));
+
+        // reset query string
+        history.replaceState(null, null, "?"); // empty string doesn't reset, so "?"...
+    });
+
+    it("Updates title according to display", async (done) => {
+        const el = document.querySelector(".pat-calendar");
+        el.setAttribute(
+            "data-pat-calendar",
+            "initial-date: 2000-10-10; initial-view: month; calendar-controls: .calendar-controls"
+        );
+
+        const title_el = document.querySelector(".cal-title");
+        let title = title_el.innerHTML;
+
+        registry.scan(document.body);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        expect(title_el.innerHTML === title).toBeFalsy();
+        title = title_el.innerHTML;
+
+        document.querySelector(".view-week").click();
+        expect(title_el.innerHTML === title).toBeFalsy();
+        title = title_el.innerHTML;
+
+        document.querySelector(".view-day").click();
+        expect(title_el.innerHTML === title).toBeFalsy();
+        title = title_el.innerHTML;
+
+        document.querySelector(".view-month").click();
+        expect(title_el.innerHTML === title).toBeFalsy();
+        title = title_el.innerHTML;
+
+        document.querySelector(".jump-next").click();
+        expect(title_el.innerHTML === title).toBeFalsy();
+        title = title_el.innerHTML;
+
+        document.querySelector(".jump-prev").click();
+        expect(title_el.innerHTML === title).toBeFalsy();
+        title = title_el.innerHTML;
+
+        document.querySelector(".jump-today").click();
+        expect(title_el.innerHTML === title).toBeFalsy();
+        title = title_el.innerHTML;
+
+        done();
+    });
+
+    it("Changes views when clicked", async (done) => {
+        const el = document.querySelector(".pat-calendar");
+        el.setAttribute("data-pat-calendar", "calendar-controls: .calendar-controls");
+
+        registry.scan(document.body);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        document.querySelector(".view-week").click();
+        expect(document.querySelector(".view-week.active")).toBeTruthy();
+        expect(document.querySelector(".view-day.active")).toBeFalsy();
+        expect(document.querySelector(".view-month.active")).toBeFalsy();
+        expect(el.querySelector(".fc-dayGridMonth-view")).toBeFalsy();
+        expect(el.querySelector(".fc-timeGridWeek-view")).toBeTruthy();
+        expect(el.querySelector(".fc-timeGridDay-view")).toBeFalsy();
+
+        document.querySelector(".view-day").click();
+        expect(document.querySelector(".view-week.active")).toBeFalsy();
+        expect(document.querySelector(".view-day.active")).toBeTruthy();
+        expect(document.querySelector(".view-month.active")).toBeFalsy();
+        expect(el.querySelector(".fc-dayGridMonth-view")).toBeFalsy();
+        expect(el.querySelector(".fc-timeGridWeek-view")).toBeFalsy();
+        expect(el.querySelector(".fc-timeGridDay-view")).toBeTruthy();
+
+        document.querySelector(".view-month").click();
+        expect(document.querySelector(".view-week.active")).toBeFalsy();
+        expect(document.querySelector(".view-day.active")).toBeFalsy();
+        expect(document.querySelector(".view-month.active")).toBeTruthy();
+        expect(el.querySelector(".fc-dayGridMonth-view")).toBeTruthy();
+        expect(el.querySelector(".fc-timeGridWeek-view")).toBeFalsy();
+        expect(el.querySelector(".fc-timeGridDay-view")).toBeFalsy();
+
+        done();
+    });
+});

--- a/src/pat/calendar/documentation.md
+++ b/src/pat/calendar/documentation.md
@@ -40,12 +40,12 @@ The calendar can be configured through a `data-pat-calendar` attribute. The avai
 
 | Property                  | Default value     | Values                                            | Description                                                                                                   | Type                   |
 | ------------------------- | ----------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `calendar-controls`       |                   |                                                   |
-| `category-controls`       |                   |                                                   |
+| `calendar-controls`       |                   | Valid CSS selector.                               | Defines the element where the calendar UI controls are located in. If not given, the pat-calendar element is used as search context. | string |
+| `category-controls`       |                   | Valid CSS selector.                               | Defines the element where the category UI controls are located in. If not given, the pat-calendar element is used as search context. | string |
 | `column-day`              | dddd M/d          |                                                   |
 | `column-month`            | ddd               |                                                   |
 | `column-week`             | ddd M/d           |                                                   |
-| `initial-date`            | none              | ISO8601 date string (yyyy-mm-dd)                  | The initial date for the calendar. Defaults to the current date.
+| `initial-date`            |                   | ISO8601 date string (yyyy-mm-dd)                  | The initial date for the calendar. Defaults to the current date.
 | `initial-view`            | month             | month, basicWeek, basicDay, agendaWeek, agendaDay | The default view of the calendar.                                                                             | Mutually Exclusive     |
 | `drag-and-drop`           |                   | true, false                                       | Enable support for drag and drop or drag to resize of the events in the calendar.                             | Mutually Exclusive     |
 | `drop-external-events`    |                   | true, false                                       | Enable support for dragging and dropping events from outside of the calendar, into it.                        | Mutually Exclusive     |


### PR DESCRIPTION
- fix(pat calendar): Implement calendar-controls.

- Implement calendar-controls to define the search context for calendar UI elements.
This allows UI elements to be defined outside the .pat-calendar context.

- maint(Tests): Remove left-over log messages.

- fix(core parser): Allow line breaks and spaces before and after pattern arguments.

