### PR TITLE
Submit button fixes

### DIFF
--- a/src/core/parser.js
+++ b/src/core/parser.js
@@ -33,13 +33,7 @@ class ArgumentParser {
         if (this.parameters[original]) {
             this.parameters[original].alias = alias;
         } else {
-            throw (
-                'Attempted to add an alias "' +
-                alias +
-                '" for a non-existing parser argument "' +
-                original +
-                '".'
-            );
+            throw `Attempted to add an alias "${alias}" for a non-existing parser argument "${original}".`;
         }
     }
 
@@ -166,19 +160,19 @@ class ArgumentParser {
                         } else if (typeof value === "number") {
                             value = !!value;
                         } else {
-                            throw "Cannot convert value for " + name + " to boolean";
+                            throw `Cannot convert value for ${name} to boolean.`;
                         }
                         break;
                     case "number":
                         if (typeof value === "string") {
                             value = parseInt(value, 10);
                             if (isNaN(value)) {
-                                throw "Cannot convert value for " + name + " to number";
+                                throw `Cannot convert value for ${name} to number.`;
                             }
                         } else if (typeof value === "boolean") {
                             value = value + 0;
                         } else {
-                            throw "Cannot convert value for " + name + " to number";
+                            throw `Cannot convert value for ${name} to number.`;
                         }
                         break;
                     case "string":
@@ -188,12 +182,9 @@ class ArgumentParser {
                     case "undefined":
                         break;
                     default:
-                        throw (
-                            "Do not know how to convert value for " +
-                            name +
-                            " to " +
+                        throw `Do not know how to convert value for ${name} of type ${typeof value} to ${
                             spec.type
-                        );
+                        }.`;
                 }
             } catch (e) {
                 this.log.warn(e);
@@ -201,7 +192,7 @@ class ArgumentParser {
             }
 
         if (spec.choices && spec.choices.indexOf(value) === -1) {
-            this.log.warn("Illegal value for " + name + ": " + value);
+            this.log.warn(`Illegal value for ${name}: ${value}.`);
             return null;
         }
         return value;
@@ -209,7 +200,7 @@ class ArgumentParser {
 
     _set(opts, name, value) {
         if (!(name in this.parameters)) {
-            this.log.debug("Ignoring value for unknown argument " + name);
+            this.log.debug(`Ignoring value for unknown argument: ${name}.`);
             return;
         }
         const spec = this.parameters[name];
@@ -261,7 +252,7 @@ class ArgumentParser {
             }
             const matches = part.match(this.named_param_pattern);
             if (!matches) {
-                this.log.warn("Invalid parameter: " + part + ": " + argstring);
+                this.log.warn(`Invalid parameter: ${part}: ${argstring}.`);
                 continue;
             }
             const name = matches[1];
@@ -280,7 +271,7 @@ class ArgumentParser {
                     this._set(opts, name + "-" + field, subopt[field]);
                 }
             } else {
-                this.log.warn("Unknown named parameter " + matches[1]);
+                this.log.warn(`Unknown named parameter: ${matches[1]}.`);
                 continue;
             }
         }
@@ -320,7 +311,7 @@ class ArgumentParser {
                 break;
             }
         }
-        if (parts.length) this.log.warn("Ignore extra arguments: " + parts.join(" "));
+        if (parts.length) this.log.warn(`Ignore extra arguments: ${parts.join(" ")}.`);
         return opts;
     }
 
