### PR TITLE
fix(core dom): show/hide - do not set the hidden attribute.

### DIFF
--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -66,7 +66,6 @@ const hide = (el) => {
         el[DATA_STYLE_DISPLAY] = el.style.display;
     }
     el.style.display = "none";
-    el.setAttribute("hidden", "");
 };
 
 /**
@@ -79,7 +78,6 @@ const show = (el) => {
     const val = el[DATA_STYLE_DISPLAY] || null;
     el.style.display = val;
     delete el[DATA_STYLE_DISPLAY];
-    el.removeAttribute("hidden");
 };
 
 /**

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -122,7 +122,6 @@ describe("core.dom tests", () => {
             expect(el.style.marginTop).toBe("4em");
             expect(el.style.display).toBe("none");
             expect(el.getAttribute("style").indexOf("display") >= -1).toBeTruthy();
-            expect(el.hasAttribute("hidden")).toBe(true);
 
             dom.show(el);
 
@@ -130,7 +129,6 @@ describe("core.dom tests", () => {
             expect(el.style.marginTop).toBe("4em");
             expect(el.style.display).toBeFalsy();
             expect(el.getAttribute("style").indexOf("display") === -1).toBeTruthy();
-            expect(el.hasAttribute("hidden")).toBe(false);
 
             el.style.display = "inline";
             dom.hide(el);
@@ -139,7 +137,6 @@ describe("core.dom tests", () => {
             expect(el.style.marginTop).toBe("4em");
             expect(el.style.display).toBe("none");
             expect(el.getAttribute("style").indexOf("display") >= -1).toBeTruthy();
-            expect(el.hasAttribute("hidden")).toBe(true);
 
             dom.show(el);
 
@@ -147,6 +144,19 @@ describe("core.dom tests", () => {
             expect(el.style.marginTop).toBe("4em");
             expect(el.style.display).toBe("inline");
             expect(el.getAttribute("style").indexOf("display") >= -1).toBeTruthy();
+
+            done();
+        });
+
+        it("most not set the hidden attribute", (done) => {
+            // dom.hide must not set the hidden attribute due to,
+            // https://stackoverflow.com/a/28340579/1337474
+            // otherwise hidden input elements might not be able to be
+            // submitted in Chrome and Safari.
+
+            const el = document.createElement("div");
+            dom.hide(el);
+
             expect(el.hasAttribute("hidden")).toBe(false);
 
             done();

--- a/src/pat/auto-suggest/auto-suggest.test.js
+++ b/src/pat/auto-suggest/auto-suggest.test.js
@@ -66,7 +66,7 @@ describe("pat-autosuggest", function () {
             testutils.removeSelect2();
 
             expect($el[0].getAttribute("type")).toBe("text");
-            expect($el[0].hasAttribute("hidden")).toBe(true);
+            expect($el[0].style.display).toBe("none");
         });
 
         it("1.1 - An <input> element with an ajax option keeps the ajax option when turning into a select2 widget", async function () {

--- a/src/pat/date-picker/date-picker.test.js
+++ b/src/pat/date-picker/date-picker.test.js
@@ -55,7 +55,7 @@ describe("pat-date-picker", function () {
         expect(display_el.textContent).toBeFalsy();
 
         expect(el.getAttribute("type")).toBe("date");
-        expect(el.hasAttribute("hidden")).toBe(true);
+        expect(el.style.display).toBe("none");
 
         display_el.click();
 


### PR DESCRIPTION
In Chrome and Safari hidden but required input fields (e.g. hidden automatically by pat-autosuggest or pat-date-picker) cannot be submitted if they fail the browser's native validation. The browser tries to set a validation message but fails because the element is not focusable.
See: https://stackoverflow.com/a/28340579/1337474