### PR TITLE
dont include the time in relative formatting if the  original date is a date-only and not a date-time object.

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -431,6 +431,12 @@ function isElementInViewport(el, partial = false, offset = 0) {
     }
 }
 
+/* parseTime - Parse a duration from a string and return the parsed time in milliseconds.
+ *
+ * @param {String} time - A duration/time string like ``1ms``, ``1s`` or ``1m``.
+ *
+ * @returns {Number} - A integer which represents the parsed time in milliseconds.
+ */
 function parseTime(time) {
     var m = /^(\d+(?:\.\d+)?)\s*(\w*)/.exec(time);
     if (!m) {
@@ -642,6 +648,17 @@ const is_iso_date_time = (value, optional_time = false) => {
     return re_date_time.test(value);
 };
 
+/**
+ * Return true, if the given value is a valid ISO 8601 date string and without a time component.
+ *
+ * @param {String} value - The date value to be checked.
+ * @return {Boolean} - True, if the given value is a valid ISO 8601 date string without a time component. False if not.
+ */
+const is_iso_date = (value) => {
+    const re_date_time = /^\d{4}-[01]\d-[0-3]\d$/;
+    return re_date_time.test(value);
+};
+
 var utils = {
     // pattern pimping - own module?
     jqueryPlugin: jqueryPlugin,
@@ -673,6 +690,7 @@ var utils = {
     escape_html: escape_html,
     unescape_html: unescape_html,
     is_iso_date_time: is_iso_date_time,
+    is_iso_date: is_iso_date,
     getCSSValue: dom.get_css_value, // BBB: moved to dom. TODO: Remove in upcoming version.
 };
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -1,6 +1,8 @@
 import $ from "jquery";
 import dom from "./dom";
 
+const _MS_PER_DAY = 1000 * 60 * 60 * 24; // Milliseconds per day.
+
 $.fn.safeClone = function () {
     var $clone = this.clone();
     // IE BUG : Placeholder text becomes actual value after deep clone on textarea
@@ -659,6 +661,22 @@ const is_iso_date = (value) => {
     return re_date_time.test(value);
 };
 
+/**
+ * Return the number of days between two dates.
+ * Based on: https://stackoverflow.com/a/15289883/1337474
+ *
+ * @param {Date} date_1 - First date to compare. We will substract date_2 from date_1.
+ * @param {Date} date_2 - Second date to compare.
+ * @return {Number} - The number of days between the two dates.
+ */
+const date_diff = (date_1, date_2) => {
+    // Discard the time and time-zone information.
+    const utc_1 = Date.UTC(date_1.getFullYear(), date_1.getMonth(), date_1.getDate());
+    const utc_2 = Date.UTC(date_2.getFullYear(), date_2.getMonth(), date_2.getDate());
+
+    return Math.floor((utc_1 - utc_2) / _MS_PER_DAY);
+};
+
 var utils = {
     // pattern pimping - own module?
     jqueryPlugin: jqueryPlugin,
@@ -691,6 +709,7 @@ var utils = {
     unescape_html: unescape_html,
     is_iso_date_time: is_iso_date_time,
     is_iso_date: is_iso_date,
+    date_diff: date_diff,
     getCSSValue: dom.get_css_value, // BBB: moved to dom. TODO: Remove in upcoming version.
 };
 

--- a/src/core/utils.test.js
+++ b/src/core/utils.test.js
@@ -748,3 +748,26 @@ describe("is_iso_date_time ...", function () {
         expect(utils.is_iso_date_time("2022-05-04T21", true)).toBe(false);
     });
 });
+
+describe("is_iso_date ...", function () {
+    it("detects valid date objects", () => {
+        // Return true on a valid ISO 8601 date.
+        expect(utils.is_iso_date("2022-05-04")).toBe(true);
+
+        // A time component is not allowed.
+        expect(utils.is_iso_date("2022-05-04T21:00")).toBe(false);
+
+        // We actually do not strictly check for a valid datetime, just if the
+        // format is correct.
+        expect(utils.is_iso_date("2222-19-39")).toBe(true);
+
+        // But some basic constraints are in place
+        expect(utils.is_iso_date("2222-20-40")).toBe(false);
+
+        // And this is for sure no valid date/time
+        expect(utils.is_iso_date("not2-ok-40")).toBe(false);
+
+        // This neigher
+        expect(utils.is_iso_date("2022-05-04ok")).toBe(false);
+    });
+});

--- a/src/core/utils.test.js
+++ b/src/core/utils.test.js
@@ -771,3 +771,28 @@ describe("is_iso_date ...", function () {
         expect(utils.is_iso_date("2022-05-04ok")).toBe(false);
     });
 });
+
+describe("date_diff ...", function () {
+    it("4 days ago...", () => {
+        const date_1 = new Date();
+        date_1.setDate(date_1.getDate() - 4);
+        const date_2 = new Date();
+        expect(utils.date_diff(date_1, date_2)).toBe(-4);
+    });
+    it("4 days up...", () => {
+        const date_1 = new Date();
+        date_1.setDate(date_1.getDate() + 4);
+        const date_2 = new Date();
+        expect(utils.date_diff(date_1, date_2)).toBe(4);
+    });
+    it("1 day ago over DST change...", () => {
+        const date_1 = new Date("Sun Oct 29 2022 10:00:00 GMT+0200"); // Before DST change
+        const date_2 = new Date("Sun Oct 30 2022 10:00:00 GMT+0100"); // After DST change
+        expect(utils.date_diff(date_1, date_2)).toBe(-1);
+    });
+    it("1 day up over DST change...", () => {
+        const date_1 = new Date("Sun Oct 30 2022 10:00:00 GMT+0100"); // After DST change
+        const date_2 = new Date("Sun Oct 29 2022 10:00:00 GMT+0200"); // Before DST change
+        expect(utils.date_diff(date_1, date_2)).toBe(1);
+    });
+});

--- a/src/pat/display-time/display-time.test.js
+++ b/src/pat/display-time/display-time.test.js
@@ -185,4 +185,149 @@ describe("pat-display-time tests", () => {
 
         expect(el.textContent).toBe("");
     });
+
+    describe("3 - from-now (relative date) with date only dates", () => {
+        it("3.1 - Today", async () => {
+            const date = new Date();
+            const iso_date = date.toISOString().split("T")[0];
+
+            document.body.innerHTML = `
+              <time
+                  class="pat-display-time"
+                  datetime="${iso_date}"
+                  data-pat-display-time="from-now: true">
+              </time>
+            `;
+            const el = document.querySelector(".pat-display-time");
+
+            Pattern.init(el);
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(el.textContent).toBe("today");
+        });
+
+        it("3.2 - Tomorrow", async () => {
+            const date = new Date();
+            date.setDate(date.getDate() + 1);
+            const iso_date = date.toISOString().split("T")[0];
+
+            document.body.innerHTML = `
+              <time
+                  class="pat-display-time"
+                  datetime="${iso_date}"
+                  data-pat-display-time="from-now: true">
+              </time>
+            `;
+            const el = document.querySelector(".pat-display-time");
+
+            Pattern.init(el);
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(el.textContent).toBe("tomorrow");
+        });
+
+        it("3.3 - Yesterday", async () => {
+            const date = new Date();
+            date.setDate(date.getDate() - 1);
+            const iso_date = date.toISOString().split("T")[0];
+
+            document.body.innerHTML = `
+              <time
+                  class="pat-display-time"
+                  datetime="${iso_date}"
+                  data-pat-display-time="from-now: true">
+              </time>
+            `;
+            const el = document.querySelector(".pat-display-time");
+
+            Pattern.init(el);
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(el.textContent).toBe("yesterday");
+        });
+
+        it("3.4 - Next week", async () => {
+            const date = new Date(); // Use the system date.
+            date.setDate(date.getDate() + 4);
+            const iso_date = date.toISOString().split("T")[0];
+
+            document.body.innerHTML = `
+              <time
+                  class="pat-display-time"
+                  datetime="${iso_date}"
+                  data-pat-display-time="from-now: true">
+              </time>
+            `;
+            const el = document.querySelector(".pat-display-time");
+
+            Pattern.init(el);
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            // Match any of these as we did not mock the system date.
+            expect(el.textContent).toMatch(
+                /Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/
+            );
+        });
+
+        it("3.5 - Last week", async () => {
+            const date = new Date(); // Use the system date.
+            date.setDate(date.getDate() - 4);
+            const iso_date = date.toISOString().split("T")[0];
+
+            document.body.innerHTML = `
+              <time
+                  class="pat-display-time"
+                  datetime="${iso_date}"
+                  data-pat-display-time="from-now: true">
+              </time>
+            `;
+            const el = document.querySelector(".pat-display-time");
+
+            Pattern.init(el);
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            // Match any of these as we did not mock the system date.
+            expect(el.textContent).toBe("4 days ago");
+        });
+
+        it("3.6 - 10 days in the future", async () => {
+            const date = new Date();
+            date.setDate(date.getDate() + 10);
+            const iso_date = date.toISOString().split("T")[0];
+
+            document.body.innerHTML = `
+              <time
+                  class="pat-display-time"
+                  datetime="${iso_date}"
+                  data-pat-display-time="from-now: true">
+              </time>
+            `;
+            const el = document.querySelector(".pat-display-time");
+
+            Pattern.init(el);
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(el.textContent).toBe("in 10 days");
+        });
+
+        it("3.7 - 10 days in the past", async () => {
+            const date = new Date();
+            date.setDate(date.getDate() - 10);
+            const iso_date = date.toISOString().split("T")[0];
+
+            document.body.innerHTML = `
+              <time
+                  class="pat-display-time"
+                  datetime="${iso_date}"
+                  data-pat-display-time="from-now: true">
+              </time>
+            `;
+            const el = document.querySelector(".pat-display-time");
+
+            Pattern.init(el);
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(el.textContent).toBe("10 days ago");
+        });
+    });
 });

