### PR TITLE
fix(pat display time): Default to locale-formatted output.

### DIFF
--- a/src/pat/display-time/display-time.js
+++ b/src/pat/display-time/display-time.js
@@ -48,6 +48,7 @@ export default Base.extend({
         let out = "";
         if (datetime) {
             const date = Moment(datetime, this.options.format, this.options.strict);
+            out = date;
             if (this.options.fromNow === true) {
                 if (utils.is_iso_date(datetime)) {
                     // date-only case.
@@ -71,8 +72,8 @@ export default Base.extend({
                     // datetime case.
                     out = date.fromNow(this.options.noSuffix);
                 }
-            } else {
-                out = date.format(this.options.outputFormat || undefined);
+            } else if (this.options.outputFormat) {
+                out = date.format(this.options.outputFormat);
             }
         }
         this.el.textContent = out;

--- a/src/pat/display-time/display-time.test.js
+++ b/src/pat/display-time/display-time.test.js
@@ -24,7 +24,7 @@ describe("pat-display-time tests", () => {
         Pattern.init(el);
         await utils.timeout(1); // wait a tick for async to settle.
 
-        expect(el.textContent).toBe("2021-04-22T03:00:00-07:00");
+        expect(el.textContent).toBe("Thu Apr 22 2021 03:00:00 GMT-0700");
     });
 
     it("Example setting the output format explicitly", async () => {


### PR DESCRIPTION
Default to formatted output according to the current locale. This fixes a regression since 4.1.0 which came with the date picker's styled behavior but let display time output an ISO date instead of a formatted date when not output format was set.