### PR TITLE
feat(core): acquire_attribute

### DIFF
--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -95,17 +95,30 @@ const get_parents = (el) => {
  * @param {DOM element} el - The DOM element to start the acquisition search for the given attribute.
  * @param {string} attribute - Name of the attribute to search for.
  * @param {Boolean} include_empty - Also return empty values.
+ * @param {Boolean} include_all - Return a list of attribute values found in all parents.
  *
- * @returns {*} - Returns the value of the searched attribute.
+ * @returns {*} - Returns the value of the searched attribute or a list of all attributes.
  */
-const acquire_attribute = (el, attribute, include_empty = false) => {
+const acquire_attribute = (
+    el,
+    attribute,
+    include_empty = false,
+    include_all = false
+) => {
     let _el = el;
+    const ret = []; // array for ``include_all`` mode.
     while (_el) {
         const val = _el.getAttribute(attribute);
         if (val || (include_empty && val === "")) {
-            return val;
+            if (!include_all) {
+                return val;
+            }
+            ret.push(val);
         }
         _el = _el.parentElement;
+    }
+    if (include_all) {
+        return ret;
     }
 };
 

--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -89,6 +89,26 @@ const get_parents = (el) => {
     return parents;
 };
 
+/**
+ * Return the value of the first attribute found in the list of parents.
+ *
+ * @param {DOM element} el - The DOM element to start the acquisition search for the given attribute.
+ * @param {string} attribute - Name of the attribute to search for.
+ * @param {Boolean} include_empty - Also return empty values.
+ *
+ * @returns {*} - Returns the value of the searched attribute.
+ */
+const acquire_attribute = (el, attribute, include_empty = false) => {
+    let _el = el;
+    while (_el) {
+        const val = _el.getAttribute(attribute);
+        if (val || (include_empty && val === "")) {
+            return val;
+        }
+        _el = _el.parentElement;
+    }
+};
+
 const is_visible = (el) => {
     // Check, if element is visible in DOM.
     // https://stackoverflow.com/a/19808107/1337474
@@ -169,6 +189,7 @@ const dom = {
     find_parents: find_parents,
     find_scoped: find_scoped,
     get_parents: get_parents,
+    acquire_attribute: acquire_attribute,
     is_visible: is_visible,
     create_from_string: create_from_string,
     add_event_listener: add_event_listener,

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -342,6 +342,64 @@ describe("core.dom tests", () => {
 
             done();
         });
+
+        it("includes all parents mode: return a list of all attributes found in the element parents.", (done) => {
+            document.body.innerHTML = `
+                <div lang="en">
+                    <div lang="">
+                        <div lang="ga">
+                            <div lang="it">
+                                <div lang="de">
+                                    <div id="start" lang="">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            const el = document.querySelector("#start");
+            const res = dom.acquire_attribute(el, "lang", false, true);
+            expect(res).toEqual(["de", "it", "ga", "en"]);
+
+            done();
+        });
+
+        it("includes all parents mode: also include empties, if requested.", (done) => {
+            document.body.innerHTML = `
+                <div lang="en">
+                    <div lang="">
+                        <div lang="ga">
+                            <div lang="it">
+                                <div lang="de">
+                                    <div id="start" lang="">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            const el = document.querySelector("#start");
+            const res = dom.acquire_attribute(el, "lang", true, true);
+            expect(res).toEqual(["", "de", "it", "ga", "", "en"]);
+
+            done();
+        });
+
+        it("includes all parents mode: return an empty list if nothing is found.", (done) => {
+            document.body.innerHTML = `
+                <div>
+                    <div id="start">
+                    </div>
+                </div>
+            `;
+            const el = document.querySelector("#start");
+            const res = dom.acquire_attribute(el, "lang", true, true);
+            expect(res).toEqual([]);
+
+            done();
+        });
     });
 
     describe("is_visible", () => {

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -269,6 +269,81 @@ describe("core.dom tests", () => {
         });
     });
 
+    describe("acquire_attribute", () => {
+        it("finds the first occurrence of an non-empty attribute in all parents.", (done) => {
+            document.body.innerHTML = `
+                <div lang="en">
+                    <div id="start" lang="">
+                    </div>
+                </div>
+            `;
+            const el = document.querySelector("#start");
+            const res = dom.acquire_attribute(el, "lang");
+            expect(res).toBe("en");
+
+            done();
+        });
+        it("finds the first occurrence of an attribute in all parents, even if empty.", (done) => {
+            document.body.innerHTML = `
+                <div lang="en">
+                    <div lang="">
+                        <div id="start">
+                        </div>
+                    </div>
+                </div>
+            `;
+            const el = document.querySelector("#start");
+            const res = dom.acquire_attribute(el, "lang", true);
+            expect(res).toBe("");
+
+            done();
+        });
+        it("traverses up a long way to find an attribute.", (done) => {
+            document.body.innerHTML = `
+                <div lang="en">
+                    <div>
+                        <div lang="">
+                            <div>
+                                <div lang="">
+                                    <div>
+                                        <div lang="">
+                                            <div>
+                                                <div lang="">
+                                                    <div>
+                                                        <div id="start" lang="">
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            const el = document.querySelector("#start");
+            const res = dom.acquire_attribute(el, "lang");
+            expect(res).toBe("en");
+
+            done();
+        });
+        it("just returns if it finds nothing.", (done) => {
+            document.body.innerHTML = `
+                <div>
+                    <div id="start">
+                    </div>
+                </div>
+            `;
+            const el = document.querySelector("#start");
+            const res = dom.acquire_attribute(el, "lang");
+            expect(res).toBe(undefined);
+
+            done();
+        });
+    });
+
     describe("is_visible", () => {
         it.skip("checks, if an element is visible or not.", (done) => {
             const div1 = document.createElement("div");

--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -1,5 +1,6 @@
 import "regenerator-runtime/runtime"; // needed for ``await`` support
 import Base from "../../core/base";
+import dom from "../../core/dom";
 import logging from "../../core/logging";
 import Modal from "../modal/modal";
 import Parser from "../../core/parser";
@@ -150,10 +151,7 @@ export default Base.extend({
         config.plugins = [fcDayGrid, fcInteraction, fcList, fcLuxon, fcTimeGrid];
         config.eventColor = this.options.eventColor;
 
-        let lang =
-            this.options.lang ||
-            document.querySelector("html").getAttribute("lang") ||
-            "en";
+        let lang = this.options.lang || dom.acquire_attribute(this.el, "lang") || "en";
         // we don't support any country-specific language variants, always use first 2 letters
         lang = lang.substr(0, 2).toLowerCase();
         if (lang !== "en") {

--- a/src/pat/calendar/calendar.test.js
+++ b/src/pat/calendar/calendar.test.js
@@ -374,6 +374,28 @@ describe("1 - Calendar tests", () => {
         const title_el = el.querySelector(".cal-title");
         expect(title_el.innerHTML).toEqual("March 2020");
     });
+
+    it("Loads correct locale if set", async () => {
+        const el = document.querySelector(".pat-calendar");
+        el.setAttribute("data-pat-calendar", "initial-date: 2020-03-01; lang: de");
+        pattern.init(el);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        const title_el = el.querySelector(".cal-title");
+        expect(title_el.innerHTML).toEqual("März 2020");
+    });
+
+    it("Loads correct locale if set in parent container", async () => {
+        // Set language on .root-element container
+        document.querySelector(".root-element").setAttribute("lang", "de");
+        const el = document.querySelector(".pat-calendar");
+        el.setAttribute("data-pat-calendar", "initial-date: 2020-03-01");
+        pattern.init(el);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        const title_el = el.querySelector(".cal-title");
+        expect(title_el.innerHTML).toEqual("März 2020");
+    });
 });
 
 describe("2 - Calendar tests with calendar controls outside pat-calendar", () => {

--- a/src/pat/display-time/display-time.js
+++ b/src/pat/display-time/display-time.js
@@ -1,6 +1,7 @@
 import "regenerator-runtime/runtime"; // needed for ``await`` support
 import Base from "../../core/base";
 import Parser from "../../core/parser";
+import dom from "../../core/dom";
 import logging from "../../core/logging";
 
 // Lazy loading modules.
@@ -27,7 +28,7 @@ export default Base.extend({
 
         this.options = parser.parse(this.el, this.options);
 
-        let lang = this.options.locale || document.querySelector("html").lang || "en";
+        let lang = this.options.locale || dom.acquire_attribute(this.el, "lang") || "en";
         // we don't support any country-specific language variants, always use first 2 letters
         lang = lang.substr(0, 2).toLowerCase();
         try {

--- a/src/pat/display-time/display-time.test.js
+++ b/src/pat/display-time/display-time.test.js
@@ -59,6 +59,24 @@ describe("pat-display-time tests", () => {
         expect(el.textContent).toBe("April Donnerstag 22. 2021, 4:00:00");
     });
 
+    it("Example setting the output format in German due containment in German container", async () => {
+        document.body.innerHTML = `
+          <section lang="de">
+              <time
+                  class="pat-display-time"
+                  datetime="2021-04-22T23:00Z"
+                  data-pat-display-time="output-format: MMMM dddd Do YYYY, h:mm:ss">
+              </time>
+          </section>
+        `;
+        const el = document.querySelector(".pat-display-time");
+
+        Pattern.init(el);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        expect(el.textContent).toBe("April Donnerstag 22. 2021, 4:00:00");
+    });
+
     it("Output formatted as local", async () => {
         document.body.innerHTML = `
           <time


### PR DESCRIPTION
Byproduct in working in scr-1389.

With the new method ``acquire_attribute`` we can e.g. get a context-specific language attribute within the DOM tree instead of just using the language form the HTML top element.


- feat(core dom): Add acquire_attribute to get the value of the first occurrence of a defined attribute up the DOM tree.

- feat(core dom): Add parameter to acquire_attribute to return a list of all found attributes up the DOM tree.