### PR TITLE
feat(core basepattern): Provide the parser as static attribute.

### DIFF
--- a/src/core/basepattern.js
+++ b/src/core/basepattern.js
@@ -13,12 +13,13 @@ const log = logging.getLogger("Patternslib Base");
 class BasePattern {
     static name; // name of pattern used in Registry.
     static trigger; // A CSS selector to match elements that should trigger the pattern instantiation.
-    parser; // Options parser.
+    static parser; // Options parser.
 
     constructor(el, options = {}) {
-        // Make static ``name`` and ``trigger`` available on instance.
+        // Make static variables available on instance.
         this.name = this.constructor.name;
         this.trigger = this.constructor.trigger;
+        this.parser = this.constructor.parser;
 
         if (!el) {
             log.warn(`No element given to pattern ${this.name}.`);
@@ -49,7 +50,7 @@ class BasePattern {
             }
 
             // Create the options object by parsing the element and using the
-            // optional optios as default.
+            // optional options as default.
             this.options = this.parser?.parse(this.el, options) ?? options;
 
             // Store pattern instance on element

--- a/src/core/basepattern.md
+++ b/src/core/basepattern.md
@@ -21,7 +21,7 @@ Also see: https://github.com/Patternslib/pat-PATTERN_TEMPLATE
     class Pattern extends BasePattern {
         static name = "test-pattern";
         static trigger = ".pat-test-pattern";
-        parser = parser;
+        static parser = parser;
 
         async init() {
             import("./test-pattern.scss");

--- a/src/core/basepattern.test.js
+++ b/src/core/basepattern.test.js
@@ -15,15 +15,17 @@ describe("Basepattern class tests", function () {
         jest.restoreAllMocks();
     });
 
-    it("1 - Trigger and name are statically available on the class.", async function () {
+    it("1 - Trigger, name and parser are statically available on the class.", async function () {
         class Pat extends BasePattern {
             static name = "example";
             static trigger = ".example";
+            static parser = { parse: () => {} }; // dummy parser
         }
 
         // trigger and name are static and available on the class itself
-        expect(Pat.trigger).toBe(".example");
         expect(Pat.name).toBe("example");
+        expect(Pat.trigger).toBe(".example");
+        expect(typeof Pat.parser.parse).toEqual("function");
 
         const el = document.createElement("div");
 
@@ -32,6 +34,7 @@ describe("Basepattern class tests", function () {
 
         expect(pat.name).toEqual("example");
         expect(pat.trigger).toEqual(".example");
+        expect(typeof pat.parser.parse).toEqual("function");
     });
 
     it("2 - Base pattern is class based and does inheritance, polymorphism, encapsulation, ... pt1", async function () {


### PR DESCRIPTION
This change is backwards compatible Change the parser attribute to a static attribute and provide it also on the object. This change was necessary because pat-inject was using the parser on a registered Pattern class to rebase URL configurations in the rebaseHTML method. There was no access to the parser attribute on non-instatiated objects before, now it is.