--- a/src/pat/display-time/documentation.md
+++ b/src/pat/display-time/documentation.md
@@ -4,3 +4,23 @@ A pattern that makes dates easier to read.
 
 ## Documentation
 
+Example:
+
+     <time class="pat-display-time"
+           datetime="2015-01-20T08:00Z"
+           data-pat-display-time="from-now: true"
+     >
+     </time>
+
+
+### Options reference
+
+| Property          | Default value                               | Description                                                                                                                                                                                                                                                                                                                                                                                     | Type                                         |
+| ----------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `output-format`   |                                             | For non-relative dates (the default, `from-now` set to `false`) show the date in the given format. For formatting options see: https://momentjs.com/docs/#/displaying/format/   | String  |
+| `from-now`        | `false`                                     | Change the date to a relative date, relative from now.                                                                                                                           | Boolean |
+| `no-suffix`       | `false`                                     | For relative dates and no-suffix is set to `true`, do not show the suffix like `8 years` instead of `8 years ago`.                                                              | Boolean |
+| `format`          |                                             | Input parsing format. If not given (the default) the format is set automatically, if possible. For more information, see: https://momentjs.com/docs/#/parsing/string-format/    | String  |
+| `locale`          |                                             | The locale to translate the resulting date/time string into. If not given (the default) the locale is retrieved from a `lang` attribute up in the DOM tree or `en`.             | String  |
+| `strict`          | `false`                                     | Strict parsing for the input format. See: https://momentjs.com/guides/#/parsing/strict-mode/                                                                                    | Boolean |
+

