### PR TITLE
scr 1152 - fixes 3

### DIFF
--- a/src/pat/tabs/tabs.js
+++ b/src/pat/tabs/tabs.js
@@ -45,7 +45,6 @@ export default Base.extend({
         this.el.classList.remove("tabs-ready");
         this.el.classList.remove("tabs-wrapped");
         this._flatten_tabs();
-        this.max_x = this._get_max_x();
         this._adjust_tabs();
         this.el.classList.add("tabs-ready");
     },
@@ -82,6 +81,8 @@ export default Base.extend({
             return;
         }
 
+        const max_x = this._get_max_x();
+
         // Check if tabs fit into one line by checking their start position not
         // exceeding the available inner width or if they are not broken to a
         // new line.
@@ -96,7 +97,7 @@ export default Base.extend({
                 parseInt(bounds.width, 10) +
                 parseInt(utils.getCSSValue(this.el, "margin-right") || 0, 10);
             logger.debug(`New tab right position: ${it_x + it_w}px.`);
-            if ((last_x && last_x > it_x) || it_x + it_w > this.max_x) {
+            if ((last_x && last_x > it_x) || it_x + it_w > max_x) {
                 // this tab exceeds initial available width or
                 // breaks into a new line when width
                 tabs_fit = false;


### PR DESCRIPTION
fix(pat tabs): Improve calculation of available width by querying the new available width after each recurision where a tab has been moved into the extra-tabs span. The width might change due to an applied padding when the extra-tabs span is added.