### PR TITLE
pat-calendar: Fix `time-format` parameter

### DIFF
--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -47,7 +47,11 @@ parser.addArgument("height", "auto");
 parser.addArgument("ignore-url", false);
 parser.addArgument("lang", null); // If not set, use "en" (See below)
 parser.addArgument("store", "none", ["none", "session", "local"]);
-parser.addArgument("time-format", "h(:mm)t");
+parser.addArgument("time-format-hour", null, [null, "numeric", "2-digit"]);
+parser.addArgument("time-format-minute", null, [null, "numeric", "2-digit"]);
+parser.addArgument("time-format-second", null, [null, "numeric", "2-digit"]);
+parser.addArgument("time-format-twelvehours", null, [true, false]);
+parser.addArgument("time-format-meridiem", null, [null, "false", "narrow", "short"]);
 parser.addArgument("timezone", null);
 parser.addArgument("title-day", "dddd, MMM d, YYYY");
 parser.addArgument("title-month", "MMMM YYYY");
@@ -172,6 +176,30 @@ export default Base.extend({
         let timezone = this.el_timezone?.value || this.options.timezone || null;
         if (timezone) {
             config.timeZone = timezone;
+        }
+
+        let eventTimeFormat = {};
+        if (this.options.time["format-hour"] !== null) {
+            eventTimeFormat["hour"] = this.options.time["format-hour"];
+        }
+        if (this.options.time["format-minute"] !== null) {
+            eventTimeFormat["minute"] = this.options.time["format-minute"];
+        }
+        if (this.options.time["format-second"] !== null) {
+            eventTimeFormat["second"] = this.options.time["format-second"];
+        }
+        if (this.options.time["format-twelvehours"] !== null) {
+            eventTimeFormat["hour12"] = this.options.time["format-twelvehours"];
+        }
+        if (this.options.time["format-meridiem"] !== null) {
+            if (this.options.time["format-meridiem"] == "false") {
+                eventTimeFormat["meridiem"] = false;
+            } else {
+                eventTimeFormat["meridiem"] = this.options.time["format-meridiem"];
+            }
+        }
+        if (Object.keys(eventTimeFormat).length > 0) {
+            config.eventTimeFormat = eventTimeFormat;
         }
 
         const sources = [...(this.options.event.sources || [])];

--- a/src/pat/calendar/calendar.test.js
+++ b/src/pat/calendar/calendar.test.js
@@ -9,8 +9,8 @@ const mockFetch = () =>
                 items: [
                     {
                         title: "Event 1",
-                        start: "2020-10-10T10:00:00Z",
-                        end: "2020-10-10T12:00:00Z",
+                        start: "2020-10-10T16:00:00Z",
+                        end: "2020-10-10T18:00:00Z",
                     },
                     {
                         "title": "Event 2",
@@ -100,6 +100,25 @@ describe("1 - Calendar tests", () => {
         registry.scan(document.body);
         await utils.timeout(1); // wait a tick for async to settle.
         expect(el.querySelector(".fc-timeGridDay-view")).toBeTruthy();
+    });
+
+    it("Formats time according to the configuration", async () => {
+        const el = document.querySelector(".pat-calendar");
+        el.setAttribute(
+            "data-pat-calendar",
+            `time-format-hour: 2-digit; time-format-twelvehours: false; lang: en;
+             initial-date: 2020-10-10; timezone: Europe/Berlin; url: ./test.json;`
+        );
+
+        global.fetch = jest.fn().mockImplementation(mockFetch);
+
+        registry.scan(document.body);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        expect(document.querySelector(".event-source--1 .fc-event-time").textContent).toBe("18");
+
+        global.fetch.mockClear();
+        delete global.fetch;
     });
 
     it("Updates title according to display", async () => {

--- a/src/pat/calendar/documentation.md
+++ b/src/pat/calendar/documentation.md
@@ -55,7 +55,11 @@ The calendar can be configured through a `data-pat-calendar` attribute. The avai
 | `height`                  | auto              |                                                   |
 | `ignore-url`              |                   |                                                   |
 | `store`                   | none              | none, session, local                              |
-| `time-format`             | h(:mm)t           |                                                   |
+| `time-format-hour`        |                   | null, "numeric", "2-digit"                        |
+| `time-format-minute`      |                   | null, "numeric", "2-digit"                        |
+| `time-format-second`      |                   | null, "numeric", "2-digit"                        |
+| `time-format-meridiem`    |                   | null, false, "narrow", "short"                    |
+| `time-format-twelvehours` |                   | null, true, false                                 |
 | `title-day`               | dddd, MMM d, YYYY |                                                   |
 | `title-month`             | MMMM YYYY         |                                                   |
 | `title-week`              | MMM D YYYY        |                                                   |

--- a/src/pat/calendar/index.html
+++ b/src/pat/calendar/index.html
@@ -26,8 +26,12 @@
                                 pat-switch-selector: #event-info;
                                 pat-switch-remove: event-info--inactive;
                                 pat-switch-add: event-info--active;
-                                timezone: Europe/Berlin;
                                 lang: en;
+                                time-format-hour: 2-digit;
+                                time-format-minute: 2-digit;
+                                time-format-meridiem: false;
+                                time-format-twelvehours: false;
+                                timezone: Europe/Berlin;
                                 store: local;">
             <form class="pat-toolbar cal-toolbar pat-form"
                   id="calendar-toolbar">

--- a/src/pat/calendar/test_event_source.json
+++ b/src/pat/calendar/test_event_source.json
@@ -2,8 +2,8 @@
   "items": [
     {
       "title": "Event 1",
-      "start": "2020-10-10T10:00:00",
-      "end": "2020-10-10T12:00:00",
+      "start": "2020-10-10T16:00:00",
+      "end": "2020-10-10T18:00:00",
       "class": "hello-class-1 hello-class-2 calendar-section1-category1",
       "@id": "./test_event.html"
     },
@@ -18,7 +18,8 @@
       "title": "Event 3",
       "start": "2020-10-14",
       "end": "2020-10-16",
-      "class": "calendar-section2-category1"
+      "class": "calendar-section2-category1",
+      "whole_day": true
     },
     {
       "title": "Event 4",


### PR DESCRIPTION
`time-format` was ignored by pat-calendar prior to this PR. It probably used to map to `timeFormat` which does not exist any more in FullCalendar version 5. The new eventTimeFormat has a different spec, see https://fullcalendar.io/docs/eventTimeFormat