### PR TITLE
Improve lib-input-change-events

### DIFF
--- a/src/lib/input-change-events.js
+++ b/src/lib/input-change-events.js
@@ -30,15 +30,15 @@ const _ = {
     },
 
     setupInputHandlers($el) {
-        if (!$el.is(":input")) {
+        if ($el.is(":input")) {
+            // The element itself is an input, se we simply register a
+            // handler fot it.
+            _.registerHandlersForElement.bind($el)();
+        } else {
             // We've been given an element that is not a form input. We
             // therefore assume that it's a container of form inputs and
             // register handlers for its children.
             $el.findInclusive(":input").each(_.registerHandlersForElement);
-        } else {
-            // The element itself is an input, se we simply register a
-            // handler fot it.
-            _.registerHandlersForElement.bind($el)();
         }
     },
 

--- a/src/lib/input-change-events.js
+++ b/src/lib/input-change-events.js
@@ -1,11 +1,12 @@
 // helper functions to make all input elements
 import $ from "jquery";
 import logging from "../core/logging";
+
 const namespace = "input-change-events";
 const log = logging.getLogger(namespace);
 
 const _ = {
-    setup: function ($el, pat) {
+    setup($el, pat) {
         if (!pat) {
             log.error("The name of the calling pattern has to be set.");
             return;
@@ -28,7 +29,7 @@ const _ = {
         }
     },
 
-    setupInputHandlers: function ($el) {
+    setupInputHandlers($el) {
         if (!$el.is(":input")) {
             // We've been given an element that is not a form input. We
             // therefore assume that it's a container of form inputs and
@@ -41,7 +42,7 @@ const _ = {
         }
     },
 
-    registerHandlersForElement: function () {
+    registerHandlersForElement() {
         const $el = $(this);
         const isNumber = $el.is("input[type=number]");
         const isText = $el.is("input:text, input[type=search], textarea");
@@ -73,7 +74,7 @@ const _ = {
         });
     },
 
-    remove: function ($el, pat) {
+    remove($el, pat) {
         let patterns = $el.data(namespace) || [];
         if (patterns.indexOf(pat) === -1) {
             log.warn("input-change-events were never installed for " + pat);

--- a/src/lib/input-change-events.js
+++ b/src/lib/input-change-events.js
@@ -38,11 +38,21 @@ const _ = {
             // We've been given an element that is not a form input. We
             // therefore assume that it's a container of form inputs and
             // register handlers for its children.
-            $el.findInclusive(":input").each(_.registerHandlersForElement);
+            for (const _el of $el[0].closest("form").elements) {
+                // Search for all form elements, also those outside the form
+                // container.
+                _.registerHandlersForElement.bind(_el)();
+            }
         }
     },
 
     registerHandlersForElement() {
+        let el_within_form = true;
+        const $form = $(this.form);
+        if (this.closest("form") !== this.form) {
+            el_within_form = false;
+        }
+
         const $el = $(this);
         const isNumber = $el.is("input[type=number]");
         const isText = $el.is("input:text, input[type=search], textarea");
@@ -53,24 +63,24 @@ const _ = {
             if ("onkeyup" in window) {
                 $el.on("keyup." + namespace, function () {
                     log.debug("translating keyup");
-                    $el.trigger("input-change");
+                    (el_within_form ? $el : $form).trigger("input-change");
                 });
             }
         }
         if (isText || isNumber) {
             $el.on("input." + namespace, function () {
                 log.debug("translating input");
-                $el.trigger("input-change");
+                (el_within_form ? $el : $form).trigger("input-change");
             });
         } else {
             $el.on("change." + namespace, function () {
                 log.debug("translating change");
-                $el.trigger("input-change");
+                (el_within_form ? $el : $form).trigger("input-change");
             });
         }
 
         $el.on("blur", function () {
-            $el.trigger("input-defocus");
+            (el_within_form ? $el : $form).trigger("input-defocus");
         });
     },
 


### PR DESCRIPTION
- lib input-change-events: Modernize a bit.

- lib input-change-events: Avoid negative condition.

- fix(lib input-change-events): Support form elements outsde a form container.
  Also support form elements which are outside of a form container.
This allows pat-autosubmit to also work with form inputs which are bound
to a form but not contained wiithin.

Also see:
https://github.com/Patternslib/Patterns/pull/1154
https://github.com/Patternslib/Patterns/pull/1188