### PR TITLE
fix(pat navigation): Don't check query string and hash fragments.

### DIFF
--- a/src/pat/navigation/navigation.js
+++ b/src/pat/navigation/navigation.js
@@ -207,7 +207,12 @@ export default Base.extend({
      * @returns {String} - The prepared url.
      */
     prepare_url(url) {
-        return url?.replace("/view", "").replaceAll("@@", "").replace(/\/$/, "");
+        return url
+            ?.replace("/view", "") // Remove Plone-specific default view.
+            .replaceAll("@@", "") // Remove Plone-specific @@ identifier of views.
+            .split("?")[0] // Remove query string.
+            .split("#")[0] // Remove hash.
+            .replace(/\/$/, ""); // Remove trailing slash.
     },
 
     /**

--- a/src/pat/navigation/navigation.test.js
+++ b/src/pat/navigation/navigation.test.js
@@ -289,7 +289,7 @@ describe("3 - Navigation pattern tests - Mark items based on URL", () => {
           </nav>
         `;
 
-        set_url("https://patternslib.com/");
+        set_url("https://patternslib.com/?a=1&b=2#hash");
 
         const instance = new Pattern(document.querySelector(".pat-navigation"));
 
@@ -310,6 +310,30 @@ describe("3 - Navigation pattern tests - Mark items based on URL", () => {
 
         instance.clear_items();
         instance.mark_items_url("https://patternslib.com/path1");
+
+        expect(document.querySelectorAll(".current").length).toBe(2);
+        expect(document.querySelectorAll(".inPath").length).toBe(0);
+        expect(document.querySelector(".current a")).toBe(it1);
+
+        // Check query string
+        instance.clear_items();
+        instance.mark_items_url("https://patternslib.com/path1?a=1&b=2");
+
+        expect(document.querySelectorAll(".current").length).toBe(2);
+        expect(document.querySelectorAll(".inPath").length).toBe(0);
+        expect(document.querySelector(".current a")).toBe(it1);
+
+        // Check hash
+        instance.clear_items();
+        instance.mark_items_url("https://patternslib.com/path1/#hash");
+
+        expect(document.querySelectorAll(".current").length).toBe(2);
+        expect(document.querySelectorAll(".inPath").length).toBe(0);
+        expect(document.querySelector(".current a")).toBe(it1);
+
+        // Check query string and hash
+        instance.clear_items();
+        instance.mark_items_url("https://patternslib.com/path1?a=1&b=2#hash");
 
         expect(document.querySelectorAll(".current").length).toBe(2);
         expect(document.querySelectorAll(".inPath").length).toBe(0);


### PR DESCRIPTION
When setting navigation markers based on URL comparison do not set the query string and hash fragments. When using hash navigation within one page, use pat-scroll to mark items as current.

This fixes a problem described in: https://github.com/euphorie/Euphorie/pull/447#issuecomment-1259660758

It has the drawback that URL based detection of the current item when using navigation based on query strings or hash fragments (e.g. a table of contents) would not be possible anymore. But that might be corner cases.