### PR TITLE
fix(core feature-detection): Fix loading of modernizr script.

### DIFF
--- a/src/core/feature-detection.js
+++ b/src/core/feature-detection.js
@@ -18,15 +18,14 @@
     }
 
     // Get the current script tag's URL.
-    // See: https://stackoverflow.com/a/984656/1337474
-    const scripts = document.getElementsByTagName("script");
-    const script = scripts[scripts.length - 1];
-    let script_url = script.src;
+    const script_url = document.currentScript.src;
     // Get the base URL of the current script tag's URL.
-    script_url = script_url.substring(0, script_url.lastIndexOf("/")) + "/";
+    let base_url = script_url.substring(0, script_url.lastIndexOf("/")) + "/";
+    // The modernizr script is located outside the chunks directory.
+    base_url = base_url.replace("chunks/", "");
 
     // Inject a new one with the modernizr bundle.
     const script_tag = document.createElement("script");
-    script_tag.src = script_url + "modernizr.min.js";
+    script_tag.src = base_url + "modernizr.min.js";
     document.getElementsByTagName("head")[0].appendChild(script_tag);
 })();

--- a/src/core/logging.js
+++ b/src/core/logging.js
@@ -46,11 +46,8 @@ function ConsoleWriter() {}
 ConsoleWriter.prototype = {
     output: function (log_name, level, messages) {
         if (log_name) messages.unshift(log_name + ":");
-        if (level <= Level.DEBUG) {
-            // console.debug exists but is deprecated
-            messages.unshift("[DEBUG]");
-            console.log.apply(console, messages);
-        } else if (level <= Level.INFO) console.info.apply(console, messages);
+        if (level <= Level.DEBUG) console.debug.apply(console, messages);
+        else if (level <= Level.INFO) console.info.apply(console, messages);
         else if (level <= Level.WARN) console.warn.apply(console, messages);
         else console.error.apply(console, messages);
     },

--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -174,9 +174,22 @@ const registry = {
             }
         }
 
+        // Clean up selectors:
+        // - Remove whitespace,
+        // - Remove trailing commas,
+        // - Join to selecto string.
+        const selector_string = selectors.map(
+            (selector) => selector.trim().replace(/,$/, "")
+        ).join(",");
+
+        // Exit, if no selector.
+        if (!selector_string) {
+            return;
+        }
+
         let matches = dom.querySelectorAllAndMe(
             content,
-            selectors.map((it) => it.trim().replace(/,$/, "")).join(",")
+            selector_string
         );
         matches = matches.filter((el) => {
             // Filter out patterns:

--- a/src/core/registry.test.js
+++ b/src/core/registry.test.js
@@ -104,4 +104,16 @@ describe("pat-registry: The registry for patterns", function () {
 
         done();
     });
+
+    it("Does nothing with Patterns without a trigger.", function () {
+        registry.register(
+            {
+                name: "pattern-without-trigger"
+            }
+        )
+
+        const el = document.createElement("div");
+        expect(() => { registry.scan(el) }).not.toThrow(DOMException);
+    });
+
 });


### PR DESCRIPTION
1) fix(core feature-detection): Fix loading of modernizr script.

In some situations loading of the modernizr.min.js script failed because the base url could be incorrect. That is fixed with a non-IE compatible method of getting the current's script URL, which is safe to use. The problem surfaced in Plone while loading the Patternslib library and in between the protect.js script was loaded. The base url was calculated for the protect.js script and the modernizr script could not be loaded.

2)‌ maint(core log): Console.debug is not deprecated. Just use it.

3) fix(core registry): Do nothing with Patterns without a trigger.
    Patterns without a trigger broke the registry scan method. Now they don't.
