### PR TITLE
fix(pat scroll-marker): Use the correct scroll container

### DIFF
--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -47,7 +47,11 @@ const querySelectorAllAndMe = (el, selector) => {
 /**
  * Wrap a element with a wrapper element.
  *
+ * The element to be wrapped will be moved into the wrapper element and the
+ * wrapper element is placed just before the old element was.
+ *
  * @param {Node} el - The DOM node to wrap.
+ * @param {Node} wrapper - The wrapper element.
  */
 const wrap = (el, wrapper) => {
     // See: https://stackoverflow.com/a/13169465/1337474

--- a/src/pat/scroll-marker/scroll-marker.js
+++ b/src/pat/scroll-marker/scroll-marker.js
@@ -53,8 +53,16 @@ class Pattern extends BasePattern {
         // Find a possible scroll container based on the first target/content
         // element in the observables map.
         // Note, a Map's values method returns an iterator.
-        const first_target = this.observables.values().next()?.value.target;
-        this.scroll_container = dom.find_scroll_container(first_target, "y", window);
+        const first_observable = this.observables.values().next();
+        if (!first_observable.value) {
+            // No targets found.
+            return;
+        }
+        this.scroll_container = dom.find_scroll_container(
+            first_observable.value.target,
+            "y",
+            window
+        );
         // window.innerHeight or el.clientHeight
         const scroll_container_height =
             typeof this.scroll_container.innerHeight !== "undefined"

--- a/src/pat/scroll-marker/scroll-marker.js
+++ b/src/pat/scroll-marker/scroll-marker.js
@@ -50,7 +50,11 @@ class Pattern extends BasePattern {
                 )
         );
 
-        this.scroll_container = dom.find_scroll_container(this.el, "y", window);
+        // Find a possible scroll container based on the first target/content
+        // element in the observables map.
+        // Note, a Map's values method returns an iterator.
+        const first_target = this.observables.values().next()?.value.target;
+        this.scroll_container = dom.find_scroll_container(first_target, "y", window);
         // window.innerHeight or el.clientHeight
         const scroll_container_height =
             typeof this.scroll_container.innerHeight !== "undefined"

--- a/src/pat/scroll-marker/scroll-marker.js
+++ b/src/pat/scroll-marker/scroll-marker.js
@@ -33,7 +33,7 @@ class Pattern extends BasePattern {
 
     async init() {
         // Get all elements that are referenced by links in the current page.
-        this.observeables = new Map(
+        this.observables = new Map(
             [...dom.querySelectorAllAndMe(this.el, "a[href^='#']")]
                 .map(
                     // Create the structure:
@@ -85,7 +85,7 @@ class Pattern extends BasePattern {
                 threshold: utils.threshold_list(10),
             }
         );
-        for (const it of this.observeables.values()) {
+        for (const it of this.observables.values()) {
             observer.observe(it.target);
         }
     }
@@ -97,7 +97,7 @@ class Pattern extends BasePattern {
         for (const entry of entries) {
             // Set the in-view class on the link.
             const id = entry.target.getAttribute("id");
-            const item = this.observeables.get(id);
+            const item = this.observables.get(id);
             if (!item) {
                 continue;
             }
@@ -122,13 +122,13 @@ class Pattern extends BasePattern {
         // Set the item which is nearest to the scroll container's middle to current.
 
         // First, set all to non-current.
-        for (const item of this.observeables.values()) {
+        for (const item of this.observables.values()) {
             item.link.classList.remove(this.options["current-class"]);
             item.target.classList.remove(this.options["current-content-class"]);
         }
 
         // Sort by distance to the middle of the scroll container.
-        let items_by_weight = [...this.observeables.values()].map((it) => it.target);
+        let items_by_weight = [...this.observables.values()].map((it) => it.target);
         log.debug("items_by_weight initial: ", items_by_weight);
 
         if (this.options.visibility === "most-visible") {
@@ -216,7 +216,7 @@ class Pattern extends BasePattern {
 
         // Finally, set the nearest to current.
         const nearest = items_by_weight[0];
-        const nearest_link = this.observeables.get(nearest?.getAttribute("id"))?.link;
+        const nearest_link = this.observables.get(nearest?.getAttribute("id"))?.link;
         log.debug("nearest: ", nearest);
         log.debug("nearest_link: ", nearest_link);
         if (nearest_link) {

--- a/src/pat/scroll-marker/scroll-marker.test.js
+++ b/src/pat/scroll-marker/scroll-marker.test.js
@@ -70,6 +70,9 @@ async function create_scroll_marker({
     });
 
     const instance = new Pattern(el, options);
+    jest.spyOn(instance, "scroll_marker_callback");
+    jest.spyOn(instance, "scroll_marker_current_callback");
+
     await events.await_pattern_init(instance);
 
     instance.scroll_marker_callback([
@@ -99,6 +102,24 @@ describe("pat-scroll-marker", () => {
         document.body.innerHTML = "";
     });
 
+    it("0: Inexistent targets do not break the runtime", async () => {
+        document.body.innerHTML = `
+          <nav class="pat-scroll-marker">
+            <a href="#id1">link 1</a>
+            <a href="#id2">link 2</a>
+            <a href="#id3">link 3</a>
+          </nav>
+        `;
+        const el = document.querySelector(".pat-scroll-marker");
+        const instance = new Pattern(el);
+        jest.spyOn(instance, "scroll_marker_callback");
+        jest.spyOn(instance, "scroll_marker_current_callback");
+        await events.await_pattern_init(instance);
+
+        expect(instance.scroll_marker_callback).not.toHaveBeenCalled();
+        expect(instance.scroll_marker_current_callback).not.toHaveBeenCalled();
+    });
+
     describe("1: Test on window as scroll container", () => {
         it("1.1: default values, id3 is current", async () => {
             // With the default values the baseline is in the middle and the
@@ -112,6 +133,10 @@ describe("pat-scroll-marker", () => {
             // Without any overflow settings in other containers, the scroll
             // container is the window object.
             expect(instance.scroll_container).toBe(window);
+
+            // Callbacks have been called.
+            expect(instance.scroll_marker_callback).toHaveBeenCalled();
+            expect(instance.scroll_marker_current_callback).toHaveBeenCalled();
 
             expect(nav_id1.classList.contains("in-view")).toBe(false);
             expect(nav_id2.classList.contains("in-view")).toBe(true);
@@ -127,12 +152,16 @@ describe("pat-scroll-marker", () => {
         });
 
         it("1.2: distance 0, id2 is current", async () => {
-            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+            const { instance, nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
                 await create_scroll_marker({
                     options: {
                         distance: 0,
                     },
                 });
+
+            // Callbacks have been called.
+            expect(instance.scroll_marker_callback).toHaveBeenCalled();
+            expect(instance.scroll_marker_current_callback).toHaveBeenCalled();
 
             expect(nav_id1.classList.contains("in-view")).toBe(false);
             expect(nav_id2.classList.contains("in-view")).toBe(true);
@@ -148,13 +177,17 @@ describe("pat-scroll-marker", () => {
         });
 
         it("1.3: distance 50, side bottom, id2 is current", async () => {
-            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+            const { instance, nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
                 await create_scroll_marker({
                     options: {
                         distance: "50%",
                         side: "bottom",
                     },
                 });
+
+            // Callbacks have been called.
+            expect(instance.scroll_marker_callback).toHaveBeenCalled();
+            expect(instance.scroll_marker_current_callback).toHaveBeenCalled();
 
             expect(nav_id1.classList.contains("in-view")).toBe(false);
             expect(nav_id2.classList.contains("in-view")).toBe(true);
@@ -174,7 +207,7 @@ describe("pat-scroll-marker", () => {
             // Only the visibility is set to most-visible, which means that id2 is
             // the current one,
             //
-            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+            const { instance, nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
                 await create_scroll_marker({
                     options: {
                         distance: "50%",
@@ -182,6 +215,10 @@ describe("pat-scroll-marker", () => {
                         visibility: "most-visible",
                     },
                 });
+
+            // Callbacks have been called.
+            expect(instance.scroll_marker_callback).toHaveBeenCalled();
+            expect(instance.scroll_marker_current_callback).toHaveBeenCalled();
 
             expect(nav_id1.classList.contains("in-view")).toBe(false);
             expect(nav_id2.classList.contains("in-view")).toBe(true);
@@ -211,6 +248,10 @@ describe("pat-scroll-marker", () => {
             // container is the window object.
             expect(instance.scroll_container).toBe(main);
 
+            // Callbacks have been called.
+            expect(instance.scroll_marker_callback).toHaveBeenCalled();
+            expect(instance.scroll_marker_current_callback).toHaveBeenCalled();
+
             expect(nav_id1.classList.contains("in-view")).toBe(false);
             expect(nav_id2.classList.contains("in-view")).toBe(true);
             expect(nav_id3.classList.contains("in-view")).toBe(true);
@@ -225,13 +266,17 @@ describe("pat-scroll-marker", () => {
         });
 
         it("2.2: distance 0, id2 is current", async () => {
-            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+            const { instance, nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
                 await create_scroll_marker({
                     options: {
                         distance: 0,
                     },
                     scroll_container_main: true,
                 });
+
+            // Callbacks have been called.
+            expect(instance.scroll_marker_callback).toHaveBeenCalled();
+            expect(instance.scroll_marker_current_callback).toHaveBeenCalled();
 
             expect(nav_id1.classList.contains("in-view")).toBe(false);
             expect(nav_id2.classList.contains("in-view")).toBe(true);
@@ -247,7 +292,7 @@ describe("pat-scroll-marker", () => {
         });
 
         it("2.3: distance 50, side bottom, id2 is current", async () => {
-            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+            const { instance, nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
                 await create_scroll_marker({
                     options: {
                         distance: "50%",
@@ -255,6 +300,10 @@ describe("pat-scroll-marker", () => {
                     },
                     scroll_container_main: true,
                 });
+
+            // Callbacks have been called.
+            expect(instance.scroll_marker_callback).toHaveBeenCalled();
+            expect(instance.scroll_marker_current_callback).toHaveBeenCalled();
 
             expect(nav_id1.classList.contains("in-view")).toBe(false);
             expect(nav_id2.classList.contains("in-view")).toBe(true);
@@ -274,7 +323,7 @@ describe("pat-scroll-marker", () => {
             // Only the visibility is set to most-visible, which means that id2 is
             // the current one,
             //
-            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+            const { instance, nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
                 await create_scroll_marker({
                     options: {
                         distance: "50%",
@@ -283,6 +332,10 @@ describe("pat-scroll-marker", () => {
                     },
                     scroll_container_main: true,
                 });
+
+            // Callbacks have been called.
+            expect(instance.scroll_marker_callback).toHaveBeenCalled();
+            expect(instance.scroll_marker_current_callback).toHaveBeenCalled();
 
             expect(nav_id1.classList.contains("in-view")).toBe(false);
             expect(nav_id2.classList.contains("in-view")).toBe(true);

--- a/src/pat/scroll-marker/scroll-marker.test.js
+++ b/src/pat/scroll-marker/scroll-marker.test.js
@@ -2,7 +2,10 @@ import Pattern from "./scroll-marker";
 import events from "../../core/events";
 import utils from "../../core/utils";
 
-async function create_scroll_marker({ options = {} } = {}) {
+async function create_scroll_marker({
+    options = {},
+    scroll_container_main = false,
+} = {}) {
     document.body.innerHTML = `
           <nav class="pat-scroll-marker">
             <a href="#id1">link 1</a>
@@ -10,16 +13,23 @@ async function create_scroll_marker({ options = {} } = {}) {
             <a href="#id3">link 3</a>
           </nav>
 
-          <section id="id1">
-          </section>
+          <main>
+            <section id="id1">
+            </section>
 
-          <section id="id2">
-          </section>
+            <section id="id2">
+            </section>
 
-          <section id="id3">
-          </section>
+            <section id="id3">
+            </section>
+          </main>
         `;
     const el = document.querySelector(".pat-scroll-marker");
+
+    const main = document.querySelector("main");
+    if (scroll_container_main) {
+        main.style["overflow-y"] = "auto";
+    }
 
     const nav_id1 = document.querySelector("[href='#id1']");
     const nav_id2 = document.querySelector("[href='#id2']");
@@ -30,6 +40,14 @@ async function create_scroll_marker({ options = {} } = {}) {
     const id3 = document.querySelector("#id3");
 
     // id1 not, id2 fully, id3 partly visible
+
+    jest.spyOn(main, "clientHeight", "get").mockReturnValue(100);
+    jest.spyOn(main, "getBoundingClientRect").mockImplementation(() => {
+        return {
+            top: 0,
+            bottom: 100,
+        };
+    });
 
     jest.replaceProperty(window, "innerHeight", 100);
     jest.spyOn(id1, "getBoundingClientRect").mockImplementation(() => {
@@ -72,6 +90,7 @@ async function create_scroll_marker({ options = {} } = {}) {
         id1: id1,
         id2: id2,
         id3: id3,
+        main: main,
     };
 }
 
@@ -162,6 +181,107 @@ describe("pat-scroll-marker", () => {
                         side: "top",
                         visibility: "most-visible",
                     },
+                });
+
+            expect(nav_id1.classList.contains("in-view")).toBe(false);
+            expect(nav_id2.classList.contains("in-view")).toBe(true);
+            expect(nav_id3.classList.contains("in-view")).toBe(true);
+
+            expect(nav_id1.classList.contains("current")).toBe(false);
+            expect(nav_id2.classList.contains("current")).toBe(true);
+            expect(nav_id3.classList.contains("current")).toBe(false);
+
+            expect(id1.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id2.classList.contains("scroll-marker-current")).toBe(true);
+            expect(id3.classList.contains("scroll-marker-current")).toBe(false);
+        });
+    });
+
+    describe("2: Test on element as scroll container", () => {
+        it("2.1: default values, id3 is current", async () => {
+            // With the default values the baseline is in the middle and the
+            // content element side's are calculated from the top. id3 is therefore
+            // the current one, as it's top is nearer to the middle than the top of
+            // id2.
+
+            const { instance, nav_id1, nav_id2, nav_id3, id1, id2, id3, main } =
+                await create_scroll_marker({ scroll_container_main: true });
+
+            // Without any overflow settings in other containers, the scroll
+            // container is the window object.
+            expect(instance.scroll_container).toBe(main);
+
+            expect(nav_id1.classList.contains("in-view")).toBe(false);
+            expect(nav_id2.classList.contains("in-view")).toBe(true);
+            expect(nav_id3.classList.contains("in-view")).toBe(true);
+
+            expect(nav_id1.classList.contains("current")).toBe(false);
+            expect(nav_id2.classList.contains("current")).toBe(false);
+            expect(nav_id3.classList.contains("current")).toBe(true);
+
+            expect(id1.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id2.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id3.classList.contains("scroll-marker-current")).toBe(true);
+        });
+
+        it("2.2: distance 0, id2 is current", async () => {
+            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+                await create_scroll_marker({
+                    options: {
+                        distance: 0,
+                    },
+                    scroll_container_main: true,
+                });
+
+            expect(nav_id1.classList.contains("in-view")).toBe(false);
+            expect(nav_id2.classList.contains("in-view")).toBe(true);
+            expect(nav_id3.classList.contains("in-view")).toBe(true);
+
+            expect(nav_id1.classList.contains("current")).toBe(false);
+            expect(nav_id2.classList.contains("current")).toBe(true);
+            expect(nav_id3.classList.contains("current")).toBe(false);
+
+            expect(id1.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id2.classList.contains("scroll-marker-current")).toBe(true);
+            expect(id3.classList.contains("scroll-marker-current")).toBe(false);
+        });
+
+        it("2.3: distance 50, side bottom, id2 is current", async () => {
+            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+                await create_scroll_marker({
+                    options: {
+                        distance: "50%",
+                        side: "bottom",
+                    },
+                    scroll_container_main: true,
+                });
+
+            expect(nav_id1.classList.contains("in-view")).toBe(false);
+            expect(nav_id2.classList.contains("in-view")).toBe(true);
+            expect(nav_id3.classList.contains("in-view")).toBe(true);
+
+            expect(nav_id1.classList.contains("current")).toBe(false);
+            expect(nav_id2.classList.contains("current")).toBe(true);
+            expect(nav_id3.classList.contains("current")).toBe(false);
+
+            expect(id1.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id2.classList.contains("scroll-marker-current")).toBe(true);
+            expect(id3.classList.contains("scroll-marker-current")).toBe(false);
+        });
+
+        it("2.4: distance 50, side top, visibility: most-visible, id2 is current", async () => {
+            // Here we have again the default values, this time explicitly set.
+            // Only the visibility is set to most-visible, which means that id2 is
+            // the current one,
+            //
+            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+                await create_scroll_marker({
+                    options: {
+                        distance: "50%",
+                        side: "top",
+                        visibility: "most-visible",
+                    },
+                    scroll_container_main: true,
                 });
 
             expect(nav_id1.classList.contains("in-view")).toBe(false);

--- a/src/pat/scroll-marker/scroll-marker.test.js
+++ b/src/pat/scroll-marker/scroll-marker.test.js
@@ -2,7 +2,7 @@ import Pattern from "./scroll-marker";
 import events from "../../core/events";
 import utils from "../../core/utils";
 
-async function create_scroll_marker(options = {}) {
+async function create_scroll_marker({ options = {} } = {}) {
     document.body.innerHTML = `
           <nav class="pat-scroll-marker">
             <a href="#id1">link 1</a>
@@ -64,6 +64,7 @@ async function create_scroll_marker(options = {}) {
     await utils.timeout(200);
 
     return {
+        instance: instance,
         el: el,
         nav_id1: nav_id1,
         nav_id2: nav_id2,
@@ -79,86 +80,101 @@ describe("pat-scroll-marker", () => {
         document.body.innerHTML = "";
     });
 
-    it("1: default values, id3 is current", async () => {
-        // With the default values the baseline is in the middle and the
-        // content element side's are calculated from the top. id3 is therefore
-        // the current one, as it's top is nearer to the middle than the top of
-        // id2.
+    describe("1: Test on window as scroll container", () => {
+        it("1.1: default values, id3 is current", async () => {
+            // With the default values the baseline is in the middle and the
+            // content element side's are calculated from the top. id3 is therefore
+            // the current one, as it's top is nearer to the middle than the top of
+            // id2.
 
-        const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
-            await create_scroll_marker();
+            const { instance, nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+                await create_scroll_marker();
 
-        expect(nav_id1.classList.contains("in-view")).toBe(false);
-        expect(nav_id2.classList.contains("in-view")).toBe(true);
-        expect(nav_id3.classList.contains("in-view")).toBe(true);
+            // Without any overflow settings in other containers, the scroll
+            // container is the window object.
+            expect(instance.scroll_container).toBe(window);
 
-        expect(nav_id1.classList.contains("current")).toBe(false);
-        expect(nav_id2.classList.contains("current")).toBe(false);
-        expect(nav_id3.classList.contains("current")).toBe(true);
+            expect(nav_id1.classList.contains("in-view")).toBe(false);
+            expect(nav_id2.classList.contains("in-view")).toBe(true);
+            expect(nav_id3.classList.contains("in-view")).toBe(true);
 
-        expect(id1.classList.contains("scroll-marker-current")).toBe(false);
-        expect(id2.classList.contains("scroll-marker-current")).toBe(false);
-        expect(id3.classList.contains("scroll-marker-current")).toBe(true);
-    });
+            expect(nav_id1.classList.contains("current")).toBe(false);
+            expect(nav_id2.classList.contains("current")).toBe(false);
+            expect(nav_id3.classList.contains("current")).toBe(true);
 
-    it("2: distance 0, id2 is current", async () => {
-        const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } = await create_scroll_marker({
-            distance: 0,
+            expect(id1.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id2.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id3.classList.contains("scroll-marker-current")).toBe(true);
         });
 
-        expect(nav_id1.classList.contains("in-view")).toBe(false);
-        expect(nav_id2.classList.contains("in-view")).toBe(true);
-        expect(nav_id3.classList.contains("in-view")).toBe(true);
+        it("1.2: distance 0, id2 is current", async () => {
+            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+                await create_scroll_marker({
+                    options: {
+                        distance: 0,
+                    },
+                });
 
-        expect(nav_id1.classList.contains("current")).toBe(false);
-        expect(nav_id2.classList.contains("current")).toBe(true);
-        expect(nav_id3.classList.contains("current")).toBe(false);
+            expect(nav_id1.classList.contains("in-view")).toBe(false);
+            expect(nav_id2.classList.contains("in-view")).toBe(true);
+            expect(nav_id3.classList.contains("in-view")).toBe(true);
 
-        expect(id1.classList.contains("scroll-marker-current")).toBe(false);
-        expect(id2.classList.contains("scroll-marker-current")).toBe(true);
-        expect(id3.classList.contains("scroll-marker-current")).toBe(false);
-    });
+            expect(nav_id1.classList.contains("current")).toBe(false);
+            expect(nav_id2.classList.contains("current")).toBe(true);
+            expect(nav_id3.classList.contains("current")).toBe(false);
 
-    it("3: distance 50, side bottom, id2 is current", async () => {
-        const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } = await create_scroll_marker({
-            distance: "50%",
-            side: "bottom",
+            expect(id1.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id2.classList.contains("scroll-marker-current")).toBe(true);
+            expect(id3.classList.contains("scroll-marker-current")).toBe(false);
         });
 
-        expect(nav_id1.classList.contains("in-view")).toBe(false);
-        expect(nav_id2.classList.contains("in-view")).toBe(true);
-        expect(nav_id3.classList.contains("in-view")).toBe(true);
+        it("1.3: distance 50, side bottom, id2 is current", async () => {
+            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+                await create_scroll_marker({
+                    options: {
+                        distance: "50%",
+                        side: "bottom",
+                    },
+                });
 
-        expect(nav_id1.classList.contains("current")).toBe(false);
-        expect(nav_id2.classList.contains("current")).toBe(true);
-        expect(nav_id3.classList.contains("current")).toBe(false);
+            expect(nav_id1.classList.contains("in-view")).toBe(false);
+            expect(nav_id2.classList.contains("in-view")).toBe(true);
+            expect(nav_id3.classList.contains("in-view")).toBe(true);
 
-        expect(id1.classList.contains("scroll-marker-current")).toBe(false);
-        expect(id2.classList.contains("scroll-marker-current")).toBe(true);
-        expect(id3.classList.contains("scroll-marker-current")).toBe(false);
-    });
+            expect(nav_id1.classList.contains("current")).toBe(false);
+            expect(nav_id2.classList.contains("current")).toBe(true);
+            expect(nav_id3.classList.contains("current")).toBe(false);
 
-    it("4: distance 50, side top, visibility: most-visible, id2 is current", async () => {
-        // Here we have again the default values, this time explicitly set.
-        // Only the visibility is set to most-visible, which means that id2 is
-        // the current one,
-        //
-        const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } = await create_scroll_marker({
-            distance: "50%",
-            side: "top",
-            visibility: "most-visible",
+            expect(id1.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id2.classList.contains("scroll-marker-current")).toBe(true);
+            expect(id3.classList.contains("scroll-marker-current")).toBe(false);
         });
 
-        expect(nav_id1.classList.contains("in-view")).toBe(false);
-        expect(nav_id2.classList.contains("in-view")).toBe(true);
-        expect(nav_id3.classList.contains("in-view")).toBe(true);
+        it("1.4: distance 50, side top, visibility: most-visible, id2 is current", async () => {
+            // Here we have again the default values, this time explicitly set.
+            // Only the visibility is set to most-visible, which means that id2 is
+            // the current one,
+            //
+            const { nav_id1, nav_id2, nav_id3, id1, id2, id3 } =
+                await create_scroll_marker({
+                    options: {
+                        distance: "50%",
+                        side: "top",
+                        visibility: "most-visible",
+                    },
+                });
 
-        expect(nav_id1.classList.contains("current")).toBe(false);
-        expect(nav_id2.classList.contains("current")).toBe(true);
-        expect(nav_id3.classList.contains("current")).toBe(false);
+            expect(nav_id1.classList.contains("in-view")).toBe(false);
+            expect(nav_id2.classList.contains("in-view")).toBe(true);
+            expect(nav_id3.classList.contains("in-view")).toBe(true);
 
-        expect(id1.classList.contains("scroll-marker-current")).toBe(false);
-        expect(id2.classList.contains("scroll-marker-current")).toBe(true);
-        expect(id3.classList.contains("scroll-marker-current")).toBe(false);
+            expect(nav_id1.classList.contains("current")).toBe(false);
+            expect(nav_id2.classList.contains("current")).toBe(true);
+            expect(nav_id3.classList.contains("current")).toBe(false);
+
+            expect(id1.classList.contains("scroll-marker-current")).toBe(false);
+            expect(id2.classList.contains("scroll-marker-current")).toBe(true);
+            expect(id3.classList.contains("scroll-marker-current")).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
The scroll container was potentially wrong and is a parent of the
hash-link target contents and not a parent of the navigation where
pat-scroll-container (or pat-navigation) are defined upon.