### PR TITLE
pat-auto-submit supping pat-clone and pat-sortable

### DIFF
--- a/src/pat/auto-submit/auto-submit.js
+++ b/src/pat/auto-submit/auto-submit.js
@@ -36,6 +36,22 @@ export default Base.extend({
         );
         this.registerSubformListeners();
         this.$el.on("patterns-injected", this.refreshListeners.bind(this));
+        this.$el.on("pat-update", (e, data) => {
+            // Refresh on some pat-update events.
+            if (
+                (data?.pattern === "clone" && data?.action === "remove") ||
+                data?.pattern === "sortable"
+            ) {
+                // Directly submit when removing a clone or changing the sorting.
+                this.$el.submit();
+                log.debug(
+                    `triggered by pat-update, pattern: ${data.pattern}, action: ${data.action}`
+                );
+            } else if (data?.pattern === "clone") {
+                // Refresh listeners on cloning.
+                this.refreshListeners(e, null, null, data.$el);
+            }
+        });
     },
 
     registerSubformListeners(ev) {

--- a/src/pat/auto-submit/auto-submit.test.js
+++ b/src/pat/auto-submit/auto-submit.test.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import Pattern from "./auto-submit";
 import events from "../../core/events";
 import registry from "../../core/registry";
@@ -53,6 +54,18 @@ describe("pat-autosubmit", function () {
             registry.scan(document.body);
             expect(spy_init).toHaveBeenCalled();
         });
+
+        it("calls refreshListeners when pat-clone adds an element", function () {
+            document.body.innerHTML = `
+              <form class="pat-autosubmit">
+              </form>
+            `;
+            const el = document.querySelector(".pat-autosubmit");
+            const instance = new Pattern(el);
+            const spy = jest.spyOn(instance, "refreshListeners");
+            $(el).trigger("pat-update", { pattern: "clone" });
+            expect(spy).toHaveBeenCalled();
+        });
     });
 
     describe("2 - Trigger a submit", function () {
@@ -72,6 +85,30 @@ describe("pat-autosubmit", function () {
             const spy = jest.spyOn(instance.$el, "submit");
             input.dispatchEvent(events.input_event());
             await utils.timeout(1);
+            expect(spy).toHaveBeenCalled();
+        });
+
+        it("when pat-clone removes an element", function () {
+            document.body.innerHTML = `
+              <form class="pat-autosubmit">
+              </form>
+            `;
+            const el = document.querySelector(".pat-autosubmit");
+            const instance = new Pattern(el);
+            const spy = jest.spyOn(instance.$el, "submit");
+            $(el).trigger("pat-update", { pattern: "clone", action: "remove" });
+            expect(spy).toHaveBeenCalled();
+        });
+
+        it("when pat-sortable changes the sorting", function () {
+            document.body.innerHTML = `
+              <form class="pat-autosubmit">
+              </form>
+            `;
+            const el = document.querySelector(".pat-autosubmit");
+            const instance = new Pattern(el);
+            const spy = jest.spyOn(instance.$el, "submit");
+            $(el).trigger("pat-update", { pattern: "sortable" });
             expect(spy).toHaveBeenCalled();
         });
     });

--- a/src/pat/auto-submit/index.html
+++ b/src/pat/auto-submit/index.html
@@ -114,6 +114,21 @@
                         </label>
                     </fieldset>
 
+                    <fieldset class="group">
+                      <legend>example with pat-clone and pat-sortable</legend>
+
+                      <ul class="pat-sortable pat-clone"
+                          data-pat-clone="template: #clone-item-template; trigger-element: #add-clone-item"
+                          data-pat-sortable="selector: .sortable-item">
+
+                        <li class="sortable-item" id="clone-item-template" hidden>
+                          <input type="text" name="pat-clone-example"/>
+                          <button type="button" class="remove-clone">x</button>
+                        </li>
+                      </ul>
+                      <button type="button" id="add-clone-item">Add clone item</button>
+                    </fieldset>
+
                 </fieldset>
             </form>
 

--- a/src/pat/sortable/sortable.js
+++ b/src/pat/sortable/sortable.js
@@ -102,6 +102,12 @@ export default Base.extend({
         if (this.options.drop) {
             this.options.drop($dragged, change);
         }
+        // Inform other patterns about sorting changes
+        $dragged.trigger("pat-update", {
+            pattern: "sortable",
+            action: "dragend",
+            $el: $dragged,
+        });
     },
 
     submitChangedAmount: function ($dragged) {

--- a/src/pat/sortable/sortable.test.js
+++ b/src/pat/sortable/sortable.test.js
@@ -88,4 +88,28 @@ describe("pat-sortable", function () {
         expect($(".sortable-amount").attr("value")).toEqual("2");
         expect(submitCallback).toHaveBeenCalled();
     });
+
+    it("Triggers pat-update on drag end", function () {
+        document.body.innerHTML = `
+          <ul class="pat-sortable">
+            <li>One</li>
+            <li>Two</li>
+            <li>Three</li>
+          </ul>
+        `;
+        const el = document.querySelector(".pat-sortable");
+        new Sortable(el);
+        const dragging_element = el.querySelector("li");
+        const handle = dragging_element.querySelector("a.sortable-handle");
+
+        let data = null;
+        $(el).on("pat-update", (e, d) => {
+            data = d;
+        });
+
+        $(handle).trigger("dragend");
+
+        expect(data.pattern).toBe("sortable");
+        expect(data.action).toBe("dragend");
+    });
 });


### PR DESCRIPTION
- feat(pat sortable): Trigger pat-update after sorting changes.
Other patterns can react on that for example submitting the form with pat-auto-submit.

- fix(pat auto submit): Support pat-clone and pat-sortable.
When pat-clone adds an element, initialize that element to listen for changes.
When pat-clone removes an element or pat-sortable changes the order, submit the form.