### PR TITLE
[WIP] pat-modal: rework event registration to not multi-run handlers

### DIFF
--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -109,7 +109,7 @@ const event_listener_map = {};
 
 /**
  * Add an event listener to a DOM element under a unique id.
- * If a event is registered under the same id for the same element, the old hander is removed first.
+ * If a event is registered under the same id for the same element, the old handler is removed first.
  *
  * @param {DOM Node} el - The element to register the event for.
  * @param {string} event_type - The event type to listen for.

--- a/src/pat/modal/modal.js
+++ b/src/pat/modal/modal.js
@@ -208,9 +208,9 @@ export default Base.extend({
             // once that has been triggered
             const destroy_handler = () => {
                 this.destroy();
-                $("body").off("patterns-inject-triggered", destroy_handler);
+                $("body").off("pat-inject-success", destroy_handler);
             };
-            $("body").on("patterns-inject-triggered", destroy_handler.bind(this));
+            $("body").on("pat-inject-success", destroy_handler.bind(this));
         } else {
             // if working without injection, destroy after waiting a tick to let
             // eventually registered on-submit handlers kick in first.


### PR DESCRIPTION
Note: Since this changes event handler registration from jQuery to plain JavaScript this PR could possibly break things.
This should go into the next major release where more testing is needed anyways.