--- a/src/pat/display-time/index.html
+++ b/src/pat/display-time/index.html
@@ -1,164 +1,148 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-        <title>pat-display-time demo</title>
-        <link rel="stylesheet" href="/style/common.css" type="text/css" />
-        <script
+  <head>
+    <meta http-equiv="content-type"
+          content="text/html; charset=utf-8"
+    />
+    <title>pat-display-time demo</title>
+    <link href="/style/common.css"
+          rel="stylesheet"
+          type="text/css"
+    />
+    <script charset="utf-8"
             src="/bundle.min.js"
             type="text/javascript"
-            charset="utf-8"
-        ></script>
-    </head>
+    ></script>
+  </head>
 
-    <body
-        role="document">
-        <div
-            class="pat-rich">
-            <h2>Example of default</h2>
-            <h3>Code</h3>
-        </div>
+  <body role="document">
 
-<pre
-    class="pat-syntax-highlight">
-&lt;time
-    class="pat-display-time"
-    datetime="2015-01-20T08:00Z"&gt;
-    20 January 2015, 08:00
-&lt;/time&gt;
-</pre>
+    <section>
+      <header><h2>1 - Basic examples</h2></header>
 
-        <div
-            class="pat-rich">
-            <h3>Output</h3>
-            <p>
-                <time class="pat-display-time" datetime="2015-01-20T08:00Z">
-                    20 January 2015, 08:00
-                </time>
-            </p>
+      <div>
+        <h3>1.1 - Default</h3>
 
