### PR TITLE
fix(Build): Register jQuery globally.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,3 +3,11 @@ import "../webpack/module_federation";
 // The next import needs to be kept with parentheses, otherwise we get this error:
 // "Shared module is not available for eager consumption."
 import("./patterns");
+
+// Register jQuery gloablly as soon as this script is executed.
+async function register_global_libraries() {
+    const jquery = (await import("jquery")).default;
+    window.jQuery = jquery;
+    window.$ = jquery;
+}
+register_global_libraries();

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -35,6 +35,13 @@ module.exports = () => {
             name: "patternslib",
             remote_entry: config.entry["bundle.min"],
             dependencies: package_json.dependencies,
+            shared: {
+                jquery: {
+                    singleton: true,
+                    requiredVersion: package_json.dependencies["jquery"],
+                    eager: true,
+                },
+            },
         })
     );
 


### PR DESCRIPTION
Since the module federation support jQuery was registered globally too late for some scripts. Now jQuery is registered as soon as the index.js is loaded. This allows for following scripts to use jQuery.