### PR TITLE
fix(pat-inject): Fix problem with inserting table rows.

### DIFF
--- a/src/pat/inject/inject.js
+++ b/src/pat/inject/inject.js
@@ -459,7 +459,7 @@ const inject = {
         /* Called after the XHR has succeeded and we have a new $sources
          * element to inject.
          */
-        const wrapper = document.createElement("div");
+        const wrapper = document.createElement("template");
         if ($sources.length > 0) {
             const method = cfg.sourceMod === "content" ? "innerHTML" : "outerHTML";
             // There might be multiple sources, so we need to loop over them.
@@ -467,7 +467,7 @@ const inject = {
             const sources_string = [...$sources].map(source => source[method]).join("\n");
             wrapper.innerHTML = sources_string;
 
-            for (const img of wrapper.querySelectorAll("img")) {
+            for (const img of wrapper.content.querySelectorAll("img")) {
                 events.add_event_listener(
                     img,
                     "load",
@@ -481,7 +481,7 @@ const inject = {
         }
 
         // Copy, because after insertion wrapper.children is empty.
-        const source_nodes = [...wrapper.childNodes];
+        const source_nodes = [...wrapper.content.childNodes];
 
         // Now the injection actually happens.
         if (this._inject(trigger, source_nodes, target, cfg)) {


### PR DESCRIPTION
# Problem 
Daniel reported a problem on signal concerning table-row injections. At one point in the current release cycle I had to add a temporary wrapper element to be able to load a string and treat it as a DOM element so that javascript functions can be used to identify elements.
I used a DIV. 
However tr elements cannot be added to divs, therefore the table-row injection failed.

# Solution in this Pull Request
A `<tr>` can live within a `<template>`. Changing the temporary div to a template solves the issue.

This temporary wrapper never makes it into the page, instead is only needed to transform an HTML string to a DOM node, so that we can do DOM operations, like `querySelectorAll` on it. That is used to find all images within the to-be-injected source and attach an event handler on it. 
After that operation, the tag is discarded again.

**Technical note**
There was a problem with injecting table rows introduced in: b0f94fb058a7067e19bc9c3101a11dfa49ff8dd2 The problem occured when setting a table row as content of a temporary `<div>` wrapper. But a `<tr>` is not a valid child node of a `<div>`. This caused visually destroyed tables. Using a `<template>` tag as wrapper instead of a div solved the problem.