-            <hr />
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+  &lt;time
+      class="pat-display-time"
+      datetime="2015-01-20T08:00Z"&gt;
+      20 January 2015, 08:00
+  &lt;/time&gt;
+      </pre>
 
-            <h2>Example setting the output format explicitly</h2>
-            <h3>Code</h3>
-        </div>
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time"
+                datetime="2015-01-20T08:00Z"
+          >
+          </time>
+        </p>
+      </div>
 
-<pre
-    class="pat-syntax-highlight">
-&lt;time
-    class="pat-display-time"
-    datetime="2015-01-20T08:00Z"
-    data-pat-display-time="output-format: MMMM dddd Do YYYY, h:mm:ss a"&gt;
-    20 January 2015, 08:00
-&lt;/time&gt;
-</pre>
+      <div>
+        <h3>1.2 - Example setting the output format explicitly</h3>
 
-        <div
-            class="pat-rich">
-            <h3>Output</h3>
-            <p>
-                <time
-                    class="pat-display-time"
-                    datetime="2015-01-20T08:00Z"
-                    data-pat-display-time="output-format: MMMM dddd Do YYYY, h:mm:ss a"
-                >
-                    20 January 2015, 08:00
-                </time>
-            </p>
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+  &lt;time
+      class="pat-display-time"
+      datetime="2015-01-20T08:00Z"
+      data-pat-display-time="output-format: MMMM dddd Do YYYY, h:mm:ss a"&gt;
+      20 January 2015, 08:00
+  &lt;/time&gt;
+      </pre>
 
-            <hr />
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time"
+                datetime="2015-01-20T08:00Z"
+                data-pat-display-time="output-format: MMMM dddd Do YYYY, h:mm:ss a"
+          >
+          </time>
+        </p>
+      </div>
 
-            <h2>Output formatted as local</h2>
-            <h3>Code</h3>
-        </div>
+      <div>
+        <h3>1.3 - Output formatted as local</h3>
 
-<pre
-    class="pat-syntax-highlight">
-&lt;time
-    class="pat-display-time"
-    datetime="2015-01-20T08:00Z"
-    data-pat-display-time="output-format: L"&gt;
-    20 January 2015, 08:00
-&lt;/time&gt;
-</pre>
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+  &lt;time
+      class="pat-display-time"
+      datetime="2015-01-20T08:00Z"
+      data-pat-display-time="output-format: L"&gt;
+      20 January 2015, 08:00
+  &lt;/time&gt;
+      </pre>
 
-        <div
-            class="pat-rich">
-            <h3>Output</h3>
-            <p>
-                <time
-                    class="pat-display-time"
-                    datetime="2015-01-20T08:00Z"
-                    data-pat-display-time="output-format: L"
-                >
-                    20 January 2015, 08:00
-                </time>
-            </p>
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time"
+                datetime="2015-01-20T08:00Z"
+                data-pat-display-time="output-format: L"
+          >
+          </time>
+        </p>
+      </div>
 
-            <hr />
+    </section>
 
-            <h2>Output formatted as 'from now'</h2>
-            <h3>Code</h3>
-        </div>
+    <section>
+      <header><h2>2 - From now examples</h2></header>
 
-<pre
-    class="pat-syntax-highlight">
+      <div>
+        <h3>2.1 - Output formatted as 'from now'</h3>
+
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
 &lt;time
     class="pat-display-time"
     datetime="2015-01-20T08:00Z"
     data-pat-display-time="from-now: true"&gt;
     20 January 2015, 08:00
 &lt;/time&gt;
-</pre>
+      </pre>
 
-        <div
-            class="pat-rich">
-            <h3>Output</h3>
-            <p>
-                <time
-                    class="pat-display-time"
-                    datetime="2015-01-20T08:00Z"
-                    data-pat-display-time="from-now: true"
-                >
-                    20 January 2015, 08:00
-                </time>
-            </p>
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time"
+                datetime="2015-01-20T08:00Z"
+                data-pat-display-time="from-now: true"
+          >
+          </time>
+        </p>
+      </div>
 
