### PR TITLE
Pat autofocus regressions

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -272,6 +272,8 @@ const hideOrShow = (nodes, visible, options, pattern_name) => {
         el.classList.add(visible ? "visible" : "hidden");
         $(el).trigger("pat-update", {
             pattern: pattern_name,
+            action: "attribute-changed",
+            dom: el,
             transition: "complete",
         });
     };
@@ -286,6 +288,8 @@ const hideOrShow = (nodes, visible, options, pattern_name) => {
             el.classList.add("in-progress");
             $(el).trigger("pat-update", {
                 pattern: pattern_name,
+                action: "attribute-changed",
+                dom: el,
                 transition: "start",
             });
             $(el)[visible ? t.show : t.hide]({

--- a/src/core/utils.test.js
+++ b/src/core/utils.test.js
@@ -277,27 +277,6 @@ describe("hideOrShow", function () {
         expect(Array.prototype.slice.call($el[0].classList)).toEqual(["visible"]);
     });
 
-    it("Single pat-update event without a transition", function () {
-        $("#lab").append('<div style="display: none"/>');
-        var $el = $("#lab div");
-        jest.spyOn($.fn, "trigger");
-        utils.hideOrShow(
-            $el,
-            true,
-            {
-                transition: "none",
-                effect: { duration: "fast", easing: "swing" },
-            },
-            "depends"
-        );
-        expect($.fn.trigger.mock.calls.length).toEqual(1);
-        expect($.fn.trigger).toHaveBeenCalledWith("pat-update", {
-            pattern: "depends",
-            transition: "complete",
-        });
-        $.fn.trigger.mockRestore();
-    });
-
     it("Fadeout with 0 duration", function () {
         $("#lab").append("<div/>");
         var $el = $("#lab div");
@@ -321,6 +300,29 @@ describe("hideOrShow", function () {
         expect(Array.prototype.slice.call($el[0].classList)).toEqual(["hidden"]);
     });
 
+    it("Single pat-update event without a transition", function () {
+        $("#lab").append('<div style="display: none"/>');
+        var $el = $("#lab div");
+        jest.spyOn($.fn, "trigger");
+        utils.hideOrShow(
+            $el,
+            true,
+            {
+                transition: "none",
+                effect: { duration: "fast", easing: "swing" },
+            },
+            "depends"
+        );
+        expect($.fn.trigger.mock.calls.length).toEqual(1);
+        expect($.fn.trigger).toHaveBeenCalledWith("pat-update", {
+            pattern: "depends",
+            action: "attribute-changed",
+            dom: $el[0],
+            transition: "complete",
+        });
+        $.fn.trigger.mockRestore();
+    });
+
     it("pat-update event with a transition", async function () {
         $("#lab").append("<div/>");
         var $el = $("#lab div");
@@ -338,10 +340,14 @@ describe("hideOrShow", function () {
         expect($.fn.trigger.mock.calls.length).toEqual(2);
         expect($.fn.trigger).toHaveBeenCalledWith("pat-update", {
             pattern: "depends",
+            action: "attribute-changed",
+            dom: $el[0],
             transition: "start",
         });
         expect($.fn.trigger).toHaveBeenCalledWith("pat-update", {
             pattern: "depends",
+            action: "attribute-changed",
+            dom: $el[0],
             transition: "complete",
         });
         $.fn.trigger.mockRestore();

--- a/src/pat/auto-submit/auto-submit.js
+++ b/src/pat/auto-submit/auto-submit.js
@@ -39,7 +39,7 @@ export default Base.extend({
         this.$el.on("pat-update", (e, data) => {
             // Refresh on some pat-update events.
             if (
-                (data?.pattern === "clone" && data?.action === "remove") ||
+                (data?.pattern === "clone" && data?.action === "removed") ||
                 data?.pattern === "sortable"
             ) {
                 // Directly submit when removing a clone or changing the sorting.

--- a/src/pat/auto-submit/auto-submit.test.js
+++ b/src/pat/auto-submit/auto-submit.test.js
@@ -96,7 +96,7 @@ describe("pat-autosubmit", function () {
             const el = document.querySelector(".pat-autosubmit");
             const instance = new Pattern(el);
             const spy = jest.spyOn(instance.$el, "submit");
-            $(el).trigger("pat-update", { pattern: "clone", action: "remove" });
+            $(el).trigger("pat-update", { pattern: "clone", action: "removed" });
             expect(spy).toHaveBeenCalled();
         });
 

--- a/src/pat/auto-suggest/auto-suggest.js
+++ b/src/pat/auto-suggest/auto-suggest.js
@@ -94,15 +94,19 @@ export default Base.extend({
 
         dom.hide(this.el); // hide input, but keep active (e.g. for validation)
 
-        this.$el.on("pat-update", (e, data) => {
-            if (data?.pattern === "depends") {
-                if (data?.enabled === true) {
-                    this.$el.select2("enable", true);
-                } else if (data?.enabled === false) {
-                    this.$el.select2("disable", true);
+        // Handle case of pat-depends, where select2 might not be visible initially
+        const pat_depends = this.el.closest(".pat-depends");
+        if (pat_depends) {
+            $(pat_depends).on("pat-update", (e, data) => {
+                if (data?.pattern === "depends") {
+                    if (data?.enabled === true) {
+                        this.$el.select2("enable", true);
+                    } else if (data?.enabled === false) {
+                        this.$el.select2("disable", true);
+                    }
                 }
-            }
-        });
+            });
+        }
 
         // Allow pat-validate to check for validity when select2 was interacted
         // with but no value selected.

--- a/src/pat/autofocus/autofocus.js
+++ b/src/pat/autofocus/autofocus.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { BasePattern } from "../../core/basepattern";
 import dom from "../../core/dom";
 import registry from "../../core/registry";
@@ -22,6 +23,16 @@ class Pattern extends BasePattern {
             // Do not autofocus in iframes.
             return;
         }
+
+        // Re-focus after relevant DOM changes.
+        $(document).on("pat-update", (e, data) => {
+            const updated = data?.dom;
+            if (updated?.contains(this.el)) {
+                // Only focus if the updated element is a parent of this autofocus element.
+                this.set_focus();
+            }
+        });
+
         this.set_focus();
     }
 

--- a/src/pat/autofocus/autofocus.test.js
+++ b/src/pat/autofocus/autofocus.test.js
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import "./autofocus";
 import registry from "../../core/registry";
 import utils from "../../core/utils";
@@ -43,5 +44,89 @@ describe("pat-autofocus", function () {
 
         const should_be_active = document.querySelector("input[name=i3]");
         expect(document.activeElement).toBe(should_be_active);
+    });
+
+    describe("pat-update and pat-inject support", function () {
+        it("4.1 - Re-focus on pat-update.", async () => {
+            document.body.innerHTML = `
+                <div id="c1">
+                    <input name="i1" type="text" class="pat-autofocus"/>
+                </div>
+                <div id="c2">
+                    <input name="i2" type="text" class="pat-autofocus" hidden/>
+                </div>
+            `;
+            registry.scan(document.body);
+            await utils.timeout(1); // Wait for async pattern initialization.
+            await utils.timeout(100); // Wait for autofocus timeout.
+
+            expect(document.activeElement).toBe(
+                document.querySelector("input[name=i1]")
+            );
+
+            document.querySelector("input[name=i2]").removeAttribute("hidden");
+            $(document).trigger("pat-update", { dom: document.querySelector("#c2") });
+            await utils.timeout(100); // Wait for autofocus timeout.
+
+            expect(document.activeElement).toBe(
+                document.querySelector("input[name=i2]")
+            );
+        });
+
+        it("4.2 - Re-focus on pat-update / collapsible.", async () => {
+            await import("../collapsible/collapsible");
+
+            document.body.innerHTML = `
+                <input name="i1" type="text" class="pat-autofocus"/>
+                <div class="pat-collapsible closed"
+                     data-pat-collapsible="transition: none">
+                    <h4>Open collapsible.</h4>
+                    <input name="i2" class="pat-autofocus" />
+                </div>
+            `;
+            registry.scan(document.body);
+            await utils.timeout(1); // Wait for async pattern initialization.
+            await utils.timeout(100); // Wait for autofocus timeout.
+
+            expect(document.activeElement).toBe(
+                document.querySelector("input[name=i1]")
+            );
+
+            document.querySelector(".pat-collapsible h4").click();
+            await utils.timeout(100); // Wait for autofocus timeout.
+
+            expect(document.activeElement).toBe(
+                document.querySelector("input[name=i2]")
+            );
+        });
+
+        it("4.3 - Re-focus on pat-inject.", async () => {
+            await import("../inject/inject");
+
+            document.body.innerHTML = `
+                <input name="i1" type="text" class="pat-autofocus"/>
+                <a href="#autofocus-demo-input"
+                   class="pat-inject"
+                   data-pat-inject="target: self::after">inject</a>
+                <template id="autofocus-demo-input">
+                    <input name="i2" class="pat-autofocus" />
+                </template>
+            `;
+            registry.scan(document.body);
+            await utils.timeout(1); // Wait for async pattern initialization.
+            await utils.timeout(100); // Wait for autofocus timeout.
+
+            expect(document.activeElement).toBe(
+                document.querySelector("input[name=i1]")
+            );
+
+            document.querySelector("a.pat-inject").click();
+            await utils.timeout(2); // Wait for inject.
+            await utils.timeout(100); // Wait for autofocus timeout.
+
+            expect(document.activeElement).toBe(
+                document.querySelector("input[name=i2]")
+            );
+        });
     });
 });

--- a/src/pat/autofocus/index.html
+++ b/src/pat/autofocus/index.html
@@ -29,6 +29,19 @@
                  type="text"
           />
         </label>
+
+        <h3>Input 4 - should get focus when collapsible is opened.</h3>
+        <div class="pat-collapsible closed">
+            <h4>Open collapsible.</h4>
+
+            <input class="pat-autofocus" />
+        </div>
+
+        <h3>Input 5 - inject element with autofocus.</h3>
+        <a href="#autofocus-demo-input"
+           class="pat-inject"
+           data-pat-inject="target: self::after">inject autofocus input here</a>
+
       </fieldset>
     </form>
 
@@ -37,5 +50,9 @@
             src="./index-iframed.html"
             style="width: 400px; height: 300px; border: 1px solid black"
     ></iframe>
+
+    <template id="autofocus-demo-input">
+      <input class="pat-autofocus" />
+    </template>
   </body>
 </html>

--- a/src/pat/bumper/bumper.test.js
+++ b/src/pat/bumper/bumper.test.js
@@ -58,7 +58,6 @@ describe("pat-bumper", function () {
             // Scroll to top-right, update getBoundingClientRect.
             Object.assign(el_bounds, { top: 0, right: 100, bottom: 80, left: 80 });
 
-            console.log("xxx", el.getBoundingClientRect());
             el.dispatchEvent(events.scroll_event());
             await utils.animation_frame();
 

--- a/src/pat/clone/clone.js
+++ b/src/pat/clone/clone.js
@@ -90,8 +90,8 @@ export default Base.extend({
 
         $clone.trigger("pat-update", {
             pattern: "clone",
-            action: "clone",
-            $el: $clone,
+            action: "added",
+            dom: $clone[0],
         });
         if (this.num_clones >= this.options.max) {
             for (const el_ of this.clone_triggers) {
@@ -159,8 +159,8 @@ export default Base.extend({
             node.remove();
             this.$el.trigger("pat-update", {
                 pattern: "clone",
-                action: "remove",
-                $el: $(node), // used by pat-sortable only.
+                action: "removed",
+                dom: node,
             });
         }
         this.num_clones -= 1;

--- a/src/pat/clone/clone.test.js
+++ b/src/pat/clone/clone.test.js
@@ -394,4 +394,43 @@ describe("pat-clone", function () {
             expect(document.querySelectorAll(".pat-clone label").length).toBe(0); // prettier-ignore
         });
     });
+
+    describe("3 - pat-update event support", function () {
+        it("throws pat-update when clones are added.", async function () {
+            document.body.innerHTML = `
+                <div class="pat-clone"
+                     data-pat-clone="remove-behaviour: none;">
+                    <div class="item">
+                        Clone Me
+                        <button class="remove-clone" type="button">remove</button>
+                    </div>
+                    <button class="add-clone" type="button">Clone!</button>
+                </div>
+            `;
+
+            const el = document.querySelector(".pat-clone");
+            new Clone(el);
+
+            let data;
+            $(el).on("pat-update", (e, d) => {
+                data = d;
+            });
+
+            expect(document.querySelectorAll(".item").length).toBe(1);
+
+            document.querySelector(".add-clone").click();
+            expect(document.querySelectorAll(".item").length).toBe(2);
+
+            const cloned = document.querySelectorAll(".item")[1];
+            expect(data.pattern).toBe("clone");
+            expect(data.action).toBe("added");
+            expect(data.dom).toBe(cloned);
+
+            cloned.querySelector(".remove-clone").click();
+            expect(document.querySelectorAll(".item").length).toBe(1);
+            expect(data.pattern).toBe("clone");
+            expect(data.action).toBe("removed");
+            expect(data.dom).toBe(cloned);
+        });
+    });
 });

--- a/src/pat/collapsible/collapsible.js
+++ b/src/pat/collapsible/collapsible.js
@@ -204,12 +204,16 @@ class Pattern extends BasePattern {
                 .addClass("collapsible-" + to_cls);
             $el.removeClass(from_cls).addClass(to_cls).trigger("pat-update", {
                 pattern: "collapsible",
+                action: "attribute-changed",
+                dom: $el[0],
                 transition: "complete",
             });
         } else {
             const t = this.transitions[this.options.transition];
             $el.addClass("in-progress").trigger("pat-update", {
                 pattern: "collapsible",
+                action: "attribute-changed",
+                dom: $el[0],
                 transition: "start",
             });
             this.$trigger.addClass("collapsible-in-progress");
@@ -226,6 +230,8 @@ class Pattern extends BasePattern {
                         .addClass(to_cls)
                         .trigger("pat-update", {
                             pattern: "collapsible",
+                            action: "attribute-changed",
+                            dom: $el[0],
                             transition: "complete",
                         });
                 }.bind(this)

--- a/src/pat/collapsible/collapsible.test.js
+++ b/src/pat/collapsible/collapsible.test.js
@@ -231,4 +231,27 @@ describe("pat-collapsible", function () {
             expect(arg_1.scrollTop).toBe(40); // the offset is substracted from the scroll position, so a negative offset is added to the scroll position and stops AFTER the target position.
         });
     });
+
+    it("9 - triggers the pat-update event.", async function () {
+        document.body.innerHTML = `
+            <div class="pat-collapsible closed">
+                <h3>Trigger header</h3>
+                <p>Collapsible content</p>
+            </div>
+        `;
+        const $collapsible = $(".pat-collapsible");
+        const instance = new Pattern($collapsible[0], { transition: "none" });
+        await events.await_pattern_init(instance);
+        const spy_trigger = jest.spyOn($.fn, "trigger");
+        instance.toggle($collapsible);
+        expect(spy_trigger).toHaveBeenCalledWith(
+            "pat-update",
+            expect.objectContaining({
+                pattern: "collapsible",
+                action: "attribute-changed",
+                dom: document.body.querySelector(".pat-collapsible"),
+                transition: "complete",
+            })
+        );
+    });
 });

--- a/src/pat/depends/depends.js
+++ b/src/pat/depends/depends.js
@@ -99,13 +99,13 @@ export default Base.extend({
         } else if (this.$el.is("a")) {
             this.$el.off("click.patternDepends");
         }
-        if (this.$el.hasClass("pat-autosuggest")) {
-            this.$el.findInclusive("input.pat-autosuggest").trigger("pat-update", {
-                pattern: "depends",
-                enabled: true,
-            });
-        }
         this.$el.removeClass("disabled");
+        this.$el.trigger("pat-update", {
+            pattern: "depends",
+            action: "attribute-changed",
+            dom: this.$el[0],
+            enabled: true,
+        });
     },
 
     disable() {
@@ -114,13 +114,13 @@ export default Base.extend({
         } else if (this.$el.is("a")) {
             this.$el.on("click.patternDepends", (e) => e.preventDefault());
         }
-        if (this.$el.hasClass("pat-autosuggest")) {
-            this.$el.findInclusive("input.pat-autosuggest").trigger("pat-update", {
-                pattern: "depends",
-                enabled: false,
-            });
-        }
         this.$el.addClass("disabled");
+        this.$el.trigger("pat-update", {
+            pattern: "depends",
+            action: "attribute-changed",
+            dom: this.$el[0],
+            enabled: false,
+        });
     },
 
     onChange(event) {

--- a/src/pat/depends/depends.test.js
+++ b/src/pat/depends/depends.test.js
@@ -3,7 +3,7 @@ import pattern from "./depends";
 import utils from "../../core/utils";
 
 describe("pat-depends", function () {
-    describe("init", function () {
+    describe("1 - init", function () {
         beforeEach(function () {
             $("<div/>", { id: "lab" }).appendTo(document.body);
         });
@@ -40,7 +40,7 @@ describe("pat-depends", function () {
         });
     });
 
-    describe("disable", function () {
+    describe("2 - disable", function () {
         beforeEach(function () {
             $("<div/>", { id: "lab" }).appendTo(document.body);
         });
@@ -84,7 +84,7 @@ describe("pat-depends", function () {
         });
     });
 
-    describe("enable", function () {
+    describe("3 - enable", function () {
         beforeEach(function () {
             $("<div/>", { id: "lab" }).appendTo(document.body);
         });
@@ -126,6 +126,65 @@ describe("pat-depends", function () {
             pat.enable();
             expect($dependent.hasClass("disabled")).toBe(false);
             expect($._data($dependent[0]).events).toBe(undefined);
+        });
+    });
+
+    describe("4 - pat-update", function () {
+        it("4.1 - Throw pat-update on enabling", async function () {
+            document.body.innerHTML = `
+                <input
+                    type="checkbox"
+                    id="control"
+                    value="yes"
+                    checked="checked"/>
+                <button
+                    id="dependent"
+                    type="button"
+                    class="pat-depends"
+                    data-pat-depends="condition: control"
+                    >Click me</button>
+            `;
+            const el = document.querySelector(".pat-depends");
+            const instance = new pattern(el);
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            let data;
+            $(el).on("pat-update", (e, d) => {
+                data = d;
+            });
+            instance.enable();
+            expect(data.pattern).toBe("depends");
+            expect(data.action).toBe("attribute-changed");
+            expect(data.dom).toBe(el);
+            expect(data.enabled).toBe(true);
+        });
+        it("4.2 - Throw pat-update on disabling", async function () {
+            document.body.innerHTML = `
+                <input
+                    type="checkbox"
+                    id="control"
+                    value="yes"
+                    checked="checked"/>
+                <button
+                    id="dependent"
+                    type="button"
+                    class="pat-depends"
+                    data-pat-depends="condition: control"
+                    >Click me</button>
+            `;
+            const el = document.querySelector(".pat-depends");
+            const instance = new pattern(el);
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            let data;
+            $(el).on("pat-update", (e, d) => {
+                data = d;
+            });
+            instance.disable();
+            expect(data.pattern).toBe("depends");
+            expect(data.action).toBe("attribute-changed");
+            expect(data.dom).toBe(el);
+            expect(data.enabled).toBe(false);
         });
     });
 });

--- a/src/pat/equaliser/equaliser.js
+++ b/src/pat/equaliser/equaliser.js
@@ -81,7 +81,11 @@ var equaliser = {
                 );
                 break;
         }
-        $container.trigger("pat-update", { pattern: "equaliser" });
+        $container.trigger("pat-update", {
+            pattern: "equaliser",
+            action: "attribute-changed",
+            dom: container,
+        });
     },
 
     _onEvent: function (event) {

--- a/src/pat/equaliser/equaliser.test.js
+++ b/src/pat/equaliser/equaliser.test.js
@@ -53,5 +53,28 @@ describe("pat-equaliser", function () {
             expect($container.find(".small").height()).toBe(100);
             expect($container.find(".large").height()).toBe(100);
         });
+
+        it("Triggers pat-update after equalisation.", function () {
+            document.body.innerHTML = `
+                <div class="pat-equaliser"
+                     data-pat-equaliser="transition: none">
+                    <div class="small"></div>
+                    <div class="large"></div>
+                </div>
+            `;
+
+            const $container = $(".pat-equaliser");
+
+            let data = null;
+            $container.on("pat-update", (e, d) => {
+                data = d;
+            });
+
+            pattern._update($container[0]);
+
+            expect(data.pattern).toBe("equaliser");
+            expect(data.action).toBe("attribute-changed");
+            expect(data.dom).toBe($container[0]);
+        });
     });
 });

--- a/src/pat/scroll-box/scroll-box.test.js
+++ b/src/pat/scroll-box/scroll-box.test.js
@@ -103,10 +103,10 @@ describe("pat-scroll-box", function () {
         // scroll-up and scroll-down are not cleared.
 
         // Still there...
-        await utils.timeout(custom_timeout / 2);
+        await utils.timeout(1);
         expect(el.classList).toContain("scrolling-up");
         // Now gone
-        await utils.timeout(custom_timeout / 2 + 1);
+        await utils.timeout(custom_timeout + 1);
         expect(el.classList).not.toContain("scrolling-up");
 
         el.scrollTop = 100;
@@ -121,10 +121,10 @@ describe("pat-scroll-box", function () {
 
         // Test for clearing the scrolling classes after a scroll stop
         // Still there...
-        await utils.timeout(custom_timeout / 2);
+        await utils.timeout(1);
         expect(el.classList).toContain("scrolling-down");
         // Now gone
-        await utils.timeout(custom_timeout / 2 + 1);
+        await utils.timeout(custom_timeout + 1);
         expect(el.classList).not.toContain("scrolling-down");
     });
 });

--- a/src/pat/scroll/scroll.js
+++ b/src/pat/scroll/scroll.js
@@ -90,8 +90,12 @@ export default Base.extend({
                         // if so, mark both the anchor and the target element
                         $target.addClass("current");
                         this.$el.addClass("current");
+                        this.$el.trigger("pat-update", {
+                            pattern: "scroll",
+                            action: "attribute-changed",
+                            dom: $target[0],
+                        });
                     }
-                    $(this.$el).trigger("pat-update", { pattern: "scroll" });
                 }
             }
         }

--- a/src/pat/scroll/scroll.test.js
+++ b/src/pat/scroll/scroll.test.js
@@ -220,4 +220,35 @@ describe("pat-scroll", function () {
         pat.options.selector = null; // Using href target
         expect(pat._get_selector_target()).toBe(el_3);
     });
+
+    it("triggers pat-update event.", async () => {
+        document.body.innerHTML = `
+            <a href="#el1" class="pat-scroll">scroll to</a>
+            <div id="el1" />
+        `;
+
+        const spy = jest
+            .spyOn(utils, "isElementInViewport")
+            .mockImplementation(() => true);
+
+        const el = document.querySelector(".pat-scroll");
+        const target = document.querySelector("#el1");
+
+        new pattern(el);
+
+        let data = null;
+        $(el).on("pat-update", (e, d) => {
+            data = d;
+        });
+
+        $(window).scroll();
+        await utils.timeout(50); // wait for debounce.
+
+        expect(data).not.toBeNull();
+        expect(data.pattern).toBe("scroll");
+        expect(data.action).toBe("attribute-changed");
+        expect(data.dom).toBe(target);
+
+        spy.mockRestore();
+    });
 });

--- a/src/pat/sortable/sortable.js
+++ b/src/pat/sortable/sortable.js
@@ -113,8 +113,8 @@ export default Base.extend({
         // Inform other patterns about sorting changes
         $dragged.trigger("pat-update", {
             pattern: "sortable",
-            action: "dragend",
-            $el: $dragged,
+            action: "changed",
+            dom: $dragged[0],
         });
     },
 

--- a/src/pat/sortable/sortable.test.js
+++ b/src/pat/sortable/sortable.test.js
@@ -110,6 +110,7 @@ describe("pat-sortable", function () {
         $(handle).trigger("dragend");
 
         expect(data.pattern).toBe("sortable");
-        expect(data.action).toBe("dragend");
+        expect(data.action).toBe("changed");
+        expect(data.dom).toBe(dragging_element);
     });
 });

--- a/src/pat/stacks/stacks.js
+++ b/src/pat/stacks/stacks.js
@@ -28,7 +28,7 @@ class Pattern extends BasePattern {
     _setupStack() {
         let selected = this._currentFragment();
         const $sheets = this.$el.find(this.options.selector);
-        let $visible = [];
+        this.$active = [];
 
         if ($sheets.length < 2) {
             log.warn("Stacks pattern: must have more than one sheet.", this.$el[0]);
@@ -37,18 +37,18 @@ class Pattern extends BasePattern {
 
         if (selected) {
             try {
-                $visible = $sheets.filter("#" + selected);
+                this.$active = $sheets.filter("#" + selected);
             } catch (e) {
                 selected = undefined;
             }
         }
 
-        if (!$visible.length) {
-            $visible = $sheets.first();
-            selected = $visible[0].id;
+        if (!this.$active.length) {
+            this.$active = $sheets.first();
+            selected = this.$active[0].id;
         }
-        const $invisible = $sheets.not($visible);
-        utils.hideOrShow($visible, true, { transition: "none" }, this.name);
+        const $invisible = $sheets.not(this.$active);
+        utils.hideOrShow(this.$active, true, { transition: "none" }, this.name);
         utils.hideOrShow($invisible, false, { transition: "none" }, this.name);
         this._updateAnchors(selected);
     }
@@ -80,6 +80,8 @@ class Pattern extends BasePattern {
         this._switch(href_parts[1]);
         $(e.target).trigger("pat-update", {
             pattern: "stacks",
+            action: "attribute-changed",
+            dom: this.$active[0],
             originalEvent: e,
         });
     }
@@ -104,13 +106,13 @@ class Pattern extends BasePattern {
     }
 
     _switch(sheet_id) {
-        const $sheet = this.$el.find("#" + sheet_id);
-        if (!$sheet.length || $sheet.hasClass("visible")) {
+        this.$active = this.$el.find("#" + sheet_id);
+        if (!this.$active.length || this.$active.hasClass("visible")) {
             return;
         }
-        const $invisible = this.$el.find(this.options.selector).not($sheet);
+        const $invisible = this.$el.find(this.options.selector).not(this.$active);
         utils.hideOrShow($invisible, false, this.options, this.name);
-        utils.hideOrShow($sheet, true, this.options, this.name);
+        utils.hideOrShow(this.$active, true, this.options, this.name);
     }
 }
 

--- a/src/pat/stacks/stacks.test.js
+++ b/src/pat/stacks/stacks.test.js
@@ -117,7 +117,12 @@ describe("pat-stacks", function () {
             await events.await_pattern_init(pattern);
             pattern.document = { URL: document.URL };
             pattern.document.URL = "http://www.example.com";
-            const spy_trigger = jest.spyOn($.fn, "trigger");
+
+            let data = null;
+            $el.on("pat-update", (e, d) => {
+                data = d;
+            });
+
             const e = {
                 target: $el,
                 type: "click",
@@ -125,10 +130,10 @@ describe("pat-stacks", function () {
                 currentTarget: { href: "http://www.example.com#s1" },
             };
             pattern._onClick(e);
-            expect(spy_trigger).toHaveBeenCalledWith(
-                "pat-update",
-                expect.objectContaining({ pattern: "stacks" })
-            );
+
+            expect(data.pattern).toBe("stacks");
+            expect(data.action).toBe("attribute-changed");
+            expect(data.dom).toBe($el[0].querySelector("#s1"));
         });
     });
 

--- a/src/pat/switch/switch.js
+++ b/src/pat/switch/switch.js
@@ -98,7 +98,11 @@ export default Base.extend({
                 target.classList.add(add);
             }
 
-            $(target).trigger("pat-update", { pattern: "switch" });
+            $(target).trigger("pat-update", {
+                pattern: "switch",
+                action: "attribute-changed",
+                dom: target,
+            });
         }
     },
 });

--- a/src/pat/switch/switch.test.js
+++ b/src/pat/switch/switch.test.js
@@ -116,14 +116,15 @@ describe("pat-switch", function () {
 
         it("Send pat-update event", function () {
             document.body.innerHTML = "<div></div>";
+            const target = document.querySelector("body div");
             const instance = new pattern(document.createElement("div"));
             const spy_trigger = jest.spyOn($.fn, "trigger");
             instance._update("body div", null, "icon-alert");
-            expect(
-                document.querySelector("body div").classList.contains("icon-alert")
-            ).toBe(true);
+            expect(target.classList.contains("icon-alert")).toBe(true);
             expect(spy_trigger).toHaveBeenCalledWith("pat-update", {
                 pattern: "switch",
+                action: "attribute-changed",
+                dom: target,
             });
         });
     });

--- a/src/pat/toggle/toggle.js
+++ b/src/pat/toggle/toggle.js
@@ -52,7 +52,11 @@ ClassToggler.prototype = {
             classes.push(value);
         }
         el.className = classes.join(" ");
-        $(el).trigger("pat-update", { pattern: "toggle" });
+        $(el).trigger("pat-update", {
+            pattern: "toggle",
+            action: "attribute-changed",
+            dom: el,
+        });
     },
 
     next(current) {
@@ -194,27 +198,19 @@ export default Base.extend({
     },
 
     _onClick() {
-        let updated = false;
-
         for (const option of this.options) {
-            const victims = $(option.selector);
-            if (!victims.length) {
+            const targets = $(option.selector);
+            if (!targets.length) {
                 continue;
             }
             const toggler = option.toggler;
-            const next_state = toggler.toggle(victims[0]);
-            for (let j = 1; j < victims.length; j++) {
-                toggler.set(victims[j], next_state);
+            const next_state = toggler.toggle(targets[0]);
+            for (const target of targets) {
+                toggler.set(target, next_state);
             }
             if (option.value_storage) {
                 option.value_storage.set(next_state);
             }
-            updated = true;
-        }
-        if (updated) {
-            // XXX: Is this necessary? pat-update gets called on changed
-            // element above.
-            this.$el.trigger("pat-update", { pattern: "toggle" });
         }
     },
 

--- a/src/pat/toggle/toggle.test.js
+++ b/src/pat/toggle/toggle.test.js
@@ -57,6 +57,24 @@ describe("pat-toggle", function () {
                 toggler.set(el, null);
                 expect(el.className).toBe("");
             });
+
+            it("triggers the pat-update event", function () {
+                const el = document.createElement("div");
+                const toggler = new ClassToggler(["active"]);
+                el.className = "active";
+
+                let data = null;
+                $(el).on("pat-update", (e, d) => {
+                    data = d;
+                });
+
+                toggler.set(el, null);
+
+                expect(el.className).toBe("");
+                expect(data.pattern).toBe("toggle");
+                expect(data.action).toBe("attribute-changed");
+                expect(data.dom).toBe(el);
+            });
         });
 
         describe("Check if ClassToggler.next()", function () {


### PR DESCRIPTION
Fix pat-autofocus regressions by using the pat-update event for re-initializing the pattern after dom changes.
That led to unifying the pat-update event handling all over Patternslib.