### PR TITLE
Bundle generation optimizations

### DIFF
--- a/src/core/basepattern.js
+++ b/src/core/basepattern.js
@@ -69,7 +69,7 @@ class BasePattern {
         }, 0);
     }
 
-    init() {
+    async init() {
         // Extend this method in your pattern.
     }
 

--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -93,6 +93,21 @@ const is_visible = (el) => {
 };
 
 /**
+ * Test, if a element is a input-type element.
+ *
+ * This is taken from Sizzle/jQuery at:
+ * https://github.com/jquery/sizzle/blob/f2a2412e5e8a5d9edf168ae3b6633ac8e6bd9f2e/src/sizzle.js#L139
+ * https://github.com/jquery/sizzle/blob/f2a2412e5e8a5d9edf168ae3b6633ac8e6bd9f2e/src/sizzle.js#L1773
+ *
+ * @param {Node} el - The DOM node to test.
+ * @returns {Boolean} - True if the element is a input-type element.
+ */
+const is_input = (el) => {
+    const re_input = /^(?:input|select|textarea|button)$/i;
+    return re_input.test(el.nodeName);
+};
+
+/**
  * Return all direct parents of ``el`` matching ``selector``.
  * This matches against all parents but not the element itself.
  * The order of elements is from the search starting point up to higher
@@ -322,6 +337,7 @@ const dom = {
     get_parents: get_parents,
     acquire_attribute: acquire_attribute,
     is_visible: is_visible,
+    is_input: is_input,
     create_from_string: create_from_string,
     get_css_value: get_css_value,
     find_scroll_container: find_scroll_container,

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -444,6 +444,20 @@ describe("core.dom tests", () => {
         });
     });
 
+    describe("is_input", () => {
+        it("checks, if an element is of type input or not.", (done) => {
+            expect(dom.is_input(document.createElement("input"))).toBe(true);
+            expect(dom.is_input(document.createElement("select"))).toBe(true);
+            expect(dom.is_input(document.createElement("textarea"))).toBe(true);
+            expect(dom.is_input(document.createElement("button"))).toBe(true);
+
+            expect(dom.is_input(document.createElement("form"))).toBe(false);
+            expect(dom.is_input(document.createElement("div"))).toBe(false);
+
+            done();
+        });
+    });
+
     describe("create_from_string", () => {
         it("Creates a DOM element from a string", (done) => {
             const res = dom.create_from_string(`

--- a/src/pat/markdown/markdown.js
+++ b/src/pat/markdown/markdown.js
@@ -2,7 +2,6 @@ import $ from "jquery";
 import { BasePattern } from "../../core/basepattern";
 import dom from "../../core/dom";
 import events from "../../core/events";
-import inject from "../inject/inject";
 import logging from "../../core/logging";
 import registry from "../../core/registry";
 import utils from "../../core/utils";
@@ -118,17 +117,25 @@ $(document).ready(function () {
     );
 });
 
-inject.registerTypeHandler("markdown", {
-    async sources(cfgs, data) {
-        return await Promise.all(
-            cfgs.map(async function (cfg) {
-                const pat = new Pattern(cfg.$target[0]);
-                const rendered = await pat.renderForInjection(cfg, data);
-                return rendered;
-            })
-        );
-    },
-});
+async function register_external_handlers() {
+    await utils.timeout(1);
+
+    const inject = registry.patterns.inject;
+    if (inject) {
+        inject.registerTypeHandler("markdown", {
+            async sources(cfgs, data) {
+                return await Promise.all(
+                    cfgs.map(async function (cfg) {
+                        const pat = new Pattern(cfg.$target[0]);
+                        const rendered = await pat.renderForInjection(cfg, data);
+                        return rendered;
+                    })
+                );
+            },
+        });
+    }
+}
+register_external_handlers();
 
 registry.register(Pattern);
 export default Pattern;

--- a/src/pat/markdown/markdown.js
+++ b/src/pat/markdown/markdown.js
@@ -1,30 +1,31 @@
 import $ from "jquery";
-import logging from "../../core/logging";
-import utils from "../../core/utils";
-import Base from "../../core/base";
+import { BasePattern } from "../../core/basepattern";
+import dom from "../../core/dom";
 import events from "../../core/events";
 import inject from "../inject/inject";
+import logging from "../../core/logging";
+import registry from "../../core/registry";
+import utils from "../../core/utils";
 
 const log = logging.getLogger("pat.markdown");
 const is_markdown_resource = /\.md$/;
 
-const Markdown = Base.extend({
-    name: "markdown",
-    trigger: ".pat-markdown",
+class Pattern extends BasePattern {
+    static name = "markdown";
+    static trigger = ".pat-markdown";
 
     async init() {
-        if (this.$el.is(this.trigger)) {
+        if (this.el.matches(this.trigger)) {
             /* This pattern can either be used standalone or as an enhancement
              * to pat-inject. The following only applies to standalone, when
-             * $el is explicitly configured with the pat-markdown trigger.
+             * the element is explicitly configured with the pat-markdown
+             * trigger.
              */
-            const source = this.$el.is(":input")
-                ? this.$el.val()
-                : this.$el[0].innerHTML;
-            let rendered = await this.render(source);
+            const source = dom.is_input(this.el) ? this.el.value : this.el.innerHTML;
+            const rendered = await this.render(source);
             this.el.replaceWith(...rendered);
         }
