### PR TITLE
New format-time parameter

### DIFF
--- a/src/pat/calendar/calendar.js
+++ b/src/pat/calendar/calendar.js
@@ -48,7 +48,7 @@ parser.addArgument("height", "auto");
 parser.addArgument("ignore-url", false);
 parser.addArgument("lang", null); // If not set, use "en" (See below)
 parser.addArgument("store", "none", ["none", "session", "local"]);
-parser.addArgument("time-format", "h(:mm)t");
+parser.addArgument("time-format", "24h", ["24h", "12h"]);
 parser.addArgument("timezone", null);
 parser.addArgument("title-day", "dddd, MMM d, YYYY");
 parser.addArgument("title-month", "MMMM YYYY");
@@ -170,6 +170,22 @@ export default Base.extend({
         let timezone = this.el_timezone?.value || this.options.timezone || null;
         if (timezone) {
             config.timeZone = timezone;
+        }
+
+        if (this.options.timeFormat == "12h") {
+            // 12h format
+            config.eventTimeFormat = {
+                hour12: true,
+                meridiem: "narrow",
+                hour: "numeric",
+            };
+        } else {
+            // 24h format
+            config.eventTimeFormat = {
+                hour12: false,
+                meridiem: "false",
+                hour: "numeric",
+            };
         }
 
         const sources = [...(this.options.event.sources || [])];

--- a/src/pat/calendar/calendar.test.js
+++ b/src/pat/calendar/calendar.test.js
@@ -9,8 +9,8 @@ const mockFetch = () =>
                 items: [
                     {
                         title: "Event 1",
-                        start: "2020-10-10T10:00:00Z",
-                        end: "2020-10-10T12:00:00Z",
+                        start: "2020-10-10T16:00:00Z",
+                        end: "2020-10-10T18:00:00Z",
                     },
                     {
                         "title": "Event 2",
@@ -100,6 +100,66 @@ describe("1 - Calendar tests", () => {
         registry.scan(document.body);
         await utils.timeout(1); // wait a tick for async to settle.
         expect(el.querySelector(".fc-timeGridDay-view")).toBeTruthy();
+    });
+
+    it("Uses 24h time format by default", async () => {
+        const el = document.querySelector(".pat-calendar");
+        el.setAttribute(
+            "data-pat-calendar",
+            `lang: en; initial-date: 2020-10-10; timezone: Europe/Berlin; url: ./test.json;`
+        );
+
+        global.fetch = jest.fn().mockImplementation(mockFetch);
+
+        registry.scan(document.body);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        expect(
+            document.querySelector(".event-source--1 .fc-event-time").textContent
+        ).toBe("18");
+
+        global.fetch.mockClear();
+        delete global.fetch;
+    });
+
+    it("Uses 24h time format also with invalid configuration", async () => {
+        const el = document.querySelector(".pat-calendar");
+        el.setAttribute(
+            "data-pat-calendar",
+            `lang: en; time-format: h(:mm)t; initial-date: 2020-10-10; timezone: Europe/Berlin; url: ./test.json;`
+        );
+
+        global.fetch = jest.fn().mockImplementation(mockFetch);
+
+        registry.scan(document.body);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        expect(
+            document.querySelector(".event-source--1 .fc-event-time").textContent
+        ).toBe("18");
+
+        global.fetch.mockClear();
+        delete global.fetch;
+    });
+
+    it("Uses 12h time format if configured", async () => {
+        const el = document.querySelector(".pat-calendar");
+        el.setAttribute(
+            "data-pat-calendar",
+            `lang: en; time-format: 12h; initial-date: 2020-10-10; timezone: Europe/Berlin; url: ./test.json;`
+        );
+
+        global.fetch = jest.fn().mockImplementation(mockFetch);
+
+        registry.scan(document.body);
+        await utils.timeout(1); // wait a tick for async to settle.
+
+        expect(
+            document.querySelector(".event-source--1 .fc-event-time").textContent
+        ).toBe("6p");
+
+        global.fetch.mockClear();
+        delete global.fetch;
     });
 
     it("Updates title according to display", async () => {

--- a/src/pat/calendar/documentation.md
+++ b/src/pat/calendar/documentation.md
@@ -55,7 +55,7 @@ The calendar can be configured through a `data-pat-calendar` attribute. The avai
 | `height`                  | auto              |                                                   |
 | `ignore-url`              |                   |                                                   |
 | `store`                   | none              | none, session, local                              |
-| `time-format`             | h(:mm)t           |                                                   |
+| `time-format`             | 24h               | 24h, 12h                                          | Time format (12 hour or 24 hour clock) to display on events. |
 | `title-day`               | dddd, MMM d, YYYY |                                                   |
 | `title-month`             | MMMM YYYY         |                                                   |
 | `title-week`              | MMM D YYYY        |                                                   |

--- a/src/pat/calendar/index.html
+++ b/src/pat/calendar/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>Demo page</title>
@@ -15,7 +15,7 @@
         <div id="event-info" class="event-info--inactive">event info here!</div>
 
         <div class="pat-calendar"
-             lang="de"
+             lang="en"
              data-pat-calendar="category-controls: .cal-categories;
                                 event-sources: ./test_event_source.json,./test_event_source2.json;
                                 add-url: ./test_add_event.html;

--- a/src/pat/calendar/test_event_source.json
+++ b/src/pat/calendar/test_event_source.json
@@ -2,8 +2,8 @@
   "items": [
     {
       "title": "Event 1",
-      "start": "2020-10-10T10:00:00",
-      "end": "2020-10-10T12:00:00",
+      "start": "2020-10-10T16:00:00",
+      "end": "2020-10-10T18:00:00",
       "class": "hello-class-1 hello-class-2 calendar-section1-category1",
       "@id": "./test_event.html"
     },


### PR DESCRIPTION
Possible values: `12h`, `24h`; default: `24h`. See quaive/ploneintranet#3658

Closes #915 