### PR TITLE
maint: Add deprecation notice for Modernizr.

### DIFF
--- a/src/core/feature-detection.js
+++ b/src/core/feature-detection.js
@@ -10,6 +10,8 @@
         html.classList.add("js");
     }
 
+    // NOTE: Modernizr will be removed in an upcoming minor release.
+
     // Do not load modernizr if disabled. It's enabled by default.
     // You might want to disable it for your project by setting:
     // window.__patternslib_disable_modernizr = true;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 // Load modernizr and the `html.js` feature class.
+// NOTE: Modernizr will be removed in an upcoming minor release.
 import "./core/feature-detection";
 
 // Webpack entry point for module federation.


### PR DESCRIPTION
Modernizr will be removed in an upcoming minor version. It is not really necessary anymore. Most browser support almost latest web technology and IE is dead.
A no-js class on the body will still be replaced with a js class.