### PR TITLE
feat(pat-ajax): Pass the URL to the pat-ajax-success event payload.

### DIFF
--- a/src/pat/ajax/ajax.js
+++ b/src/pat/ajax/ajax.js
@@ -98,7 +98,7 @@ const _ = {
                 // if this url is requested multiple time, only return the last result
                 $el.trigger({
                     type: "pat-ajax-success",
-                    jqxhr: jqxhr,
+                    jqxhr: {"url": cfg.url, ...jqxhr},
                 });
             } else {
                 // ignore


### PR DESCRIPTION
This allows to use the URL in an event handler for certain actions.