-    },
+    }
 
     async render(text) {
         const marked = (await import("marked")).marked;
@@ -44,7 +45,7 @@ const Markdown = Base.extend({
             await events.await_event(pre, "init.syntax-highlight.patterns");
         }
         return $(wrapper);
-    },
+    }
 
     async renderForInjection(cfg, data) {
         let header;
@@ -59,7 +60,7 @@ const Markdown = Base.extend({
         }
         const rendered = await this.render(source);
         return rendered.attr("data-src", cfg.source ? cfg.url + cfg.source : cfg.url);
-    },
+    }
 
     extractSection(text, header) {
         let pattern;
@@ -96,8 +97,8 @@ const Markdown = Base.extend({
             log.error("Failed to find section with known present header?");
         }
         return match !== null ? match[0] : null;
-    },
-});
+    }
+}
 
 $(document).ready(function () {
     $(document.body).on(
@@ -121,7 +122,7 @@ inject.registerTypeHandler("markdown", {
     async sources(cfgs, data) {
         return await Promise.all(
             cfgs.map(async function (cfg) {
-                const pat = new Markdown(cfg.$target[0]);
+                const pat = new Pattern(cfg.$target[0]);
                 const rendered = await pat.renderForInjection(cfg, data);
                 return rendered;
             })
@@ -129,4 +130,6 @@ inject.registerTypeHandler("markdown", {
     },
 });
 
-export default Markdown;
+registry.register(Pattern);
+export default Pattern;
+export { Pattern };

--- a/src/pat/markdown/markdown.js
+++ b/src/pat/markdown/markdown.js
@@ -29,20 +29,25 @@ class Pattern extends BasePattern {
     async render(text) {
         const marked = (await import("marked")).marked;
         const DOMPurify = (await import("dompurify")).default;
-        const SyntaxHighlight = (await import("../syntax-highlight/syntax-highlight")).default; // prettier-ignore
 
         const wrapper = document.createElement("div");
         const parsed = DOMPurify.sanitize(marked.parse(text));
         wrapper.innerHTML = parsed;
-        for (const item of wrapper.querySelectorAll("pre > code")) {
-            const pre = item.parentElement;
-            pre.classList.add("pat-syntax-highlight");
-            // If the code block language was set in a fenced code block,
-            // marked has already set the language as a class on the code tag.
-            // pat-syntax-highlight will understand this.
-            new SyntaxHighlight(pre);
-            await events.await_event(pre, "init.syntax-highlight.patterns");
+
+        // If pat-syntax-highlight is available, highlight code blocks.
+        const SyntaxHighlight = registry.patterns["syntax-highlight"];
+        if (SyntaxHighlight) {
+            for (const item of wrapper.querySelectorAll("pre > code")) {
+                const pre = item.parentElement;
+                pre.classList.add("pat-syntax-highlight");
+                // If the code block language was set in a fenced code block,
+                // marked has already set the language as a class on the code tag.
+                // pat-syntax-highlight will understand this.
+                new SyntaxHighlight(pre);
+                await events.await_event(pre, "init.syntax-highlight.patterns");
+            }
         }
+
         return $(wrapper);
     }
 

--- a/src/pat/markdown/markdown.test.js
+++ b/src/pat/markdown/markdown.test.js
@@ -170,6 +170,8 @@ describe("pat-markdown", function () {
 
     describe("Code blocks", function () {
         it("It correctly renders code blocks", async function () {
+            await import("../syntax-highlight/syntax-highlight");
+
             document.body.innerHTML = `
                 <main>
                     <div class="pat-markdown">
@@ -187,7 +189,6 @@ some content
 
             const instance = new Pattern(document.querySelector(".pat-markdown"));
             await events.await_pattern_init(instance);
-            await utils.timeout(1); // wait a tick for async to settle.
 
             expect(document.body.querySelector("main > div > h1").textContent).toBe("Title"); // prettier-ignore
             expect(document.body.querySelector("main > div > p").textContent).toBe("some content"); // prettier-ignore

--- a/src/pat/stacks/stacks.js
+++ b/src/pat/stacks/stacks.js
@@ -16,7 +16,7 @@ parser.addArgument("effect-easing", "swing");
 class Pattern extends BasePattern {
     static name = "stacks";
     static trigger = ".pat-stacks";
-    parser = parser;
+    static parser = parser;
     document = document;
 
     init() {

--- a/src/pat/syntax-highlight/syntax-highlight.js
+++ b/src/pat/syntax-highlight/syntax-highlight.js
@@ -34,7 +34,7 @@ class Pattern extends BasePattern {
         }
 
         import(`highlight.js/styles/${theme}.css`);
-        const hljs = (await import("highlight.js")).default;
+        const hljs = (await import("highlight.js/lib/core")).default;
 
         // Get the language
         let language = [..._el.classList, ...this.el.classList]

--- a/src/pat/syntax-highlight/syntax-highlight.js
+++ b/src/pat/syntax-highlight/syntax-highlight.js
@@ -11,7 +11,7 @@ parser.addArgument("features", null, ["line-highlight", "line-numbers"], true);
 class Pattern extends BasePattern {
     static name = "syntax-highlight";
     static trigger = ".pat-syntax-highlight";
-    parser = parser;
+    static parser = parser;
 
     async init() {
         let _el = this.el;

--- a/src/pat/syntax-highlight/syntax-highlight.js
+++ b/src/pat/syntax-highlight/syntax-highlight.js
@@ -71,7 +71,7 @@ class Pattern extends BasePattern {
                 const hljs_language = (
                     await import(`highlight.js/lib/languages/${lang_file}`)
                 ).default;
-                hljs.registerLanguage("javascript", hljs_language);
+                hljs.registerLanguage(language, hljs_language);
                 high = hljs.highlight(value, { language: language }).value;
             } catch {
                 high = hljs.highlightAuto(value).value;

--- a/src/pat/tooltip/tooltip.js
+++ b/src/pat/tooltip/tooltip.js
@@ -1,5 +1,5 @@
 import $ from "jquery";
-import Base from "../../core/base";
+import { BasePattern } from "../../core/basepattern";
 import logging from "../../core/logging";
 import Parser from "../../core/parser";
 import events from "../../core/events";
@@ -54,14 +54,15 @@ parser.addArgument("url", null);
 // onAfterUpdate
 // onDestroy
 
-export default Base.extend({
-    name: "tooltip",
-    trigger: ".pat-tooltip, .pat-tooltip-ng",
+class Pattern extends BasePattern {
+    static name = "tooltip";
+    static trigger = ".pat-tooltip, .pat-tooltip-ng";
+    static parser = parser;
 
-    tippy: null,
+    tippy = null;
 
-    active_class: "tooltip-active-hover",
-    inactive_class: "tooltip-inactive",
+    active_class = "tooltip-active-hover";
+    inactive_class = "tooltip-inactive";
 
     async init() {
         const el = this.el;
@@ -70,8 +71,6 @@ export default Base.extend({
             import("tippy.js/dist/tippy.css");
         }
         const Tippy = (await import("tippy.js")).default;
-
-        this.options = parser.parse(el, this.options);
         this.tippy_options = this.parseOptionsForTippy(this.options);
 
         const defaultProps = {
@@ -116,25 +115,25 @@ export default Base.extend({
             // Initially mark as inactive
             el.classList.add(this.inactive_class);
         }
-    },
+    }
 
     show() {
         // Show this tooltip
         // API method.
         this.tippy.show();
-    },
+    }
 
     async hide() {
         // Hide this tooltip
         await utils.timeout(1); // wait a tick for event being processed by other handlers.
         this.tippy.hide();
-    },
+    }
 
     destroy() {
         // Remove this tooltip
         // API method.
         this.tippy.destroy();
-    },
+    }
 
     parseOptionsForTippy(opts) {
         const placement = (pos) => {
@@ -253,12 +252,12 @@ export default Base.extend({
         }
 
         return tippy_options;
-    },
+    }
 
     _initialize_content() {
         // Initialize any other patterns.
         registry.scan(this.tippy.popper);
-    },
+    }
 
     async _onShow() {
         const tippy_classes = [];
@@ -322,7 +321,7 @@ export default Base.extend({
         ]);
 
         this._initialize_content();
-    },
+    }
 
     _onHide() {
         if (this.options.markInactive) {
@@ -338,7 +337,7 @@ export default Base.extend({
         if (this.options.source === "ajax") {
             this.tippy.setContent(document.createElement("progress"));
         }
-    },
+    }
 
     async _get_content(url = this.options.url) {
         let selector;
@@ -369,13 +368,13 @@ export default Base.extend({
             await utils.timeout(1); // Wait a tick before forceUpdate. Might fail due to unset popperInstance.
             this.tippy.popperInstance.forceUpdate(); // re-position tippy after content is known.
         }
-    },
+    }
 
     async get_content(url = this.options.url) {
         // API method: _get_content + _initialize_content
         await this._get_content(url);
         this._initialize_content();
-    },
+    }
 
     get_url_parts(href) {
         // Return the URL and a CSS ID selector.
@@ -392,9 +391,9 @@ export default Base.extend({
             url = `${url}?${query}`;
         }
         return { url, selector };
-    },
+    }
 
-    _ajaxDataTypeHandlers: {
+    _ajaxDataTypeHandlers = {
         html(text, url, selector) {
             let tmp = document.createElement("div");
             tmp.innerHTML = text;
@@ -414,5 +413,9 @@ export default Base.extend({
             const ret = await pat.renderForInjection(cfg, text);
             return ret[0];
         },
-    },
-});
+    };
+}
+
+registry.register(Pattern);
+export default Pattern;
+export { Pattern };

--- a/src/pat/tooltip/tooltip.test.js
+++ b/src/pat/tooltip/tooltip.test.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import autosubmit from "../auto-submit/auto-submit";
-import pattern from "./tooltip";
+import events from "../../core/events";
+import Pattern from "./tooltip";
 import registry from "../../core/registry";
 import utils from "../../core/utils";
 import { jest } from "@jest/globals";
@@ -69,8 +70,8 @@ describe("pat-tooltip", () => {
                 data: "trigger: click",
                 title: "tooltip",
             });
-            const instance = new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1);
@@ -88,8 +89,8 @@ describe("pat-tooltip", () => {
                 const el = $el[0];
                 const title = el.title;
 
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 // NOTE 1:
                 // spy on tippy instance's "onShow", which holds the reference
@@ -126,9 +127,10 @@ describe("pat-tooltip", () => {
                     title: "tooltip2",
                 });
 
-                new pattern($el1);
-                new pattern($el2);
-                await utils.timeout(1);
+                const instance1 = new Pattern($el1);
+                await events.await_pattern_init(instance1);
+                const instance2 = new Pattern($el2);
+                await events.await_pattern_init(instance2);
 
                 let container;
 
@@ -151,8 +153,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "source: title; trigger: click; class: wasabi kohlrabi",
                 });
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -172,8 +174,8 @@ describe("pat-tooltip", () => {
                 const el = document.querySelector("a.pat-tooltip");
                 const $el = $(el);
                 const title = el.title;
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const timer = {};
 
@@ -206,8 +208,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "trigger: click; closing: auto",
                 });
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const tp = instance.tippy.props;
                 const spy_show = jest.spyOn(tp, "onShow");
@@ -239,8 +241,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "trigger: hover; closing: auto",
                 });
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const tp = instance.tippy.props;
                 const spy_show = jest.spyOn(tp, "onShow");
@@ -271,8 +273,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "trigger: click; closing: sticky",
                 });
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const tp = instance.tippy.props;
                 const spy_show = jest.spyOn(tp, "onShow");
@@ -304,8 +306,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "trigger: hover; closing: sticky",
                 });
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const tp = instance.tippy.props;
                 const spy_show = jest.spyOn(tp, "onShow");
@@ -334,8 +336,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "trigger: click; closing: close-button",
                 });
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const tp = instance.tippy.props;
                 const spy_show = jest.spyOn(tp, "onShow");
@@ -374,8 +376,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "trigger: hover; closing: close-button",
                 });
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
                 const tp = instance.tippy.props;
                 const spy_show = jest.spyOn(tp, "onShow");
                 const spy_hide = jest.spyOn(tp, "onHide");
@@ -416,8 +418,8 @@ describe("pat-tooltip", () => {
                 `;
 
                 const el = document.querySelector(".pat-tooltip");
-                new pattern(el);
-                await utils.timeout(1);
+                const instance = new Pattern(el);
+                await events.await_pattern_init(instance);
 
                 el.click();
                 await utils.timeout(1);
@@ -457,8 +459,10 @@ describe("pat-tooltip", () => {
             const title1 = $el1.attr("title");
             const title2 = $el2.attr("title");
 
-            const instance1 = new pattern($el1);
-            const instance2 = new pattern($el2);
+            const instance1 = new Pattern($el1);
+            await events.await_pattern_init(instance1);
+            const instance2 = new Pattern($el2);
+            await events.await_pattern_init(instance2);
             await utils.timeout(1);
 
             const spy_show1 = jest.spyOn(instance1.tippy.props, "onShow");
@@ -501,8 +505,8 @@ describe("pat-tooltip", () => {
             const $el = testutils.createTooltip({
                 data: "position-list: lt",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1);
@@ -514,8 +518,8 @@ describe("pat-tooltip", () => {
             const $el = testutils.createTooltip({
                 data: "position-list: lb",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1);
@@ -527,8 +531,8 @@ describe("pat-tooltip", () => {
             const $el = testutils.createTooltip({
                 data: "position-list: lm",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1);
@@ -540,8 +544,8 @@ describe("pat-tooltip", () => {
             const $el = testutils.createTooltip({
                 data: "position-list: bl",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1);
@@ -553,8 +557,8 @@ describe("pat-tooltip", () => {
             const $el = testutils.createTooltip({
                 data: "position-list: br",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1);
@@ -566,8 +570,8 @@ describe("pat-tooltip", () => {
             const $el = testutils.createTooltip({
                 data: "position-list: bm",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1);
@@ -580,8 +584,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "position-list: tl; position-policy: force",
                 });
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -593,8 +597,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "position-list: tr; position-policy: force",
                 });
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -606,8 +610,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "position-list: tm; position-policy: force",
                 });
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -619,8 +623,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "position-list: rt; position-policy: force",
                 });
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -632,8 +636,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "position-list: rb; position-policy: force",
                 });
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -645,8 +649,8 @@ describe("pat-tooltip", () => {
                 const $el = testutils.createTooltip({
                     data: "position-list: rm; position-policy: force",
                 });
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -664,8 +668,8 @@ describe("pat-tooltip", () => {
                     data: "mark-inactive: true",
                 });
                 const el = $el[0];
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const spy_show = jest.spyOn(instance.tippy.props, "onShow");
                 const spy_hide = jest.spyOn(instance.tippy.props, "onHide");
@@ -705,8 +709,8 @@ describe("pat-tooltip", () => {
                     data: "mark-inactive: false",
                 });
                 const el = $el[0];
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const spy_show = jest.spyOn(instance.tippy.props, "onShow");
                 const spy_hide = jest.spyOn(instance.tippy.props, "onHide");
@@ -746,8 +750,8 @@ describe("pat-tooltip", () => {
                     data: "mark-inactive: true; trigger: hover",
                 });
                 const el = $el[0];
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const spy_show = jest.spyOn(instance.tippy.props, "onShow");
 
@@ -777,8 +781,8 @@ describe("pat-tooltip", () => {
                     const el = $el[0];
                     const title = el.title;
 
-                    const instance = new pattern($el);
-                    await utils.timeout(1);
+                    const instance = new Pattern($el);
+                    await events.await_pattern_init(instance);
 
                     const spy_show = jest.spyOn(instance.tippy.props, "onShow");
 
@@ -804,8 +808,8 @@ describe("pat-tooltip", () => {
                         data: "source: title; trigger: hover",
                     });
 
-                    const instance = new pattern($el);
-                    await utils.timeout(1);
+                    const instance = new Pattern($el);
+                    await events.await_pattern_init(instance);
 
                     const spy_hide = jest.spyOn(instance.tippy.props, "onHide");
 
@@ -836,8 +840,8 @@ describe("pat-tooltip", () => {
                         href: "#lab",
                         content: content,
                     });
-                    const instance = new pattern($el);
-                    await utils.timeout(1);
+                    const instance = new Pattern($el);
+                    await events.await_pattern_init(instance);
 
                     const spy_show = jest.spyOn(instance.tippy.props, "onShow");
 
@@ -858,8 +862,8 @@ describe("pat-tooltip", () => {
                 const el = document.createElement("div");
                 el.setAttribute("title", "hello.");
 
-                const instance = new pattern(el, { trigger: "none" });
-                await utils.timeout(1);
+                const instance = new Pattern(el, { trigger: "none" });
+                await events.await_pattern_init(instance);
 
                 // normal trigger shouldn't open
                 el.click();
@@ -896,8 +900,8 @@ describe("pat-tooltip", () => {
                 const el = document.createElement("div");
                 el.setAttribute("title", "hello.");
 
-                const instance = new pattern(el, { trigger: "none" });
-                await utils.timeout(1);
+                const instance = new Pattern(el, { trigger: "none" });
+                await events.await_pattern_init(instance);
 
                 expect(document.querySelector(".tippy-box .tippy-content")).toBeFalsy();
 
@@ -920,8 +924,8 @@ describe("pat-tooltip", () => {
                     data: "target: body",
                     href: "#",
                 });
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -937,8 +941,8 @@ describe("pat-tooltip", () => {
                     data: "target: parent",
                     href: "#",
                 });
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -965,8 +969,8 @@ describe("pat-tooltip", () => {
                 `;
                 document.body.appendChild(container);
 
-                new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 testutils.click($el);
                 await utils.timeout(1);
@@ -984,8 +988,8 @@ describe("pat-tooltip", () => {
                 data: "source: title; trigger: click",
             });
             const title = $el[0].title;
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             await utils.timeout(1);
 
@@ -1004,8 +1008,8 @@ describe("pat-tooltip", () => {
                 data: "source: content; trigger: click",
                 content: content,
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1);
@@ -1024,8 +1028,8 @@ describe("pat-tooltip", () => {
                 data: "source: ajax",
                 href: "http://test.com",
             });
-            const instance = new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             const spy_content = jest.spyOn(instance, "_get_content");
             const spy_show = jest.spyOn(instance.tippy.props, "onShow");
@@ -1057,8 +1061,8 @@ describe("pat-tooltip", () => {
                 data: "source: ajax",
                 href: "#lab",
             });
-            const instance = new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             const spy_content = jest.spyOn(instance, "_get_content");
             const spy_show = jest.spyOn(instance.tippy.props, "onShow");
@@ -1100,7 +1104,8 @@ describe("pat-tooltip", () => {
 
             const el = document.body.querySelector(".pat-tooltip");
 
-            const instance = new pattern(el);
+            const instance = new Pattern(el);
+            await events.await_pattern_init(instance);
             await utils.timeout(1);
 
             const spy_content = jest.spyOn(instance, "_get_content");
@@ -1144,8 +1149,8 @@ describe("pat-tooltip", () => {
 
             const el = document.body.querySelector(".pat-tooltip");
 
-            const instance = new pattern(el);
-            await utils.timeout(1);
+            const instance = new Pattern(el);
+            await events.await_pattern_init(instance);
 
             const spy_content = jest.spyOn(instance, "_get_content");
             const spy_show = jest.spyOn(instance.tippy.props, "onShow");
@@ -1177,8 +1182,8 @@ describe("pat-tooltip", () => {
                 data: "source: ajax",
                 href: "http://test.com",
             });
-            const instance = new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             const spy_content = jest.spyOn(instance, "_get_content");
             const spy_get_content = jest.spyOn(instance, "get_content");
@@ -1222,8 +1227,8 @@ describe("pat-tooltip", () => {
                 data: "source: ajax",
                 href: "http://test.com",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1); // wait a tick for async fetch
@@ -1248,8 +1253,8 @@ describe("pat-tooltip", () => {
                 data: "source: ajax",
                 href: "tests/content.html#content",
             });
-            const instance = new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             const click = new Event("click");
 
@@ -1290,8 +1295,8 @@ describe("pat-tooltip", () => {
                 data: "source: ajax",
                 href: "http://test.com#content",
             });
-            const instance = new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             const spy_ajax = jest.spyOn(instance, "_get_content");
             const spy_show = jest.spyOn(instance.tippy.props, "onShow");
@@ -1318,8 +1323,8 @@ describe("pat-tooltip", () => {
                 data: "source: ajax; ajax-data-type: markdown",
                 href: "http://test.com",
             });
-            const instance = await new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             const spy_ajax = jest.spyOn(instance, "_get_content");
             const spy_show = jest.spyOn(instance.tippy.props, "onShow");
@@ -1356,8 +1361,8 @@ this will be extracted.
                 data: "source: ajax; ajax-data-type: markdown",
                 href: "http://test.com/#hello",
             });
-            const instance = new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             const spy_ajax = jest.spyOn(instance, "_get_content");
             const spy_show = jest.spyOn(instance.tippy.props, "onShow");
@@ -1393,8 +1398,8 @@ this will be extracted.
                     data: "source: ajax; trigger: click",
                     href: "http://test.com",
                 });
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const spy_ajax = jest.spyOn(instance, "_get_content");
                 const spy_fetch = jest.spyOn(window, "fetch");
@@ -1438,8 +1443,8 @@ this will be extracted.
                     data: "source: ajax; trigger: hover",
                     href: "http://test.com",
                 });
-                const instance = new pattern($el);
-                await utils.timeout(1);
+                const instance = new Pattern($el);
+                await events.await_pattern_init(instance);
 
                 const spy_ajax = jest.spyOn(instance, "_get_content");
                 const spy_fetch = jest.spyOn(window, "fetch");
@@ -1487,8 +1492,8 @@ this will be extracted.
                 data: "source: ajax; trigger: click",
                 href: "http://test.com",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             testutils.click($el);
             await utils.timeout(1); // wait a tick for async fetch
@@ -1515,8 +1520,8 @@ this will be extracted.
                 data: "source: ajax; trigger: click; target: form",
                 href: "http://test.com",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             const instance2 = new autosubmit($(form));
             const spy_handler1 = jest.spyOn(instance2, "refreshListeners");
@@ -1543,8 +1548,8 @@ this will be extracted.
             const $el = testutils.createTooltip({
                 data: "source: content; trigger: click",
             });
-            new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             const spy_scan = jest.spyOn(registry, "scan");
 
@@ -1562,8 +1567,8 @@ this will be extracted.
     describe("9 - URL splitting", () => {
         it("9.1 - it extracts the correct parts from any url", async () => {
             const $el = testutils.createTooltip({});
-            const instance = new pattern($el);
-            await utils.timeout(1);
+            const instance = new Pattern($el);
+            await events.await_pattern_init(instance);
 
             let parts = instance.get_url_parts("https://text.com/#selector");
             expect(parts.url).toBe("https://text.com/");
@@ -1599,8 +1604,8 @@ this will be extracted.
                     title="This is the title attribute"
                 >test</a>
             `;
-            new pattern(document.querySelector(".pat-tooltip"));
-            await utils.timeout(1);
+            const instance = new Pattern(document.querySelector(".pat-tooltip"));
+            await events.await_pattern_init(instance);
 
             expect(document.querySelector(".pat-tooltip").title).toBeFalsy();
         });
@@ -1611,8 +1616,8 @@ this will be extracted.
                     title="This is the title attribute"
                 >test</a>
             `;
-            new pattern(document.querySelector(".pat-tooltip"));
-            await utils.timeout(1);
+            const instance = new Pattern(document.querySelector(".pat-tooltip"));
+            await events.await_pattern_init(instance);
 
             expect(document.querySelector(".pat-tooltip").title).toBe(
                 "This is the title attribute"
@@ -1625,8 +1630,8 @@ this will be extracted.
                     title="This is the title attribute"
                 >test</a>
             `;
-            new pattern(document.querySelector(".pat-tooltip"));
-            await utils.timeout(1);
+            const instance = new Pattern(document.querySelector(".pat-tooltip"));
+            await events.await_pattern_init(instance);
 
             expect(document.querySelector(".pat-tooltip").title).toBe(
                 "This is the title attribute"

--- a/src/pat/tooltip/tooltip.test.js
+++ b/src/pat/tooltip/tooltip.test.js
@@ -1317,6 +1317,7 @@ describe("pat-tooltip", () => {
         });
 
         it("7.3 - will handle markdown content", async () => {
+            await import("../markdown/markdown");
             global.fetch = jest.fn().mockImplementation(mockFetch("## hello."));
 
             const $el = testutils.createTooltip({
@@ -1331,6 +1332,7 @@ describe("pat-tooltip", () => {
 
             testutils.click($el);
             await utils.timeout(1); // wait a tick for async fetch
+            await utils.timeout(1);
 
             expect(spy_ajax).toHaveBeenCalled();
             expect(spy_show).toHaveBeenCalled();
@@ -1345,6 +1347,7 @@ describe("pat-tooltip", () => {
         });
 
         it("7.4 - will extract a section from markdown", async () => {
+            await import("../markdown/markdown");
             global.fetch = jest.fn().mockImplementation(
                 mockFetch(`
 # note a limitation
@@ -1369,6 +1372,7 @@ this will be extracted.
 
             testutils.click($el);
             await utils.timeout(1); // wait a tick for async fetch
+            await utils.timeout(1);
 
             expect(spy_ajax).toHaveBeenCalled();
             expect(spy_show).toHaveBeenCalled();


### PR DESCRIPTION
Basically this PR fixes a problem where including e.g. pat-tiptap which depends on pat-tootip also includes pat-markdown and pat-syntax-highlight with all the language definitions. This makes the generated bundle huge and creates a suboptimal situation for module federation bundles. Because I want to add the generated bundles to npm packages directly, so that they can be used via unpkg or jsdelivr CDN services. Therefore I'd like to have small bundles and not upload dozens of MB to npm and pollute node_modules directories unnecessarily.

Note: what is not used is not downloaded, so this PR solves not a runtime problem. Except for this one commit except for the one commit where:

Loading of pat-syntax-highlight is optimized - before all languages were bundled into the highlight.js chunk, now each language is loaded on demand.