### PR TITLE
pat-tabs: Extra classes to indicate tabs state

### DIFF
--- a/src/pat/tabs/tabs.js
+++ b/src/pat/tabs/tabs.js
@@ -39,6 +39,12 @@ export default Base.extend({
     },
 
     adjust_tabs() {
+        this.el.classList.remove("tabs-ready", "tabs-wrapped");
+        this._adjust_tabs();
+        this.el.classList.add("tabs-ready");
+    },
+
+    _adjust_tabs() {
         this.skip_adjust = true;
         const container_width = this.$el.width() * 0.95;
 
@@ -75,7 +81,7 @@ export default Base.extend({
 
         const extra_el = document.createElement("span");
         extra_el.setAttribute("class", "extra-tabs");
-        this.el.classList.add("closed");
+        this.el.classList.add("closed", "tabs-wrapped");
         extra_el.addEventListener("click", () => {
             // Toggle opened/closed class on extra-tabs
             if (this.el.classList.contains("open")) {

--- a/src/pat/tabs/tabs.test.js
+++ b/src/pat/tabs/tabs.test.js
@@ -22,9 +22,12 @@ describe("pat-tabs", function () {
             </nav>
         `;
         const tabs = document.querySelector(".pat-tabs");
+        expect(tabs.classList.contains("tabs-ready")).toBeFalsy();
         pattern.init(tabs);
         await utils.timeout(100);
         expect(tabs.querySelectorAll(".extra-tabs").length).toBeTruthy();
+        expect(tabs.classList.contains("tabs-wrapped")).toBeTruthy();
+        expect(tabs.classList.contains("tabs-ready")).toBeTruthy();
     });
 
     it("When the size of all the tabs (padding included) cannot fit in the pat-tabs div some tabs will be placed in the extra-tabs span, which is a child of the pat-tabs element", async () => {
@@ -39,9 +42,12 @@ describe("pat-tabs", function () {
         `;
 
         const tabs = document.querySelector(".pat-tabs");
+        expect(tabs.classList.contains("tabs-ready")).toBeFalsy();
         pattern.init(tabs);
         await utils.timeout(100);
         expect(tabs.querySelectorAll(".extra-tabs").length).toBeTruthy();
+        expect(tabs.classList.contains("tabs-wrapped")).toBeTruthy();
+        expect(tabs.classList.contains("tabs-ready")).toBeTruthy();
     });
 
     it("When the size of all the tabs can fit in the pat-tabs div the extra-tabs span will not exist as a child of the pat-tabs element", async () => {
@@ -60,9 +66,12 @@ describe("pat-tabs", function () {
         `;
 
         const tabs = document.querySelector(".pat-tabs");
+        expect(tabs.classList.contains("tabs-ready")).toBeFalsy();
         pattern.init(tabs);
         await utils.timeout(100);
         expect(tabs.querySelectorAll(".extra-tabs").length).toBeFalsy();
+        expect(tabs.classList.contains("tabs-wrapped")).toBeFalsy();
+        expect(tabs.classList.contains("tabs-ready")).toBeTruthy();
     });
 
     it("When the size of all the tabs (padding included) can fit in the pat-tabs div the extra-tabs span will not exist as a child of the pat-tabs element", async () => {
@@ -81,9 +90,12 @@ describe("pat-tabs", function () {
         `;
 
         const tabs = document.querySelector(".pat-tabs");
+        expect(tabs.classList.contains("tabs-ready")).toBeFalsy();
         pattern.init(tabs);
         await utils.timeout(100);
         expect(tabs.querySelectorAll(".extra-tabs").length).toBeFalsy();
+        expect(tabs.classList.contains("tabs-wrapped")).toBeFalsy();
+        expect(tabs.classList.contains("tabs-ready")).toBeTruthy();
     });
 
     it("Clicking on extra-tabs toggles the ``open`` and ``closed`` classes.", async () => {


### PR DESCRIPTION
Note: The tests currently don't cover resizing the browser after first init; e.g. when width increases the `tabs-wrapped` class may need to disappear. I've verified this manually only.

Closes #841