### PR TITLE
feat(pat-date-picker): Cache the ajax call to retrieve i18n picker translations.

### DIFF
--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -5,6 +5,7 @@ import logging from "../../core/logging";
 import Parser from "../../core/parser";
 import dom from "../../core/dom";
 import events from "../../core/events";
+import store from "../../core/store";
 import utils from "../../core/utils";
 
 const log = logging.getLogger("date-picker");
@@ -29,6 +30,9 @@ parser.addAlias("behaviour", "behavior");
  *   "weekdays"     : ["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],
  *   "weekdaysShort": ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"]
  * } */
+
+export const storage = store.session("pat-date-picker");
+
 
 export default Base.extend({
     name: "date-picker",
@@ -184,11 +188,18 @@ export default Base.extend({
         }
 
         if (this.options.i18n) {
-            try {
-                const response = await fetch(this.options.i18n);
-                config.i18n = await response.json();
-            } catch {
-                log.error(`date-picker could not load i18n for ${this.options.i18n}`);
+            let i18n = storage.get(this.options.i18n);
+            if (!i18n) {
+                try {
+                    const response = await fetch(this.options.i18n);
+                    i18n = await response.json();
+                    storage.set(this.options.i18n, i18n);
+                } catch {
+                    log.error(`date-picker could not load i18n for ${this.options.i18n}`);
+                }
+            }
+            if (i18n) {
+                config.i18n = i18n;
             }
         }
         this.pikaday = new Pikaday(config);


### PR DESCRIPTION
Ref: scrum-2726

This implementation uses good ol' `store` module from `@patternslib/patternslib/src/core/store` - it's still handy.
However, we can spare us the `supported` query because the web storage is just supported in practice by all modern browsers since Firefox 2 etc.

Testing FTW, I found a case where a unsuccessful call to an i18n URL led to an error.


NOTE: in a real environment where multiple instances are
initialized at once on the same page, before the ajax call has
been completed, each instance will do an AJAX call. After that,
when navigating to other pages with other date picker instance
the cached value should be used and no more AJAX calls should be
made.

It would be hard to work around this limitation and I think it's a tradeoff we can live with, right?