-            <hr />
+      <div>
+        <h3>2.2 - Output formatted as 'from now' with no suffix</h3>
 
-            <h2>Output formatted as 'from now' with no suffix</h2>
-            <h3>Code</h3>
-        </div>
-
-<pre
-    class="pat-syntax-highlight">
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
 &lt;time
     class="pat-display-time"
     datetime="2015-01-20T08:00Z"
     data-pat-display-time="from-now: true; no-suffix: true"&gt;
     20 January 2015, 08:00
 &lt;/time&gt;
-</pre>
+      </pre>
 
-        <div
-            class="pat-rich">
-            <h3>Output</h3>
-            <p>
-                <time
-                    class="pat-display-time"
-                    datetime="2015-01-20T08:00Z"
-                    data-pat-display-time="from-now: true; no-suffix: true"
-                >
-                    20 January 2015, 08:00
-                </time>
-            </p>
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time"
+                datetime="2015-01-20T08:00Z"
+                data-pat-display-time="from-now: true; no-suffix: true"
+          >
+          </time>
+        </p>
+      </div>
 
-            <h2>Output formatted as 'from now' with no suffix in german</h2>
-            <h3>Code</h3>
-        </div>
+      <div>
+        <h3>2.3 - Output formatted as 'from now' with no suffix in german</h3>
 
-<pre
-    class="pat-syntax-highlight">
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
 &lt;time
     class="pat-display-time"
     datetime="2015-01-20T08:00Z"
@@ -167,20 +151,19 @@
 &gt;
     20 January 2015, 08:00
 &lt;/time&gt;
-</pre>
+      </pre>
 
-        <div class="pat-rich">
-            <h3>Output</h3>
-            <p>
-                <time
-                    class="pat-display-time"
-                    datetime="2015-01-20T08:00Z"
-                    lang="de"
-                    data-pat-display-time="from-now: true; no-suffix: true"
-                >
-                    20 January 2015, 08:00
-                </time>
-            </p>
-        </div>
-    </body>
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time"
+                datetime="2015-01-20T08:00Z"
+                lang="de"
+                data-pat-display-time="from-now: true; no-suffix: true"
+          >
+          </time>
+        </p>
+      </div>
+    </section>
+
+  </body>
 </html>

--- a/src/pat/display-time/index.html
+++ b/src/pat/display-time/index.html
@@ -165,5 +165,230 @@
       </div>
     </section>
 
