### PR TITLE
maint(core parser): Enforce whitespace around multi-config concatenation operator

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -441,7 +441,7 @@ class ArgumentParser {
             }
             const _parse = this._parse.bind(this);
             if (data.match(/&&/)) {
-                frame = data.split(/\s*&&\s*/).map(_parse);
+                frame = data.split(/\s+&&\s+/).map(_parse);
             } else {
                 frame = _parse(data);
             }


### PR DESCRIPTION
For multiple configurations like in concatenating multiple source and
target options pat-inject with the && operator, enforce whitespace
around the double-ampersand.


Note: I don't remember the reason why I came up with this. I keep the PR around, maybe I recall it one time.