### PR TITLE
fix(pat inject): Second attempt to fix the scrolling behavior, where the scrolling target could not be found.

### DIFF
--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -492,7 +492,7 @@ const inject = {
             // 2) getting the element to scroll to (if not "top")
             const scroll_target = ["top", "target"].includes(cfg.scroll)
                 ? cfg.$target[0]
-                : $(cfg.scroll, $injected)[0];
+                : $injected.findInclusive(cfg.scroll)[0];
 
             const scroll_container = dom.find_scroll_container(
                 scroll_target,
@@ -502,7 +502,7 @@ const inject = {
 
             if (cfg.scroll === "top") {
                 dom.scroll_to_top(scroll_container);
-            } else {
+            } else if (scroll_target) {
                 dom.scroll_to_element(scroll_target, scroll_container);
             }
         }


### PR DESCRIPTION
The original problem fixed in commit 911b8b8660197d44291c7d5a9537bbb496df1a38 for 9.9.0-beta.1 addressed a problem where the scroll target was not a direct child of the injected content but some levels deeper. But this fix broke the situation where the scroll target is a direct child of the injected content. The fix applied here handles both situations.