### PR TITLE
Fix inject parameter error

### DIFF
--- a/src/core/parser.test.js
+++ b/src/core/parser.test.js
@@ -127,6 +127,69 @@ describe("The Patterns parser", function () {
             done();
         });
 
+        it("does a type casting to the default value's type", function (done) {
+            const parser = new ArgumentParser("mypattern");
+            parser.addArgument("selector");
+            parser.addArgument("detector", 0);
+            parser.addArgument("reflector");
+            parser.addArgument("collector", false);
+            const content = document.createElement("div");
+            content.innerHTML = `
+                <div data-pat-mypattern="selector: 2; detector: 2; reflector: true; collector: true"></div>
+            `;
+            const opts = parser.parse(content.querySelector("[data-pat-mypattern]"));
+            expect(opts).toEqual({
+                selector: "2", // no typecast without default
+                detector: 2,
+                reflector: "true", // no typecast without default
+                collector: true,
+            });
+
+            done();
+        });
+
+        it("does not include defaults with inherit set to false", function (done) {
+            const parser = new ArgumentParser("mypattern");
+            parser.addArgument("selector", 0);
+            parser.addArgument("detector", 1);
+            parser.addArgument("reflector", 2);
+
+            const content = document.createElement("div");
+            content.innerHTML = `
+                <div data-pat-mypattern="selector: 2"></div>
+            `;
+            const opts = parser.parse(
+                content.querySelector("[data-pat-mypattern]"),
+                {},
+                false,
+                false
+            );
+            expect(opts).toEqual({ selector: 2 });
+
+            done();
+        });
+
+        it("does not group options when set to false", function (done) {
+            const parser = new ArgumentParser("mypattern");
+            parser.addArgument("group-one", 0);
+            parser.addArgument("group-two", 0);
+
+            const content = document.createElement("div");
+            content.innerHTML = `
+                <div data-pat-mypattern="group-one: 1; group-two: 2"></div>
+            `;
+            const opts = parser.parse(
+                content.querySelector("[data-pat-mypattern]"),
+                {},
+                false,
+                false,
+                false
+            );
+            expect(opts).toEqual({ "group-one": 1, "group-two": 2 });
+
+            done();
+        });
+
         it("only the allowed values for an argument are parsed", function () {
             var parser = new ArgumentParser();
             parser.addArgument("color", "red", ["red", "blue"]);
@@ -811,6 +874,15 @@ describe("The Patterns parser", function () {
                 var opts = { "group-foo": 15, "group": { bar: 20 } };
                 parser._cleanupOptions(opts);
                 expect(opts).toEqual({ group: { foo: 15, bar: 20 } });
+            });
+
+            it("Do not group", function () {
+                const parser = new ArgumentParser();
+                parser.addArgument("group-foo");
+                parser.addArgument("group-bar");
+                const opts = { "group-foo": 15, "group-bar": 20 };
+                parser._cleanupOptions(opts, false);
+                expect(opts).toEqual({ "group-foo": 15, "group-bar": 20 });
             });
         });
     });

--- a/src/pat/inject/index.html
+++ b/src/pat/inject/index.html
@@ -421,7 +421,7 @@
                 data-pat-inject="url:./index.html#rebase-url-demo; target: self::element"
             >
               injection happens here! <a href="tel:3632347">Call for help</a>
-            </button>
+            </a>
           </div>
         </section>
 

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -869,33 +869,33 @@ const inject = {
                 $page[0],
                 `[data-pat-${pattern_name}]`
             )) {
-                const val = el_.getAttribute(`data-pat-${pattern_name}`, false);
-                if (val) {
-                    const pattern = registry.patterns[pattern_name];
-                    const pattern_parser = pattern?.parser;
-                    if (!pattern_parser) {
-                        continue;
-                    }
-                    let options = pattern_parser._parse(val);
-                    let changed = false;
+                const pattern = registry.patterns?.[pattern_name];
+                const pattern_parser = pattern?.parser;
+                if (!pattern_parser) {
+                    continue;
+                }
+                // parse: no default options, possibly multiple configs, no grouping.
+                const options = pattern_parser.parse(el_, {}, true, false, false);
+                let changed = false;
+                for (const config of options) {
                     for (const opt of opts) {
-                        const val = options[opt];
+                        const val = config[opt];
                         if (!val) {
                             continue;
                         }
                         changed = true;
                         if (Array.isArray(val)) {
-                            options[opt] = val.map((it) => utils.rebaseURL(base, it));
+                            config[opt] = val.map((it) => utils.rebaseURL(base, it));
                         } else {
-                            options[opt] = utils.rebaseURL(base, val);
+                            config[opt] = utils.rebaseURL(base, val);
                         }
                     }
-                    if (changed) {
-                        el_.setAttribute(
-                            `data-pat-${pattern_name}`,
-                            JSON.stringify(options)
-                        );
-                    }
+                }
+                if (changed) {
+                    el_.setAttribute(
+                        `data-pat-${pattern_name}`,
+                        JSON.stringify(options.length === 1 ? options[0] : options)
+                    );
                 }
             }
         }

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -1077,14 +1077,9 @@ const inject = {
         onInteraction();
 
         ["scroll", "resize"].forEach((e) => window.addEventListener(e, onInteraction));
-        [
-            "click",
-            "keypress",
-            "keyup",
-            "mousemove",
-            "touchstart",
-            "touchend",
-        ].forEach((e) => document.addEventListener(e, onInteraction));
+        ["click", "keypress", "keyup", "mousemove", "touchstart", "touchend"].forEach(
+            (e) => document.addEventListener(e, onInteraction)
+        );
     },
 
     // XXX: simple so far to see what the team thinks of the idea


### PR DESCRIPTION
- maint(pat inject): Fix invalid HTML in demo.
- feat(core parser): Add config to not group parsed options. This allows more flexibility when reusing the parser.
-  fix(pat inject): Use the main argument parser when rebasing HTML so that it supports all kinds of arguments, including multiple configurations as seen in pat-inject and semicolons at the end of a config line after a line-break.