### PR TITLE
pat-scroll-box: Timeout tweaks

### DIFF
--- a/src/pat/scroll-box/scroll-box.js
+++ b/src/pat/scroll-box/scroll-box.js
@@ -1,12 +1,12 @@
 import Base from "../../core/base";
 
+export const TIMEOUT_FIRST_CALLBACK = 40; // Timeout for first run of the callback
+export const TIMEOUT_CALLBACK = 200; // Timeout for subsequent runs of the callback
+export const TIMEOUT_PAUSE = 600; // Timeout to detect scrolling pause and reset for TIMEOUT_FIRST_CALLBACK
+
 export default Base.extend({
     name: "scroll-box",
     trigger: ".pat-scroll-box",
-
-    // A timeout of 200 works good for smooth scrolling on trackpads.
-    // With low values like 10 or 50 sometimes no change in scroll position is detected.
-    timeout: 200,
 
     scroll_listener: null,
     last_known_scroll_position: 0,
@@ -35,7 +35,7 @@ export default Base.extend({
                     const scroll_y = this.get_scroll_y();
                     this.set_scroll_classes(scroll_y);
                     this.last_known_scroll_position = scroll_y;
-                }, 10);
+                }, TIMEOUT_FIRST_CALLBACK);
                 // Set a dummy timeout_id and return.
                 // Next scroll event should not reach this block but start with
                 // default callback scheduling.
@@ -48,16 +48,14 @@ export default Base.extend({
                 const scroll_y = this.get_scroll_y();
                 this.set_scroll_classes(scroll_y);
                 this.last_known_scroll_position = scroll_y;
-            }, this.timeout);
+            }, TIMEOUT_CALLBACK);
 
-            // Reset the timeout_id after a multiple of timeout when scrolling
-            // has stopped for sure.
-            // Then, when scrolling again the scroll classes are set
-            // immediately and at the end of a series of scroll events.
+            // Reset the timeout_id after when he user stops scrolling.
+            // When scrolling again the scroll classes are set again after TIMEOUT_FIRST_CALLBACK
             window.clearTimeout(this.timeout_id__scroll_stop);
             this.timeout_id__scroll_stop = window.setTimeout(() => {
                 this.timeout_id = null;
-            }, Math.max(500, this.timeout * 3)); // Note: should be more than the timespan in which scroll events are thrown.
+            }, TIMEOUT_PAUSE);
         });
 
         // Set initial state

--- a/src/pat/scroll-box/scroll-box.test.js
+++ b/src/pat/scroll-box/scroll-box.test.js
@@ -1,4 +1,8 @@
-import pattern from "./scroll-box";
+import pattern, {
+    TIMEOUT_CALLBACK,
+    TIMEOUT_FIRST_CALLBACK,
+    TIMEOUT_PAUSE,
+} from "./scroll-box";
 import utils from "../../core/utils";
 
 describe("pat-scroll-box", function () {
@@ -18,51 +22,52 @@ describe("pat-scroll-box", function () {
 
         const spy_set_scroll_classes = jest.spyOn(instance, "set_scroll_classes");
 
-        // First invocation is after 10ms
+        // First invocation is after TIMEOUT_FIRST_CALLBACK
         el.dispatchEvent(new Event("scroll"));
-        await utils.timeout(3);
+        await utils.timeout(1);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(0);
-        await utils.timeout(7);
+        await utils.timeout(TIMEOUT_FIRST_CALLBACK - 1);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(1);
         // No other callback invocations with just one scroll event.
-        await utils.timeout(200);
+        await utils.timeout(TIMEOUT_CALLBACK - TIMEOUT_FIRST_CALLBACK - 1);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(1);
 
-        // Now, subsequent scroll events invoke the callback after 200ms
+        // Now, subsequent scroll events invoke the callback after TIMEOUT_CALLBACK
         // But multiple scroll events don't lead to multiple callback invocations.
         el.dispatchEvent(new Event("scroll"));
         await utils.timeout(1);
         el.dispatchEvent(new Event("scroll"));
         await utils.timeout(1);
         el.dispatchEvent(new Event("scroll"));
-        // After 10ms no NEW cb invocation
-        await utils.timeout(10);
+        // After TIMEOUT_FIRST_CALLBACK no NEW cb invocation
+        await utils.timeout(TIMEOUT_FIRST_CALLBACK);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(1);
-        // After 200ms there should be another cb invocation
-        await utils.timeout(190);
+        // After TIMEOUT_CALLBACK there should be another cb invocation
+        await utils.timeout(TIMEOUT_CALLBACK - TIMEOUT_FIRST_CALLBACK);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(2);
         // But without a new scroll event no more callback invocations.
-        await utils.timeout(200);
+        await utils.timeout(TIMEOUT_CALLBACK);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(2);
 
         // Another scroll event, another callback invocation after 200ms
         // We have to dispatch again
         el.dispatchEvent(new Event("scroll"));
-        // After 10ms no NEW cb invocation
-        await utils.timeout(10);
+        // After TIMEOUT_FIRST_CALLBACK no NEW cb invocation
+        await utils.timeout(TIMEOUT_FIRST_CALLBACK);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(2);
-        // After 200ms there should be another cb invocation
-        await utils.timeout(190);
+        // After TIMEOUT_CALLBACK there should be another cb invocation
+        await utils.timeout(TIMEOUT_CALLBACK - TIMEOUT_FIRST_CALLBACK);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(3);
 
-        // Let's wait for 3*200ms to reset and start again with the first call after 10ms.
+        // Let's wait for TIMEOUT_PAUSE to reset and start again with the
+        // first call after TIMEOUT_FIRST_CALLBACK.
         // The user probably stopped scrolling and starts over again
-        await utils.timeout(600);
+        await utils.timeout(TIMEOUT_PAUSE);
         el.dispatchEvent(new Event("scroll"));
-        await utils.timeout(10);
+        await utils.timeout(TIMEOUT_FIRST_CALLBACK);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(4);
         el.dispatchEvent(new Event("scroll"));
-        await utils.timeout(200);
+        await utils.timeout(TIMEOUT_CALLBACK);
         expect(spy_set_scroll_classes).toHaveBeenCalledTimes(5);
     });
 });


### PR DESCRIPTION
pat-scroll-box: Tweak timeouts for a better user experience. 40ms for the first callback covers fast scrolling better and does not have a noticeable impact on setting classes a little later. Adapt tests to use configurable timeouts.