### PR TITLE
fix: Fix reference to 3rd party styles in stylesheets.

### DIFF
--- a/src/pat/colour-picker/_colour-picker.scss
+++ b/src/pat/colour-picker/_colour-picker.scss
@@ -1,5 +1,6 @@
 @charset "UTF-8";
-@import "node_modules/spectrum-colorpicker/spectrum";
+
+@import "spectrum-colorpicker/spectrum";
 
 .checkNative,
 .checkPattern {

--- a/src/pat/date-picker/_date-picker.scss
+++ b/src/pat/date-picker/_date-picker.scss
@@ -1,2 +1,2 @@
 @charset "UTF-8";
-@import "node_modules/pikaday/scss/pikaday.scss";
+@import "pikaday/scss/pikaday.scss";


### PR DESCRIPTION
Since latest scss build tools which became available in `@patternslib/dev` version 3.6 references to `node_modules` need to be left out. The build tool searches in node_modules anyways. This is now fixed.