### PR TITLE
Fix pat depends

### DIFF
--- a/src/core/dom.js
+++ b/src/core/dom.js
@@ -142,6 +142,24 @@ const is_input = (el) => {
 };
 
 /**
+ * Test, if a element is a button-like input type.
+ *
+ * @param {Node} el - The DOM node to test.
+ * @returns {Boolean} - True if the element is a input-type element.
+ */
+const is_button = (el) => {
+    return el.matches(`
+        button,
+        input[type=image],
+        input[type=button],
+        input[type=reset],
+        input[type=submit]
+    `);
+};
+
+
+
+/**
  * Return all direct parents of ``el`` matching ``selector``.
  * This matches against all parents but not the element itself.
  * The order of elements is from the search starting point up to higher
@@ -613,6 +631,7 @@ const dom = {
     acquire_attribute: acquire_attribute,
     is_visible: is_visible,
     is_input: is_input,
+    is_button: is_button,
     create_from_string: create_from_string,
     get_css_value: get_css_value,
     find_scroll_container: find_scroll_container,

--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -547,6 +547,47 @@ describe("core.dom tests", () => {
         });
     });
 
+    describe("is_button", () => {
+        it("checks, if an element is a button-like element or not.", (done) => {
+
+            const button = document.createElement("button");
+            const button_button = document.createElement("button");
+            button_button.setAttribute("type", "button");
+            const button_submit = document.createElement("button");
+            button_submit.setAttribute("type", "submit");
+
+            const input_button = document.createElement("input");
+            input_button.setAttribute("type", "button");
+            const input_submit = document.createElement("input");
+            input_submit.setAttribute("type", "submit");
+            const input_reset = document.createElement("input");
+            input_reset.setAttribute("type", "reset");
+            const input_image = document.createElement("input");
+            input_image.setAttribute("type", "image");
+
+            expect(dom.is_button(button)).toBe(true);
+            expect(dom.is_button(button_button)).toBe(true);
+            expect(dom.is_button(button_submit)).toBe(true);
+            expect(dom.is_button(input_button)).toBe(true);
+            expect(dom.is_button(input_image)).toBe(true);
+            expect(dom.is_button(input_reset)).toBe(true);
+            expect(dom.is_button(input_submit)).toBe(true);
+
+            const input_text = document.createElement("input");
+            input_text.setAttribute("type", "text");
+
+            expect(dom.is_button(input_text)).toBe(false);
+            expect(dom.is_button(document.createElement("input"))).toBe(false);
+            expect(dom.is_button(document.createElement("select"))).toBe(false);
+            expect(dom.is_button(document.createElement("textarea"))).toBe(false);
+            expect(dom.is_button(document.createElement("form"))).toBe(false);
+            expect(dom.is_button(document.createElement("div"))).toBe(false);
+
+            done();
+        });
+    });
+
+
     describe("create_from_string", () => {
         it("Creates a DOM element from a string", (done) => {
             const res = dom.create_from_string(`

--- a/src/pat/depends/index.html
+++ b/src/pat/depends/index.html
@@ -9,7 +9,7 @@
         <script src="/bundle.min.js"></script>
     </head>
     <body>
-        <section id="pat-depends-demo">
+        <section id="pat-depends-demo" data-pat-depends="action: both">
             <h2>pat-depends with checkboxes, radiobuttons and multiselects</h2>
             <form>
                 <fieldset class="horizontal">
@@ -83,7 +83,7 @@
                         <legend>Extra toppings</legend>
                         <label
                             class="pat-depends"
-                            data-pat-depends="flavour:list!=hawaii"
+                            data-pat-depends="condition:flavour:list!=hawaii"
                         >
                             <input autocomplete="off" name="pineapple" type="checkbox" />
                             Pineapple
@@ -157,7 +157,7 @@
             </form>
         </section>
 
-        <section id="pat-depends-demo-2">
+        <section id="pat-depends-demo-2" data-pat-depends="action: both">
             <h2>pat-depends with optional date/time inputs</h2>
             <form>
                 <label


### PR DESCRIPTION
[feat(core dom): Add method is_button.](https://github.com/Patternslib/Patterns/commit/132e42bbb84784f1ab7cd3e897c90ed5e368c666)

dom.is_button tests, if an element is a button like element.
Button like elements are the following:

    button,
    button[type=button],
    button[type=submit],
    input[type=image],
    input[type=button],
    input[type=reset],
    input[type=submit]

[fix(pat-depends): Fix infinite loop situations.](https://github.com/Patternslib/Patterns/commit/af5ecc55b7a9c9fd6a01f0d3ca717d26cbd37ff7)

Fix some situations where infinite loops were created of unnecessary
function calls were done:

- Do not en/disable already en/disabled inputs.
- Do not trigger and pat-depends element if the input is the element
  itself and not a contained sub-input.
- Do not trigger input events on button-like elements.
