### PR TITLE
Stabilize pat tabs

### DIFF
--- a/src/pat/tabs/tabs.js
+++ b/src/pat/tabs/tabs.js
@@ -5,6 +5,7 @@ import utils from "../../core/utils";
 import dom from "../../core/dom";
 
 const logger = logging.getLogger("tabs");
+export const DEBOUNCE_TIMEOUT = 10;
 
 export default Base.extend({
     name: "tabs",
@@ -22,7 +23,10 @@ export default Base.extend({
 
     init() {
         // debounce_resize to cancel previous runs of adjust_tabs
-        const debounced_resize = utils.debounce(() => this.adjust_tabs(), 10);
+        const debounced_resize = utils.debounce(
+            () => this.adjust_tabs(),
+            DEBOUNCE_TIMEOUT
+        );
         const resize_observer = new ResizeObserver(() => {
             logger.debug("Entering resize observer");
             debounced_resize();

--- a/src/pat/tabs/tabs.js
+++ b/src/pat/tabs/tabs.js
@@ -49,6 +49,7 @@ export default Base.extend({
         this.el.classList.remove("tabs-ready");
         this.el.classList.remove("tabs-wrapped");
         this._flatten_tabs();
+        this.max_x = this._get_max_x();
         this._adjust_tabs();
         this.el.classList.add("tabs-ready");
     },
@@ -85,8 +86,6 @@ export default Base.extend({
             return;
         }
 
-        const max_x = this._get_max_x();
-
         // Check if tabs fit into one line by checking their start position not
         // exceeding the available inner width or if they are not broken to a
         // new line.
@@ -101,7 +100,7 @@ export default Base.extend({
                 parseInt(bounds.width, 10) +
                 parseInt(utils.getCSSValue(this.el, "margin-right") || 0, 10);
             logger.debug(`New tab right position: ${it_x + it_w}px.`);
-            if ((last_x && last_x > it_x) || it_x + it_w > max_x) {
+            if ((last_x && last_x > it_x) || it_x + it_w > this.max_x) {
                 // this tab exceeds initial available width or
                 // breaks into a new line when width
                 tabs_fit = false;
@@ -137,6 +136,7 @@ export default Base.extend({
                 }
             });
             this.el.append(extra_tabs);
+            this.max_x = this._get_max_x();
         }
 
         logger.debug("Prepend last tab to .extra_tabs.");

--- a/src/pat/tabs/tabs.test.js
+++ b/src/pat/tabs/tabs.test.js
@@ -1,5 +1,6 @@
 import pattern from "./tabs";
 import utils from "../../core/utils";
+import { DEBOUNCE_TIMEOUT } from "./tabs";
 
 describe("pat-tabs", function () {
     afterEach(function () {
@@ -30,7 +31,7 @@ describe("pat-tabs", function () {
 
         expect(nav.classList.contains("tabs-ready")).toBeFalsy();
         pattern.init(nav);
-        await utils.timeout(11);
+        await utils.timeout(DEBOUNCE_TIMEOUT);
 
         expect(nav.querySelector(".extra-tabs")).toBeTruthy();
         expect(nav.querySelector(".extra-tabs").children.length).toBe(1);
@@ -61,7 +62,7 @@ describe("pat-tabs", function () {
 
         expect(nav.classList.contains("tabs-ready")).toBeFalsy();
         pattern.init(nav);
-        await utils.timeout(11);
+        await utils.timeout(DEBOUNCE_TIMEOUT);
 
         expect(nav.querySelector(".extra-tabs")).toBeTruthy();
         expect(nav.querySelector(".extra-tabs").children.length).toBe(2);
@@ -92,7 +93,7 @@ describe("pat-tabs", function () {
 
         expect(nav.classList.contains("tabs-ready")).toBeFalsy();
         pattern.init(nav);
-        await utils.timeout(11);
+        await utils.timeout(DEBOUNCE_TIMEOUT);
 
         expect(nav.querySelector(".extra-tabs")).toBeFalsy();
         expect(nav.classList.contains("tabs-wrapped")).toBeFalsy();
@@ -122,7 +123,7 @@ describe("pat-tabs", function () {
 
         expect(nav.classList.contains("tabs-ready")).toBeFalsy();
         pattern.init(nav);
-        await utils.timeout(11);
+        await utils.timeout(DEBOUNCE_TIMEOUT);
 
         expect(nav.querySelector(".extra-tabs")).toBeTruthy();
         expect(nav.querySelector(".extra-tabs").children.length).toBe(3);
@@ -152,7 +153,7 @@ describe("pat-tabs", function () {
         jest.spyOn(tabs[1], "getBoundingClientRect").mockImplementation(() => { return { x: 100, width: 40 }; }); // prettier-ignore
 
         pattern.init(nav);
-        await utils.timeout(11);
+        await utils.timeout(DEBOUNCE_TIMEOUT);
 
         const extra_tabs = nav.querySelector(".extra-tabs");
 
@@ -186,11 +187,28 @@ describe("pat-tabs", function () {
         jest.spyOn(tabs[1], "getBoundingClientRect").mockImplementation(() => { return { x: 200, width: 40 }; }); // prettier-ignore
 
         pattern.init(nav);
-        await utils.timeout(11);
+        await utils.timeout(DEBOUNCE_TIMEOUT);
 
         const extra_tabs = nav.querySelector(".extra-tabs");
         expect(extra_tabs).toBeFalsy();
 
         expect(nav.classList.contains("closed")).toBeFalsy();
+    });
+
+    it("7 - The adjust_tabs method is called after 10ms.", async () => {
+        document.body.innerHTML = `<nav class="pat-tabs"></nav>`;
+        const nav = document.querySelector(".pat-tabs");
+
+        const pat = pattern.init(nav);
+        const spy_adjust_tabs = jest
+            .spyOn(pat, "adjust_tabs")
+            .mockImplementation(() => {});
+        expect(spy_adjust_tabs).not.toHaveBeenCalled();
+        await utils.timeout(1);
+        expect(spy_adjust_tabs).not.toHaveBeenCalled();
+        await utils.timeout(5);
+        expect(spy_adjust_tabs).not.toHaveBeenCalled();
+        await utils.timeout(4);
+        expect(spy_adjust_tabs).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
- fix(pat tabs): Only calculate available space twice: Once initially and then after the extra-tabs span including extra classes have been added. This should stabilize tabs calculation in some cases.
- maint(pat tabs): Test for debounce timeout.