+    <section>
+      <header>
+        <h2>3 - from-now (relative date) with date only dates.</h2>
+      </header>
+
+      <div>
+        <h3>3.1 - Today</h3>
+
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+&lt;time
+    class="pat-display-time"
+    datetime="2022-07-21"
+    lang="de"
+    data-pat-display-time="from-now: true"
+&gt;
+    heute
+&lt;/time&gt;
+        </pre>
+
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time example-3-1"
+                datetime="2022-07-21"
+                lang="de"
+                data-pat-display-time="from-now: true"
+          >
+          </time>
+        </p>
+
+        <script charset="utf-8">
+          document.querySelector(".example-3-1").setAttribute("datetime", new Date().toISOString().split("T")[0]);
+        </script>
+      </div>
+
+      <div>
+        <h3>3.2 - Tomorrow</h3>
+
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+&lt;time
+    class="pat-display-time"
+    datetime="2022-07-22"
+    lang="de"
+    data-pat-display-time="from-now: true"
+&gt;
+    morgen
+&lt;/time&gt;
+        </pre>
+
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time example-3-2"
+                datetime="2022-07-22"
+                lang="de"
+                data-pat-display-time="from-now: true"
+          >
+          </time>
+        </p>
+
+        <script charset="utf-8">
+          var date = new Date();
+          date.setDate(date.getDate() + 1);
+          document.querySelector(".example-3-2").setAttribute("datetime", date.toISOString().split("T")[0]);
+        </script>
+      </div>
+
+      <div>
+        <h3>3.3 - Yesterday</h3>
+
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+&lt;time
+    class="pat-display-time"
+    datetime="2022-07-20"
+    lang="de"
+    data-pat-display-time="from-now: true"
+&gt;
+    gestern
+&lt;/time&gt;
+        </pre>
+
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time example-3-3"
+                datetime="2022-07-20"
+                lang="de"
+                data-pat-display-time="from-now: true"
+          >
+          </time>
+        </p>
+
+        <script charset="utf-8">
+          var date = new Date();
+          date.setDate(date.getDate() - 1);
+          document.querySelector(".example-3-3").setAttribute("datetime", date.toISOString().split("T")[0]);
+        </script>
+      </div>
+
+      <div>
+        <h3>3.4 - Next week</h3>
+
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+&lt;time
+    class="pat-display-time"
+    datetime="2022-07-25"
+    lang="de"
+    data-pat-display-time="from-now: true"
+&gt;
+&lt;/time&gt;
+        </pre>
+
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time example-3-4"
+                datetime="2022-07-21"
+                lang="de"
+                data-pat-display-time="from-now: true"
+          >
+          </time>
+        </p>
+
+        <script charset="utf-8">
+          var date = new Date();
+          date.setDate(date.getDate() + 4);
+          document.querySelector(".example-3-4").setAttribute("datetime", date.toISOString().split("T")[0]);
+        </script>
+      </div>
+
+      <div>
+        <h3>3.5 - Last week</h3>
+
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+&lt;time
+    class="pat-display-time"
+    datetime="2022-07-17"
+    lang="de"
+    data-pat-display-time="from-now: true"
+&gt;
+&lt;/time&gt;
+        </pre>
+
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time example-3-5"
+                datetime="2022-07-17"
+                lang="de"
+                data-pat-display-time="from-now: true"
+          >
+          </time>
+        </p>
+
+        <script charset="utf-8">
+          var date = new Date();
+          date.setDate(date.getDate() - 4);
+          document.querySelector(".example-3-5").setAttribute("datetime", date.toISOString().split("T")[0]);
+        </script>
+      </div>
+
+      <div>
+        <h3>3.6 - 10 days in the future</h3>
+
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+&lt;time
+    class="pat-display-time"
+    datetime="2022-07-31"
+    lang="de"
+    data-pat-display-time="from-now: true"
+&gt;
+&lt;/time&gt;
+        </pre>
+
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time example-3-6"
+                datetime="2022-07-31"
+                lang="de"
+                data-pat-display-time="from-now: true"
+          >
+          </time>
+        </p>
+
+        <script charset="utf-8">
+          var date = new Date();
+          date.setDate(date.getDate() + 10);
+          document.querySelector(".example-3-6").setAttribute("datetime", date.toISOString().split("T")[0]);
+        </script>
+      </div>
+
+      <div>
+        <h3>3.7 - 10 days in the past</h3>
+
+        <strong>Code</strong>
+        <pre class="pat-syntax-highlight">
+&lt;time
+    class="pat-display-time"
+    datetime="2022-07-11"
+    lang="de"
+    data-pat-display-time="from-now: true"
+&gt;
+&lt;/time&gt;
+        </pre>
+
+        <strong>Output</strong>
+        <p>
+          <time class="pat-display-time example-3-7"
+                datetime="2022-07-11"
+                lang="de"
+                data-pat-display-time="from-now: true"
+          >
+          </time>
+        </p>
+
+        <script charset="utf-8">
+          var date = new Date();
+          date.setDate(date.getDate() - 10);
+          document.querySelector(".example-3-7").setAttribute("datetime", date.toISOString().split("T")[0]);
+        </script>
+      </div>
+
+    </section>
+
   </body>
 </html>


### PR DESCRIPTION
Ref: scrum-465

implemented: https://stackoverflow.com/a/50157224

this uses a mixture of momentjs and intl. intl can translate "today", "yesterday" and "tomorrow" - momentjs does not have these translations available. MomentJS‌ can do a "Tuesday" for next tuesday while the Intl relativetimeformat only shows "in x days".
there is yet no solution for "last tuesday"‌ if the formatted date is within a week-range.
momentjs only has translations for "last tuesday at XX o' clock", so it includes the time component (``lastWeek``).
intl does only "x days ago".
but we probably can live with this restriction.

We could of course switch to Intl only, but we would loose the formatting option "Tuesday" for the next tuesday.

If we need more granular formatting options for relative dates, we'd need to provide our own translation files.

Ref:
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat
 
Example from the demo

![Screen Shot 2022-07-21 at 15 18 20](https://user-images.githubusercontent.com/170891/180223519-b6cba7ed-0039-4655-ae22-ad872e835dc8.png)