@@ -332,7 +323,7 @@ class ArgumentParser {
             try {
                 return JSON.parse(parameter);
             } catch (e) {
-                this.log.warn("Invalid JSON argument found: " + parameter);
+                this.log.warn(`Invalid JSON argument found: ${parameter}.`);
             }
         }
         if (parameter.match(this.named_param_pattern)) {
@@ -352,15 +343,18 @@ class ArgumentParser {
 
     _defaults($el) {
         const result = {};
-        for (const name in this.parameters)
-            if (typeof this.parameters[name].value === "function")
+        for (const name in this.parameters) {
+            if (typeof this.parameters[name].value === "function") {
                 try {
                     result[name] = this.parameters[name].value($el, name);
                     this.parameters[name].type = typeof result[name];
                 } catch (e) {
-                    this.log.error("Default function for " + name + " failed.");
+                    this.log.error(`Default function for ${name} failed.`);
                 }
-            else result[name] = this.parameters[name].value;
+            } else {
+                result[name] = this.parameters[name].value;
+            }
+        }
         return result;
     }
 
@@ -368,25 +362,31 @@ class ArgumentParser {
         // Resolve references
         for (const name of Object.keys(options)) {
             const spec = this.parameters[name];
-            if (spec === undefined) continue;
+            if (spec === undefined) {
+                continue;
+            }
 
             if (
                 options[name] === spec.value &&
                 typeof spec.value === "string" &&
                 spec.value.slice(0, 1) === "$"
-            )
+            ) {
                 options[name] = options[spec.value.slice(1)];
+            }
         }
         if (group_options) {
             // Move options into groups and do renames
             for (const name of Object.keys(options)) {
                 const spec = this.parameters[name];
                 let target;
-                if (spec === undefined) continue;
+                if (spec === undefined) {
+                    continue;
+                }
 
                 if (spec.group) {
-                    if (typeof options[spec.group] !== "object")
+                    if (typeof options[spec.group] !== "object") {
                         options[spec.group] = {};
+                    }
                     target = options[spec.group];
                 } else {
                     target = options;
@@ -430,9 +430,7 @@ class ArgumentParser {
         ) {
             $possible_config_providers = $el;
         } else {
-            $possible_config_providers = $el
-                .parents("[" + this.attribute + "]")
-                .addBack();
+            $possible_config_providers = $el.parents(`[${this.attribute}]`).addBack();
         }
 
         for (const provider of $possible_config_providers) {

--- a/src/pat/ajax/ajax.js
+++ b/src/pat/ajax/ajax.js
@@ -14,9 +14,8 @@ const log = logging.getLogger("pat.ajax");
 export const parser = new Parser("ajax");
 parser.addArgument("accept", "text/html");
 parser.addArgument("url", function ($el) {
-    return (
-        $el.is("a") ? $el.attr("href") : $el.is("form") ? $el.attr("action") : ""
-    ).split("#")[0];
+    var val = $el.is("a") ? $el.attr("href") : $el.is("form") ? $el.attr("action") : "";
+    return (val || "").split("#")[0];
 });
 parser.addArgument("browser-cache", "no-cache", ["cache", "no-cache"]); // Cache ajax requests
 

--- a/src/pat/ajax/ajax.js
+++ b/src/pat/ajax/ajax.js
@@ -14,8 +14,14 @@ const log = logging.getLogger("pat.ajax");
 export const parser = new Parser("ajax");
 parser.addArgument("accept", "text/html");
 parser.addArgument("url", function ($el) {
-    var val = $el.is("a") ? $el.attr("href") : $el.is("form") ? $el.attr("action") : "";
-    return (val || "").split("#")[0];
+    const el = $el[0];
+    const value =
+        el.tagName === "A"
+            ? el.getAttribute("href")
+            : el.tagName === "FORM"
+            ? el.getAttribute("action")
+            : "";
+    return (value || "").split("#")[0];
 });
 parser.addArgument("browser-cache", "no-cache", ["cache", "no-cache"]); // Cache ajax requests
 

--- a/src/pat/ajax/ajax.test.js
+++ b/src/pat/ajax/ajax.test.js
@@ -131,6 +131,18 @@ describe("pat-ajax", function () {
             const ajaxargs = $.ajax.mock.calls[$.ajax.mock.calls.length - 1][0];
             expect(ajaxargs.url).toEqual("else.html");
         });
+        it("Does not break with missing anchor-href", async function () {
+            document.body.innerHTML = `<a class="pat-ajax"/>`;
+            jest.spyOn(pattern.parser.log, "error");
+            pattern.parser.parse(document.body.querySelector(".pat-ajax"));
+            expect(pattern.parser.log.error).not.toHaveBeenCalled();
+        });
+        it("Does not break with missing form-action", async function () {
+            document.body.innerHTML = `<form class="pat-ajax"/>`;
+            jest.spyOn(pattern.parser.log, "error");
+            pattern.parser.parse(document.body.querySelector(".pat-ajax"));
+            expect(pattern.parser.log.error).not.toHaveBeenCalled();
+        });
 
         // Accept
         it("Default accept header", function () {

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -99,12 +99,15 @@ const inject = {
                         $el.on("submit.pat-inject", this.onTrigger.bind(this))
                             .on(
                                 "click.pat-inject",
-                                "[type=submit]:not([formaction])",
+                                `[type=submit]:not([formaction]),
+                                 button:not([formaction]):not([type=button])`,
                                 ajax.onClickSubmit
                             )
                             .on(
                                 "click.pat-inject",
-                                "[type=submit][formaction], [type=image][formaction]",
+                                `[type=submit][formaction],
+                                 [type=image][formaction],
+                                 button[formaction]:not([type=button])`,
                                 this.onFormActionSubmit.bind(this)
                             );
                     } else if ($el.is(".pat-subform")) {

--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -97,7 +97,11 @@ const inject = {
                     // setup event handlers
                     if ($el.is("form")) {
                         $el.on("submit.pat-inject", this.onTrigger.bind(this))
-                            .on("click.pat-inject", "[type=submit]", ajax.onClickSubmit)
+                            .on(
+                                "click.pat-inject",
+                                "[type=submit]:not([formaction])",
+                                ajax.onClickSubmit
+                            )
                             .on(
                                 "click.pat-inject",
                                 "[type=submit][formaction], [type=image][formaction]",

--- a/src/pat/inject/inject.test.js
+++ b/src/pat/inject/inject.test.js
@@ -1221,6 +1221,25 @@ describe("pat-inject", function () {
                         "other"
                     );
                 });
+
+                it("9.2.5.10 - does not call ajax.onClickSubmit twice.", async function () {
+                    document.body.innerHTML = `
+                        <form class="pat-inject">
+                            <button type="submit" formaction="test.cgi"/>
+                        </form>
+                    `;
+
+                    const pat_ajax = (await import("../ajax/ajax.js")).default;
+                    jest.spyOn(pat_ajax, "onClickSubmit");
+
+                    const form = document.querySelector("form");
+                    const button = form.querySelector("button");
+
+                    pattern.init($(form));
+                    button.click();
+
+                    expect(pat_ajax.onClickSubmit).toHaveBeenCalledTimes(1);
+                });
             });
         });
     });

--- a/src/pat/inject/inject.test.js
+++ b/src/pat/inject/inject.test.js
@@ -1241,6 +1241,50 @@ describe("pat-inject", function () {
                     expect(pat_ajax.onClickSubmit).toHaveBeenCalledTimes(1);
                 });
             });
+
+            describe("9.2.6 - Support submit buttons without type attribute ...", () => {
+                it("9.2.6.1 - ... without a formaction atttribute.", async function () {
+                    document.body.innerHTML = `
+                        <form class="pat-inject" action="test.cgi">
+                            <button/>
+                        </form>
+                    `;
+
+                    const pat_ajax = (await import("../ajax/ajax.js")).default;
+                    jest.spyOn(pat_ajax, "onClickSubmit");
+                    jest.spyOn(pattern, "onFormActionSubmit");
+
+                    const form = document.querySelector("form");
+                    const button = form.querySelector("button");
+
+                    pattern.init($(form));
+                    button.click();
+
+                    expect(pat_ajax.onClickSubmit).toHaveBeenCalledTimes(1);
+                    expect(pattern.onFormActionSubmit).toHaveBeenCalledTimes(0);
+                });
+
+                it("9.2.6.1 - ... with a formaction atttribute.", async function () {
+                    document.body.innerHTML = `
+                        <form class="pat-inject">
+                            <button formaction="test.cgi"/>
+                        </form>
+                    `;
+
+                    const pat_ajax = (await import("../ajax/ajax.js")).default;
+                    jest.spyOn(pat_ajax, "onClickSubmit");
+                    jest.spyOn(pattern, "onFormActionSubmit");
+
+                    const form = document.querySelector("form");
+                    const button = form.querySelector("button");
+
+                    pattern.init($(form));
+                    button.click();
+
+                    expect(pat_ajax.onClickSubmit).toHaveBeenCalledTimes(1);
+                    expect(pattern.onFormActionSubmit).toHaveBeenCalledTimes(1);
+                });
+            });
         });
     });
 


### PR DESCRIPTION
Fixes a problem recently reported by @cornae

- Submitting `pat-inject` enabled forms without an `action` attribute but a submit button with a `formaction` attribute would break `pat-ajax`.

This fixes also two other problems I found on the way:

- Submitting with a formaction-button called a pat-ajax method twice.
- pat-inject did not support submit buttons without an explicit `type="submit"` attribute, e.g. `<button>`, which is implicitly a submit button.