### PR TITLE
Fix performance problems with pat-checklist

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -58,13 +58,19 @@ const remove_event_listener = (el, id) => {
     if (id) {
         // remove event listener with specific id
         const entry = el_events[id];
-        entries = entry ? [entry] : [];
+        entries = entry ? [[id, entry]] : [];
     } else {
         // remove all event listeners of element
         entries = Object.entries(el_events);
     }
     for (const entry of entries || []) {
-        el.removeEventListener(entry[0], entry[1], entry[2]);
+        el.removeEventListener(entry[1][0], entry[1][1], entry[1][2]);
+        // Delete entry from event_listener_map
+        delete event_listener_map[el][entry[0]];
+        // Delete element from event_listener_map if no more events are registered.
+        if (!Object.keys(event_listener_map[el]).length) {
+            delete event_listener_map[el];
+        }
     }
 };
 

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -1,3 +1,5 @@
+import utils from "./utils";
+
 // Event related methods and event factories
 
 // Event listener registration for easy-to-remove event listeners.
@@ -49,8 +51,14 @@ const add_event_listener = (el, event_type, id, cb, opts = {}) => {
  * If an id but no element is given, all event listeners for any element matching the id are removed.
  * If no element and no id are given, all event listeners are removed.
  *
+ * The id can be a wildcard string, e.g. `test-*-event`, which would match any
+ * event which starts with "test-" and ends with "-event". The wildcard "*" can
+ * be anywhere in the string and also be used multiple times. If no wildcard is
+ * present the search string is used for an exact match.
+ *
  * @param {DOM Node} [el] - The element to register the event for.
  * @param {string} [id] - A unique id under which the event is registered.
+ *                        Can be a wildcard string.
  *
  */
 const remove_event_listener = (el, id) => {
@@ -65,9 +73,10 @@ const remove_event_listener = (el, id) => {
         }
         let entries;
         if (id) {
-            // remove event listener with specific id
-            const entry = el_events.get(id);
-            entries = entry ? [[id, entry]] : [];
+            // remove event listener with matching id
+            entries = [...el_events.entries()].filter((entry) =>
+                utils.regexp_from_wildcard(id).test(entry[0])
+            );
         } else {
             // remove all event listeners of element
             entries = el_events.entries();

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -44,34 +44,43 @@ const add_event_listener = (el, event_type, id, cb, opts = {}) => {
 /**
  * Remove an event listener from a DOM element under a unique id.
  *
- * @param {DOM Node} el - The element to register the event for.
- * @param {string} id - A unique id under which the event is registered.
+ * If an element and id are given, the event listeners for the given element matching the id are removed.
+ * If an element but no id is given, all event listeners for that element are removed.
+ * If an id but no element is given, all event listeners for any element matching the id are removed.
+ * If no element and no id are given, all event listeners are removed.
+ *
+ * @param {DOM Node} [el] - The element to register the event for.
+ * @param {string} [id] - A unique id under which the event is registered.
  *
  */
 const remove_event_listener = (el, id) => {
-    if (!el?.removeEventListener) {
-        return; // nothing to do.
-    }
-    const el_events = event_listener_map.get(el);
-    if (!el_events) {
-        return;
-    }
-    let entries;
-    if (id) {
-        // remove event listener with specific id
-        const entry = el_events.get(id);
-        entries = entry ? [[id, entry]] : [];
-    } else {
-        // remove all event listeners of element
-        entries = el_events.entries();
-    }
-    for (const entry of entries || []) {
-        el.removeEventListener(entry[1][0], entry[1][1], entry[1][2]);
-        // Delete entry from event_listener_map
-        event_listener_map.get(el).delete(entry[0]);
-        // Delete element from event_listener_map if no more events are registered.
-        if (!event_listener_map.get(el).size) {
-            event_listener_map.delete(el);
+    const els = el ? [el] : event_listener_map.keys();
+    for (const el of els) {
+        if (!el?.removeEventListener) {
+            return; // nothing to do.
+        }
+        const el_events = event_listener_map.get(el);
+        if (!el_events) {
+            return;
+        }
+        let entries;
+        if (id) {
+            // remove event listener with specific id
+            const entry = el_events.get(id);
+            entries = entry ? [[id, entry]] : [];
+        } else {
+            // remove all event listeners of element
+            entries = el_events.entries();
+        }
+        for (const entry of entries || []) {
+            // Remove event listener
+            el.removeEventListener(entry[1][0], entry[1][1], entry[1][2]);
+            // Delete entry from event_listener_map
+            event_listener_map.get(el).delete(entry[0]);
+            // Delete element from event_listener_map if no more events are registered.
+            if (!event_listener_map.get(el).size) {
+                event_listener_map.delete(el);
+            }
         }
     }
 };

--- a/src/core/events.test.js
+++ b/src/core/events.test.js
@@ -7,9 +7,7 @@ describe("core.events tests", () => {
     describe("1 - add / remove event listener", () => {
         afterEach(() => {
             // Clear event_listener_map after each test.
-            for (const el in event_listener_map) {
-                delete event_listener_map[el];
-            }
+            event_listener_map.clear();
         });
 
         it("Registers events only once and unregisters events.", (done) => {
@@ -66,10 +64,10 @@ describe("core.events tests", () => {
                 once: true,
             });
 
-            expect(event_listener_map[el].test_once_event).toBeDefined();
+            expect(event_listener_map.get(el).get("test_once_event")).toBeDefined();
             el.dispatchEvent(new Event("test"));
 
-            expect(event_listener_map[el].test_once_event).not.toBeDefined();
+            expect(event_listener_map.get(el).get("test_once_event")).not.toBeDefined();
         });
 
         it("Removes a specific event listener.", () => {
@@ -79,7 +77,7 @@ describe("core.events tests", () => {
 
             // register the once-event handler
             events.add_event_listener(el, "test", "test_event", () => cnt++);
-            expect(event_listener_map[el].test_event).toBeDefined();
+            expect(event_listener_map.get(el).get("test_event")).toBeDefined();
 
             el.dispatchEvent(new Event("test"));
             expect(cnt).toBe(1);
@@ -90,9 +88,9 @@ describe("core.events tests", () => {
             events.remove_event_listener(el, "test_event");
 
             // Now the event listener should be removed.
-            expect(event_listener_map[el]?.test_once_event).not.toBeDefined();
+            expect(event_listener_map.get(el)?.get("test_once_event")).not.toBeDefined();
             // Even the element itself should be removed, if there are no more event listeners on it.
-            expect(event_listener_map[el]).not.toBeDefined();
+            expect(event_listener_map.get("el")).not.toBeDefined();
 
             // counter should not increase anymore
             el.dispatchEvent(new Event("test"));
@@ -101,7 +99,7 @@ describe("core.events tests", () => {
 
         it("Remove single and all event listeners from an element, not touching others.", () => {
             const el1 = document.createElement("div");
-            const el2 = document.createElement("span");
+            const el2 = document.createElement("div");
 
             let cnt1 = 0;
             let cnt2 = 0;
@@ -117,12 +115,12 @@ describe("core.events tests", () => {
             events.add_event_listener(el1, "test3", "test_event_3", () => cnt2++);
             events.add_event_listener(el2, "test4", "test_event_4", () => cnt3++);
 
-            expect(event_listener_map[el1].test_event_1).toBeDefined();
-            expect(event_listener_map[el1].test_event_2).toBeDefined();
-            expect(event_listener_map[el1].test_event_3).toBeDefined();
-            expect(event_listener_map[el2].test_event_4).toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_1")).toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_2")).toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_3")).toBeDefined();
+            expect(event_listener_map.get(el2).get("test_event_4")).toBeDefined();
 
-            expect(Object.keys(event_listener_map).length).toBe(2);
+            expect(event_listener_map.size).toBe(2);
 
             el1.dispatchEvent(new Event("test1"));
             expect(cnt1).toBe(1);
@@ -151,11 +149,11 @@ describe("core.events tests", () => {
 
             // Remove only test_event_1
             events.remove_event_listener(el1, "test_event_1");
-            expect(event_listener_map[el1].test_event_1).not.toBeDefined();
-            expect(event_listener_map[el1].test_event_2).toBeDefined();
-            expect(event_listener_map[el1].test_event_3).toBeDefined();
-            expect(event_listener_map[el2].test_event_4).toBeDefined();
-            expect(Object.keys(event_listener_map).length).toBe(2);
+            expect(event_listener_map.get(el1).get("test_event_1")).not.toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_2")).toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_3")).toBeDefined();
+            expect(event_listener_map.get(el2).get("test_event_4")).toBeDefined();
+            expect(event_listener_map.size).toBe(2);
 
             // Counter should not increase anymore on event "test1"
             el1.dispatchEvent(new Event("test1"));
@@ -173,8 +171,8 @@ describe("core.events tests", () => {
 
             // Remove all event handler on el1
             events.remove_event_listener(el1);
-            expect(event_listener_map[el1]).not.toBeDefined();
-            expect(Object.keys(event_listener_map).length).toBe(1);
+            expect(event_listener_map.get(el1)).not.toBeDefined();
+            expect(event_listener_map.size).toBe(1);
 
             // Counter should not increase anymore on el1
             el1.dispatchEvent(new Event("test1"));

--- a/src/core/events.test.js
+++ b/src/core/events.test.js
@@ -303,6 +303,41 @@ describe("core.events tests", () => {
             events.remove_event_listener();
             expect(event_listener_map.size).toBe(0);
         });
+
+        it("Remove wildcard matching event listeners.", () => {
+            const el = document.createElement("div");
+
+            // register the event handlers
+            events.add_event_listener(el, "test", "test_event_1", () => {});
+            events.add_event_listener(el, "test", "test_event_2", () => {});
+            events.add_event_listener(el, "test", "test_event_3", () => {});
+
+            events.add_event_listener(el, "test", "a_aha", () => {});
+            events.add_event_listener(el, "test", "b_aha", () => {});
+            events.add_event_listener(el, "test", "c_aha", () => {});
+
+            events.add_event_listener(el, "test", "ok_aha_ok", () => {});
+            events.add_event_listener(el, "test", "ok_bhb_ok", () => {});
+            events.add_event_listener(el, "test", "ok_chc_ok", () => {});
+
+            events.add_event_listener(el, "test", "oh_aha_ok", () => {});
+            events.add_event_listener(el, "test", "ah_bhb_ok", () => {});
+            events.add_event_listener(el, "test", "uh_chc_ok", () => {});
+
+            expect(event_listener_map.get(el).size).toBe(12);
+
+            events.remove_event_listener(el, "test_event_*");
+            expect(event_listener_map.get(el).size).toBe(9);
+
+            events.remove_event_listener(el, "*_aha");
+            expect(event_listener_map.get(el).size).toBe(6);
+
+            events.remove_event_listener(el, "ok_*_ok");
+            expect(event_listener_map.get(el).size).toBe(3);
+
+            events.remove_event_listener(el, "*h_*_ok");
+            expect(event_listener_map.get(el)).not.toBeDefined();
+        });
     });
 
     describe("2 - await pattern initialization", () => {

--- a/src/core/events.test.js
+++ b/src/core/events.test.js
@@ -169,7 +169,7 @@ describe("core.events tests", () => {
             expect(cnt2).toBe(2);
             expect(cnt3).toBe(2);
 
-            // Remove all event handler on el1
+            // Remove all event handlers on el1
             events.remove_event_listener(el1);
             expect(event_listener_map.get(el1)).not.toBeDefined();
             expect(event_listener_map.size).toBe(1);
@@ -187,6 +187,121 @@ describe("core.events tests", () => {
             expect(cnt1).toBe(4);
             expect(cnt2).toBe(2);
             expect(cnt3).toBe(3);
+        });
+
+        it("Remove all events matching exactly an id from any element.", () => {
+            const el1 = document.createElement("div");
+            const el2 = document.createElement("div");
+
+            let cnt1 = 0;
+            let cnt2 = 0;
+            let cnt3 = 0;
+
+            const shared_cb = () => {
+                cnt1++;
+            };
+
+            // register the event handlers
+            events.add_event_listener(el1, "test1", "test_event_1", shared_cb);
+            events.add_event_listener(el1, "test2", "test_event_2", shared_cb);
+            events.add_event_listener(el1, "test3", "test_event_3", () => cnt2++);
+            events.add_event_listener(el2, "test4", "test_event_4", () => cnt3++);
+
+            expect(event_listener_map.get(el1).get("test_event_1")).toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_2")).toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_3")).toBeDefined();
+            expect(event_listener_map.get(el2).get("test_event_4")).toBeDefined();
+
+            expect(event_listener_map.size).toBe(2);
+
+            el1.dispatchEvent(new Event("test1"));
+            expect(cnt1).toBe(1);
+            expect(cnt2).toBe(0);
+            expect(cnt3).toBe(0);
+
+            el1.dispatchEvent(new Event("test1"));
+            expect(cnt1).toBe(2);
+            expect(cnt2).toBe(0);
+            expect(cnt3).toBe(0);
+
+            el1.dispatchEvent(new Event("test2"));
+            expect(cnt1).toBe(3);
+            expect(cnt2).toBe(0);
+            expect(cnt3).toBe(0);
+
+            el1.dispatchEvent(new Event("test3"));
+            expect(cnt1).toBe(3);
+            expect(cnt2).toBe(1);
+            expect(cnt3).toBe(0);
+
+            el2.dispatchEvent(new Event("test4"));
+            expect(cnt1).toBe(3);
+            expect(cnt2).toBe(1);
+            expect(cnt3).toBe(1);
+
+            // Remove only test_event_1
+            events.remove_event_listener(undefined, "test_event_1");
+            expect(event_listener_map.get(el1).get("test_event_1")).not.toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_2")).toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_3")).toBeDefined();
+            expect(event_listener_map.get(el2).get("test_event_4")).toBeDefined();
+            expect(event_listener_map.size).toBe(2);
+
+            // Counter should not increase anymore on event "test1"
+            el1.dispatchEvent(new Event("test1"));
+            expect(cnt1).toBe(3);
+            expect(cnt2).toBe(1);
+            expect(cnt3).toBe(1);
+
+            // Rest should not be affected.
+            el1.dispatchEvent(new Event("test2"));
+            el1.dispatchEvent(new Event("test3"));
+            el2.dispatchEvent(new Event("test4"));
+            expect(cnt1).toBe(4);
+            expect(cnt2).toBe(2);
+            expect(cnt3).toBe(2);
+
+            // Remove rest of event handlers on el1
+            events.remove_event_listener(undefined, "test_event_2");
+            events.remove_event_listener(undefined, "test_event_3");
+            expect(event_listener_map.get(el1)).not.toBeDefined();
+            expect(event_listener_map.size).toBe(1);
+
+            // Counter should not increase anymore on el1
+            el1.dispatchEvent(new Event("test1"));
+            el1.dispatchEvent(new Event("test2"));
+            el1.dispatchEvent(new Event("test3"));
+            expect(cnt1).toBe(4);
+            expect(cnt2).toBe(2);
+            expect(cnt3).toBe(2);
+
+            // But el2 should still work.
+            el2.dispatchEvent(new Event("test4"));
+            expect(cnt1).toBe(4);
+            expect(cnt2).toBe(2);
+            expect(cnt3).toBe(3);
+        });
+
+        it("Remove all event listeners at once.", () => {
+            const el1 = document.createElement("div");
+            const el2 = document.createElement("div");
+
+            // register the event handlers
+            events.add_event_listener(el1, "test1", "test_event_1", () => {});
+            events.add_event_listener(el1, "test2", "test_event_2", () => {});
+            events.add_event_listener(el1, "test3", "test_event_3", () => {});
+            events.add_event_listener(el2, "test4", "test_event_4", () => {});
+
+            expect(event_listener_map.get(el1).get("test_event_1")).toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_2")).toBeDefined();
+            expect(event_listener_map.get(el1).get("test_event_3")).toBeDefined();
+            expect(event_listener_map.get(el2).get("test_event_4")).toBeDefined();
+
+            expect(event_listener_map.size).toBe(2);
+
+            // Remove all event listeners
+            events.remove_event_listener();
+            expect(event_listener_map.size).toBe(0);
         });
     });
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -575,7 +575,10 @@ const timeout = (ms) => {
  * @param {Function} func - The function to debounce.
  * @param {Number} ms - The time in milliseconds to debounce.
  * @param {Object} timer - A module-global timer as an object.
- * @param {Boolean} postpone - If true, the function will be called after it stops being called for N milliseconds.
+ * @param {Boolean} [postpone=true] - If true, the function will only be called
+ * at the end, after it stops being called for N milliseconds. If false, the
+ * function will be called no more than each [ms] milliseconds, ensuring that
+ * the function isn't postponed for for too long.
  *
  * @returns {Function} - The debounced function.
  */

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -176,6 +176,23 @@ function escapeRegExp(str) {
 }
 
 /**
+ * Create a RegExp object of a wildcard search string.
+ *
+ * @param {string} wildcard: A search string which can contain wildcards "*".
+ *                           The wildcard "*" can be anywhere in the string and
+ *                           can also be used multiple times. If no wildcard is
+ *                           present the search string is used for an exact match.
+
+ * @returns {RegExp}: A RegExp object which can be used to match strings.
+ */
+function regexp_from_wildcard(wildcard) {
+    let regexp = wildcard.replace(/[\-\[\]{}()+?.,\\\^$|#\s]/g, "\\$&");
+    regexp = regexp.replace(/[*]/g, ".*");
+    regexp = new RegExp(`^${regexp}$`);
+    return regexp;
+}
+
+/**
  * Remove classes from a list of targets if they match a specific pattern.
  *
  * @param {Node, NodeList} targets: Dom Node or NodeList where the classes should be removed.
@@ -193,10 +210,7 @@ function removeWildcardClass(targets, classes) {
             target.classList.remove(classes);
         }
     } else {
-        let matcher = classes.replace(/[\-\[\]{}()+?.,\\\^$|#\s]/g, "\\$&");
-        matcher = matcher.replace(/[*]/g, ".*");
-        matcher = new RegExp("^" + matcher + "$");
-
+        const matcher = regexp_from_wildcard(classes);
         for (const target of targets) {
             const class_list = (target.getAttribute("class") || "").split(/\s+/);
             if (!class_list.length) {
@@ -780,6 +794,7 @@ var utils = {
     isObject: isObject,
     extend: extend,
     findLabel: findLabel,
+    regexp_from_wildcard: regexp_from_wildcard,
     removeWildcardClass: removeWildcardClass,
     hideOrShow: hideOrShow,
     addURLQueryParameter: addURLQueryParameter,
@@ -807,7 +822,7 @@ var utils = {
     date_diff: date_diff,
     threshold_list: threshold_list,
     is_option_truthy: is_option_truthy,
-    getCSSValue: dom.get_css_value, // BBB: moved to dom. TODO: Remove in upcoming version.
+    //getCSSValue: dom.get_css_value, // BBB: moved to dom. TODO: Remove in upcoming version.
     elementInViewport: (el) => {
         // BBB: Remove with next major version.
         console.warn("Deprecated. Use utils.isElementInViewport");

--- a/src/core/utils.test.js
+++ b/src/core/utils.test.js
@@ -161,6 +161,29 @@ describe("basic tests", function () {
     });
 });
 
+describe("regexp_from_wildcard", function () {
+    it("creates regular expressions from wildcard strings", function () {
+        let regex = utils.regexp_from_wildcard("test-*-tset");
+        expect(regex.test("test-abcd-defg-tset")).toBe(true);
+        expect(regex.test("tset-abcd-defg-test")).toBe(false);
+
+        regex = utils.regexp_from_wildcard("*-test");
+        expect(regex.test("abdc-test")).toBe(true);
+        expect(regex.test("abdc-wxyz")).toBe(false);
+
+        regex = utils.regexp_from_wildcard("test-*");
+        expect(regex.test("test-abcd")).toBe(true);
+        expect(regex.test("abdc-wxyz")).toBe(false);
+
+        regex = utils.regexp_from_wildcard("*-test-*");
+        expect(regex.test("abcd-test-wxyz")).toBe(true);
+        expect(regex.test("abcd-efgh-wxyz")).toBe(false);
+
+        regex = utils.regexp_from_wildcard("*");
+        expect(regex.test("abcd")).toBe(true);
+    });
+});
+
 describe("removeWildcardClass", function () {
     describe("... with single element", function () {
         it("Remove basic class", function () {

--- a/src/pat/checklist/checklist.js
+++ b/src/pat/checklist/checklist.js
@@ -1,6 +1,7 @@
 import Base from "../../core/base";
 import Parser from "../../core/parser";
 import dom from "../../core/dom";
+import events from "../../core/events";
 import utils from "../../core/utils";
 import "../../core/jquery-ext";
 
@@ -121,7 +122,7 @@ export default Base.extend({
         );
         for (const box of chkbxs) {
             box.checked = true;
-            box.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+            box.dispatchEvent(events.change_event());
         }
     },
 
@@ -130,7 +131,7 @@ export default Base.extend({
         const chkbxs = this.find_checkboxes(e.target, "input[type=checkbox]:checked");
         for (const box of chkbxs) {
             box.checked = false;
-            box.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+            box.dispatchEvent(events.change_event());
         }
     },
 
@@ -140,7 +141,7 @@ export default Base.extend({
         const chkbxs = this.find_checkboxes(e.target, "input[type=checkbox]");
         for (const box of chkbxs) {
             box.checked = checked;
-            box.dispatchEvent(new Event("change", { bubbles: true, cancelable: true }));
+            box.dispatchEvent(events.change_event());
         }
     },
 

--- a/src/pat/checklist/checklist.js
+++ b/src/pat/checklist/checklist.js
@@ -23,6 +23,12 @@ export default Base.extend({
     init() {
         this.options = parser.parse(this.el, this.options, false);
         this.$el.on("patterns-injected", this._init.bind(this));
+
+        this.change_handler = utils.debounce(() => {
+            this.change_buttons_and_toggles();
+            this.change_checked();
+        }, 50);
+
         this._init();
     },
 
@@ -46,14 +52,9 @@ export default Base.extend({
         }
 
         // update select/deselect button status
-        this.el.addEventListener("change", this._handler_change.bind(this));
         this.change_buttons_and_toggles();
         this.change_checked();
-    },
-
-    _handler_change() {
-        utils.debounce(() => this.change_buttons_and_toggles(), 50)();
-        utils.debounce(() => this.change_checked(), 50)();
+        this.el.addEventListener("change", this.change_handler.bind(this));
     },
 
     destroy() {
@@ -63,7 +64,7 @@ export default Base.extend({
         for (const it of this.all_deselects) {
             it.removeEventListener("click", this.deselect_all);
         }
-        this.el.removeEventListener("change", this._handler_change);
+        this.el.removeEventListener("change", this.change_handler);
         this.$el.off("patterns_injected");
     },
 

--- a/src/pat/checklist/checklist.js
+++ b/src/pat/checklist/checklist.js
@@ -38,33 +38,56 @@ export default Base.extend({
 
         this.all_selects = dom.find_scoped(this.el, this.options.select);
         for (const btn of this.all_selects) {
-            btn.addEventListener("click", this.select_all.bind(this));
+            events.add_event_listener(
+                btn,
+                "click",
+                "pat-checklist--select-all--click",
+                this.select_all.bind(this)
+            );
         }
 
         this.all_deselects = dom.find_scoped(this.el, this.options.deselect);
         for (const btn of this.all_deselects) {
-            btn.addEventListener("click", this.deselect_all.bind(this));
+            events.add_event_listener(
+                btn,
+                "click",
+                "pat-checklist--deselect-all--click",
+                this.deselect_all.bind(this)
+            );
         }
 
         this.all_toggles = dom.find_scoped(this.el, this.options.toggle);
         for (const btn of this.all_toggles) {
-            btn.addEventListener("click", this.toggle_all.bind(this));
+            events.add_event_listener(
+                btn,
+                "click",
+                "pat-checklist--toggle-all--click",
+                this.toggle_all.bind(this)
+            );
         }
 
         // update select/deselect button status
         this.change_buttons_and_toggles();
         this.change_checked();
-        this.el.addEventListener("change", this.change_handler.bind(this));
+        events.add_event_listener(
+            this.el,
+            "change",
+            "pat-checklist--change-handler--change",
+            this.change_handler.bind(this)
+        );
     },
 
     destroy() {
         for (const it of this.all_selects) {
-            it.removeEventListener("click", this.select_all);
+            events.remove_event_listener(it, "pat-checklist--select-all--click");
         }
         for (const it of this.all_deselects) {
-            it.removeEventListener("click", this.deselect_all);
+            events.remove_event_listener(it, "pat-checklist--deselect-all--click");
         }
-        this.el.removeEventListener("change", this.change_handler);
+        for (const it of this.all_toggles) {
+            events.remove_event_listener(it, "pat-checklist--toggle-all--click");
+        }
+        events.remove_event_listener(this.el, "pat-checklist--change-handler--change");
         this.$el.off("patterns_injected");
     },
 

--- a/src/pat/checklist/index.html
+++ b/src/pat/checklist/index.html
@@ -155,5 +155,29 @@
             <div class="six columns"></div>
         </form>
 
+        <section>
+          <header>
+            <h3>Infinite scrolling example</h3>
+          </header>
+
+          <form class="pat-checklist">
+            <label><input type="checkbox" class="toggle-all" />Toggle checkboxes</label><br>
+            <fieldset id="infinite-boxes">
+                <label><input type="checkbox" checked="checked" /> Option one</label><br>
+                <label><input type="checkbox" /> Option two</label><br>
+                <label><input type="checkbox" /> Option three</label><br>
+                <label><input type="checkbox" /> Option four</label><br>
+
+                <a
+                    href="./index.html#infinite-boxes"
+                    class="pat-inject"
+                    data-pat-inject="trigger: autoload-visible; target:self::element"
+                    >Loading...</a>
+
+            </fieldset>
+          </form>
+
+        </section>
+
     </body>
 </html>

--- a/src/pat/switch/documentation.md
+++ b/src/pat/switch/documentation.md
@@ -20,8 +20,8 @@ This pattern takes three properties:
 
 -   `selector`: the CSS selector identifying the elements that must be
     updated
--   `remove`: the class that should be added
--   `add`: a class that should be removed
+-   `remove`: the class that should be removed
+-   `add`: a class that should be added
 
 You must provide the selector and at least one of _remove_ or _add_.
 


### PR DESCRIPTION
- Fixes performance problems with pat-checklist,
- Fix remove_event_handler logic which wasn't working properly,
- Allow to use wildcard-removal of registered events.

The remove_event_handler fixes and features are hanging around since August.
They are well tested and now even useful for the checklist destroy method within the checklist performance fixes in PR too.