### PR TITLE
Feature: input checkbox to toggle checked boxes true/false.

### DIFF
--- a/src/pat/checklist/checklist.js
+++ b/src/pat/checklist/checklist.js
@@ -26,7 +26,9 @@ export default Base.extend({
     },
 
     _init() {
-        this.all_checkboxes = this.el.querySelectorAll(`input[type=checkbox]:not(${this.options.toggle}`);
+        this.all_checkboxes = this.el.querySelectorAll(
+            `input[type=checkbox]:not(${this.options.toggle}`
+        );
         this.all_radios = this.el.querySelectorAll("input[type=radio]");
 
         this.all_selects = dom.find_scoped(this.el, this.options.select);
@@ -145,10 +147,9 @@ export default Base.extend({
     },
 
     change_checked() {
-        for (const it of [...this.all_checkboxes].concat([...this.all_radios])) {
+        for (const it of [...this.all_checkboxes, ...this.all_radios]) {
             for (const label of it.labels) {
-                label.classList.remove("unchecked");
-                label.classList.remove("checked");
+                label.classList.remove("checked", "unchecked");
                 label.classList.add(it.checked ? "checked" : "unchecked");
             }
         }

--- a/src/pat/checklist/checklist.js
+++ b/src/pat/checklist/checklist.js
@@ -7,6 +7,7 @@ import "../../core/jquery-ext";
 export const parser = new Parser("checklist");
 parser.addArgument("select", ".select-all");
 parser.addArgument("deselect", ".deselect-all");
+parser.addArgument("toggle", ".toggle-all");
 
 export default Base.extend({
     name: "checklist",
@@ -14,6 +15,7 @@ export default Base.extend({
     jquery_plugin: true,
     all_selects: [],
     all_deselects: [],
+    all_toggles: [],
     all_checkboxes: [],
     all_radios: [],
 
@@ -24,7 +26,7 @@ export default Base.extend({
     },
 
     _init() {
-        this.all_checkboxes = this.el.querySelectorAll("input[type=checkbox]");
+        this.all_checkboxes = this.el.querySelectorAll(`input[type=checkbox]:not(${this.options.toggle}`);
         this.all_radios = this.el.querySelectorAll("input[type=radio]");
 
         this.all_selects = dom.find_scoped(this.el, this.options.select);
@@ -37,14 +39,19 @@ export default Base.extend({
             btn.addEventListener("click", this.deselect_all.bind(this));
         }
 
+        this.all_toggles = dom.find_scoped(this.el, this.options.toggle);
+        for (const btn of this.all_toggles) {
+            btn.addEventListener("click", this.toggle_all.bind(this));
+        }
+
         // update select/deselect button status
         this.el.addEventListener("change", this._handler_change.bind(this));
-        this.change_buttons();
+        this.change_buttons_and_toggles();
         this.change_checked();
     },
 
     _handler_change() {
-        utils.debounce(() => this.change_buttons(), 50)();
+        utils.debounce(() => this.change_buttons_and_toggles(), 50)();
         utils.debounce(() => this.change_checked(), 50)();
     },
 
@@ -65,7 +72,7 @@ export default Base.extend({
         let res;
         let parent = el.parentNode;
         while (parent) {
-            res = parent.querySelectorAll(sel);
+            res = parent.querySelectorAll(`${sel}:not(${this.options.toggle})`);
             if (res.length || parent === this.el) {
                 // return if results were found or we reached the pattern top
                 return res;
@@ -84,7 +91,7 @@ export default Base.extend({
         return chkbxs;
     },
 
-    change_buttons() {
+    change_buttons_and_toggles() {
         let chkbxs;
         for (const btn of this.all_selects) {
             chkbxs = this.find_checkboxes(btn, "input[type=checkbox]");
@@ -97,6 +104,12 @@ export default Base.extend({
             btn.disabled = [...chkbxs]
                 .map((el) => el.matches(":checked"))
                 .every((it) => it === false);
+        }
+        for (const tgl of this.all_toggles) {
+            chkbxs = this.find_checkboxes(tgl, "input[type=checkbox]");
+            tgl.checked = [...chkbxs]
+                .map((el) => el.matches(":checked"))
+                .every((it) => it === true);
         }
     },
 
@@ -121,6 +134,16 @@ export default Base.extend({
         }
     },
 
+    toggle_all(e) {
+        e.preventDefault();
+        const checked = e.target.checked;
+        const chkbxs = this.find_checkboxes(e.target, "input[type=checkbox]");
+        for (const box of chkbxs) {
+            box.checked = checked;
+            box.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+        }
+    },
+
     change_checked() {
         for (const it of [...this.all_checkboxes].concat([...this.all_radios])) {
             for (const label of it.labels) {
@@ -133,7 +156,7 @@ export default Base.extend({
         for (const fieldset of dom.querySelectorAllAndMe(this.el, "fieldset")) {
             if (
                 fieldset.querySelectorAll(
-                    "input[type=checkbox]:checked, input[type=radio]:checked"
+                    `input[type=checkbox]:checked:not(${this.options.toggle}), input[type=radio]:checked`
                 ).length
             ) {
                 fieldset.classList.remove("unchecked");

--- a/src/pat/checklist/checklist.test.js
+++ b/src/pat/checklist/checklist.test.js
@@ -553,4 +553,44 @@ describe("pat-checklist", () => {
         expect(l2.classList.contains("unchecked")).toEqual(true);
         expect(l3.classList.contains("checked")).toEqual(true);
     });
+
+    it("Initializes on checkboxes with toggle-all checkbox", async () => {
+        document.body.innerHTML = `
+            <fieldset class="pat-checklist">
+                <label><input type="checkbox" class="toggle-all"> toggle selection</label>
+                <label><input type="checkbox" checked>Option 1</label>
+                <label><input type="checkbox">Option 2</label>
+                <label><input type="checkbox">Option 3</label>
+            </fieldset>
+        `;
+        Pattern.init(document.querySelector(".pat-checklist"));
+
+        const [f1] = document.querySelectorAll("fieldset");
+        const [t1] = document.querySelectorAll("input.toggle-all");
+        const [i1, i2, i3] = document.querySelectorAll("input[type=checkbox]:not(.toggle-all)");
+
+        expect(f1.classList.contains("checked")).toEqual(true);
+        expect(i1.checked).toEqual(true);
+        expect(i2.checked).toEqual(false);
+        expect(i3.checked).toEqual(false);
+        expect(t1.checked).toEqual(false);
+
+        t1.click();
+        await utils.timeout(100);
+
+        expect(f1.classList.contains("checked")).toEqual(true);
+        expect(i1.checked).toEqual(true);
+        expect(i2.checked).toEqual(true);
+        expect(i3.checked).toEqual(true);
+        expect(t1.checked).toEqual(true);
+
+        t1.click();
+        await utils.timeout(100);
+
+        expect(f1.classList.contains("unchecked")).toEqual(true);
+        expect(i1.checked).toEqual(false);
+        expect(i2.checked).toEqual(false);
+        expect(i3.checked).toEqual(false);
+        expect(t1.checked).toEqual(false);
+    });
 });

--- a/src/pat/checklist/documentation.md
+++ b/src/pat/checklist/documentation.md
@@ -53,8 +53,10 @@ disabled. And if no checkboxes are checked the deselect-all button will
 be disabled.
 
 
-### JavaScript API
+### Option reference
 
-The JavaScript API is entirely optional since Patterns already
-automatically enables the switching behaviour for all elements with a
-`data-pat-checklist` attribute.
+| Property    | Type    | Default Value    | Description                                                                                                                                                                                                    |
+| ----------- | ------- | ---------------- | -------------------------------------------- |
+| `select`    | String  | `.select-all`    | CSS selector for the "Select All" button.    |
+| `deselect`  | String  | `.deselect-all`  | CSS selector for the "Deselect All" button.  |
+| `toggle`    | String  | `.toggle-all`    | CSS selector for the "Toggle" button.        |

--- a/src/pat/checklist/documentation.md
+++ b/src/pat/checklist/documentation.md
@@ -10,7 +10,7 @@ select and deselect all checkboxes in a block. This requires two changes
 in your markup:
 
 1.  add a `pat-checklist` class to the containing element
-2.  add a select and deselect buttons
+2.  add a select and deselect buttons or a toggle checkbox
 
 Here is a simple example.
 
@@ -26,9 +26,19 @@ Here is a simple example.
       <label><input type="checkbox"/> Option four</label>
     </fieldset>
 
+An example with toggle checkbox.
+
+    <fieldset class="pat-checklist">
+      <label><input type="checkbox" class="toggle-all"> Select all/none</label>
+      <label><input type="checkbox" checked="checked"/> Option one</label>
+      <label><input type="checkbox"/> Option two</label>
+      <label><input type="checkbox"/> Option three</label>
+      <label><input type="checkbox"/> Option four</label>
+    </fieldset>
+
 The selectors used to find the select-all and deselect-all buttons are
 configurable. The default values are `.functions .select-all` and
-`.functions .dselect-all`. You can configure them using shorthand
+`.functions .deselect-all`. You can configure them using shorthand
 notation:
 
     <fieldset class="pat-checklist" data-pat-checklist=".selectAll .deselectAll">
@@ -41,6 +51,7 @@ The buttons will be disabled if they would not make any changes. That
 is: if all checkboxes are already checked the select-all button will be
 disabled. And if no checkboxes are checked the deselect-all button will
 be disabled.
+
 
 ### JavaScript API
 

--- a/src/pat/checklist/index.html
+++ b/src/pat/checklist/index.html
@@ -12,7 +12,7 @@
     </head>
     <body>
         <div class="functions" id="ElemOutsidePatChecklist">
-        <h3>Select / Deselect all for exmaple 2</h3>
+        <h3>Select / Deselect all for example 2</h3>
           <div class="pat-toolbar">
               <div class="toggles list-functions pat-button-cluster">
                   <button class="pat-button select-all">Select all</button>
@@ -73,9 +73,27 @@
                 </fieldset>
             </div>
         </form>
+
         <form class="vertical row">
             <div class="six columns">
-                <h3>Example 3: Hierarchy of Checkboxes</h3>
+                <h3>Example 3: Toggle checkbox</h3>
+                <p>
+                    Clicking the toggle checkbox to change the states.
+                </p>
+                <fieldset class="pat-checklist checklist">
+                    <label><input type="checkbox" class="toggle-all" /> Toggle checkboxes</label>
+
+                    <label><input type="checkbox" checked="checked" /> Option one</label>
+                    <label><input type="checkbox" /> Option two</label>
+                    <label><input type="checkbox" /> Option three</label>
+                    <label><input type="checkbox" /> Option four</label>
+                </fieldset>
+            </div>
+        </form>
+
+        <form class="vertical row">
+            <div class="six columns">
+                <h3>Example 4: Hierarchy of Checkboxes</h3>
                 <p>
                     Clicking select all / deselect all only affects parent of
                     buttons and its children.
@@ -136,5 +154,6 @@
             </div>
             <div class="six columns"></div>
         </form>
+
     </body>
 </html>


### PR DESCRIPTION
I need a checkbox (for example at the header column of a table) to select/deselect all sibling checkboxes.

This extends the `pat-checklist` pattern to look for a `<input class="toggle-all" />` which selects/deselets all its siblings according to its checked state.