### PR TITLE
Fix scroll to position.

### DIFF
--- a/src/pat/collapsible/collapsible.js
+++ b/src/pat/collapsible/collapsible.js
@@ -106,6 +106,13 @@ class Pattern extends BasePattern {
             $(document).on("click", this.options.openTrigger, this.open.bind(this));
         }
 
+        // scroll debouncer for later use.
+        this.debounce_scroll = utils.debounce(
+            this._scroll.bind(this),
+            10,
+            debounce_scroll_timer
+        );
+
         // pat-scroll support
         if (this.options.scroll?.selector) {
             const Scroll = (await import("../scroll/scroll")).default;
@@ -116,13 +123,6 @@ class Pattern extends BasePattern {
             });
             await events.await_pattern_init(this.scroll);
         }
-
-        // scroll debouncer for later use.
-        this.debounce_scroll = utils.debounce(
-            this._scroll.bind(this),
-            10,
-            debounce_scroll_timer
-        );
 
         return $el;
     }
@@ -136,12 +136,16 @@ class Pattern extends BasePattern {
     }
 
     open() {
-        if (!this.$el.hasClass("open")) this.toggle();
+        if (!this.$el.hasClass("open")) {
+            this.toggle();
+        }
         return this.$el;
     }
 
     close() {
-        if (!this.$el.hasClass("closed")) this.toggle();
+        if (!this.$el.hasClass("closed")) {
+            this.toggle();
+        }
         return this.$el;
     }
 
@@ -151,7 +155,9 @@ class Pattern extends BasePattern {
 
     _onKeyPress(event) {
         const keycode = event.keyCode ? event.keyCode : event.which;
-        if (keycode === 13) this.toggle();
+        if (keycode === 13) {
+            this.toggle();
+        }
     }
 
     _loadContent($el, url, $target) {

--- a/src/pat/scroll/scroll.js
+++ b/src/pat/scroll/scroll.js
@@ -68,7 +68,6 @@ class Pattern extends BasePattern {
             this.options.direction === "top" ? "y" : "x",
             window
         );
-        const rect = target.getBoundingClientRect();
 
         const scroll_options = { behavior: "auto" }; // Set the behavior in CSS.
         if (this.options.selector === "top") {
@@ -86,9 +85,9 @@ class Pattern extends BasePattern {
                 ).scrollWidth;
             }
         } else if (this.options.direction === "top") {
-            scroll_options.top = rect.top;
+            scroll_options.top = target.offsetTop;
         } else if (this.options.direction === "left") {
-            scroll_options.left = rect.left;
+            scroll_options.left = target.offsetLeft;
         }
 
         if (typeof scroll_options.top !== "undefined") {


### PR DESCRIPTION
The scrolling offset was incorrectly calculated since Patternslib
9.9.0-alpha.5. Fix the calculation for the scrolling position by using
`offsetTop` and `offsetLeft` instead `getBoundingClientRect`.