### PR TITLE
breaking(pat-depends): change action default to "both"

### DIFF
--- a/src/pat/depends/depends.js
+++ b/src/pat/depends/depends.js
@@ -11,7 +11,7 @@ const log = logging.getLogger("depends");
 
 export const parser = new Parser("depends");
 parser.addArgument("condition");
-parser.addArgument("action", "show", ["show", "enable", "both"]);
+parser.addArgument("action", "both", ["show", "enable", "both"]);
 parser.addArgument("transition", "none", ["none", "css", "fade", "slide"]);
 parser.addArgument("effect-duration", "fast");
 parser.addArgument("effect-easing", "swing");


### PR DESCRIPTION
Set the action default to "both" so that a dependent markup structure is
not only shown respective hidden but contained input elements also enabled and
disabled.

Input fields which are not shown should be disabled, so that they do not
participate in form validation and are not submitted.

If you need a different behavior set it via the "action" parameter on a
pat-depends enabled element itself.

