### PR TITLE
feat(pat-validation): Support definition of minimum or maximum number of selections.

### DIFF
--- a/src/core/dom.test.js
+++ b/src/core/dom.test.js
@@ -10,6 +10,24 @@ describe("core.dom tests", () => {
         jest.restoreAllMocks();
     });
 
+    describe("jsDOM tests", () => {
+        it("jsDOM supports input elements outside forms.", () => {
+            document.body.innerHTML = `
+                <input name="outside" form="a_form"/>
+                <form id="a_form">
+                    <input name="inside"/>
+                </form>
+            `;
+
+            const outside = document.querySelector("input[name=outside]");
+            const inside = document.querySelector("input[name=inside]");
+            const form = document.querySelector("form");
+
+            expect(outside.form).toBe(form);
+            expect(inside.form).toBe(form);
+        });
+    });
+
     describe("document_ready", () => {
         it("calls the callback, once the document is ready.", async () => {
             let cnt = 0;

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -172,7 +172,7 @@ const await_pattern_init = (pattern) => {
  * A event factory for a bubbling and cancelable generic event.
  *
  * @param {string} name - The event name.
- * @returns {Event} - Returns a blur event.
+ * @returns {Event} - Returns a DOM event.
  */
 const generic_event = (name) => {
     return new Event(name, {
@@ -227,6 +227,20 @@ const change_event = () => {
 const focus_event = () => {
     return new Event("focus", {
         bubbles: false,
+        cancelable: false,
+    });
+};
+
+const focusin_event = () => {
+    return new Event("focusin", {
+        bubbles: true,
+        cancelable: false,
+    });
+};
+
+const focusout_event = () => {
+    return new Event("focusout", {
+        bubbles: true,
         cancelable: false,
     });
 };
@@ -293,6 +307,8 @@ export default {
     click_event: click_event,
     change_event: change_event,
     focus_event: focus_event,
+    focusin_event: focusin_event,
+    focusout_event: focusout_event,
     input_event: input_event,
     mousedown_event: mousedown_event,
     mouseup_event: mouseup_event,

--- a/src/core/events.test.js
+++ b/src/core/events.test.js
@@ -529,6 +529,24 @@ describe("core.events tests", () => {
             expect(catched).toBe("inner");
         });
 
+        it("focusin event", async () => {
+            outer.addEventListener("focusin", () => {
+                catched = "outer";
+            });
+            inner.dispatchEvent(events.focusin_event());
+            await utils.timeout(1);
+            expect(catched).toBe("outer");
+        });
+
+        it("focusout event", async () => {
+            outer.addEventListener("focusout", () => {
+                catched = "outer";
+            });
+            inner.dispatchEvent(events.focusout_event());
+            await utils.timeout(1);
+            expect(catched).toBe("outer");
+        });
+
         it("input event", async () => {
             outer.addEventListener("input", () => {
                 catched = "outer";

--- a/src/pat/auto-suggest/auto-suggest.js
+++ b/src/pat/auto-suggest/auto-suggest.js
@@ -122,9 +122,9 @@ export default Base.extend({
             const val = $sel2.select2("val");
             if (val?.length === 0) {
                 // catches "" and []
-                // blur the input field so that pat-validate can kick in when
-                // nothing was selected.
-                this.el.dispatchEvent(events.blur_event());
+                // focus-out the input field so that pat-validate can kick in
+                // when nothing was selected.
+                this.el.dispatchEvent(events.focusout_event());
             }
         };
         this.$el.on("select2-close", initiate_empty_check.bind(this));

--- a/src/pat/date-picker/date-picker.js
+++ b/src/pat/date-picker/date-picker.js
@@ -173,9 +173,9 @@ export default Base.extend({
             onSelect: () => this.dispatch_change_event(),
             onClose: () => {
                 if (this.options.behavior === "styled" && !this.el.value) {
-                    // blur the input field so that pat-validate can kick in when
-                    // nothing was selected.
-                    el.dispatchEvent(events.blur_event());
+                    // focus-out the input field so that pat-validate can kick
+                    // in when nothing was selected.
+                    el.dispatchEvent(events.focusout_event());
                 }
             },
         };

--- a/src/pat/validation/documentation.md
+++ b/src/pat/validation/documentation.md
@@ -126,6 +126,12 @@ pat-validation can handle structures like these:
 More information on the `form` attribute can be found at [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#form).
 
 
+### Dynamic forms
+
+pat-validation supports dynamic forms where form elements are added after the Pattern was initialized.
+There is no need to re-initialize the pattern or to dispatch a special event.
+
+
 ### Options reference
 
 > **_NOTE:_**  The form inputs must have a `name` attribute, otherwise the

--- a/src/pat/validation/documentation.md
+++ b/src/pat/validation/documentation.md
@@ -20,6 +20,7 @@ These extra validation rules are:
 
 - Equality checking between two fields (e.g. password confirmation).
 - Date and datetime validation for before and after a given date or another input field.
+- Minimum and maximum number of checked, selected or filled-out fields. Most useful for checkboxes, but also works for text-inputs, selects and other form elements.
 
 
 ### HTML form validation framework integration.
@@ -146,7 +147,11 @@ More information on the `form` attribute can be found at [MDN](https://developer
 | message-number   | The error message for numbers.                                                                                             | This value must be a number.                         | String                                 |
 | message-required | The error message for required fields.                                                                                     | This field is required.                              | String                                 |
 | message-equality | The error message for fields required to be equal                                                                          | is not equal to %{attribute}                         | String                                 |
+| message-min-values | The error message when the minimim number of checked, selected or filled-out fields has not been reached.                | You need to select at least %{count} item(s).        | String                                 |
+| message-max-values | The error message when the maximum number of checked, selected or filled-out fields has not been reached.                | You need to select at most %{count} item(s).         | String                                 |
 | equality         | Field-specific extra rule. The name of another input this input should equal to (useful for password confirmation).        |                                                      | String                                 |
 | not-after        | Field-specific extra rule. A lower time limit restriction for date and datetime fields.                                    |                                                      | CSS Selector or a ISO8601 date string. |
 | not-before       | Field-specific extra rule. An upper time limit restriction for date and datetime fields.                                   |                                                      | CSS Selector or a ISO8601 date string. |
+| min-values       | Minimum number of checked, selected or filled out form elements.                                                           | null                                                 | Integer (or null)                      |
+| max-values       | Maximum number of checked, selected or filled out form elements.                                                           | null                                                 | Integer (or null)                      |
 | delay            | Time in milliseconds before validation starts to avoid validating while typing.                                            | 100                                                  | Integer                                |

--- a/src/pat/validation/documentation.md
+++ b/src/pat/validation/documentation.md
@@ -109,6 +109,22 @@ ValidationPattern.prototype.error_template = (message) =>
     `<em class="invalid-feedback">${message}</em>`;
 ```
 
+
+### Form elements outside the form
+
+Input elements outside of form elements are fully supported.
+pat-validation can handle structures like these:
+
+```html
+<input name="outside" form="myform" required>
+<form id="myform">
+</form>
+<button form="myform">submit</button>
+```
+
+More information on the `form` attribute can be found at [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#form).
+
+
 ### Options reference
 
 > **_NOTE:_**  The form inputs must have a `name` attribute, otherwise the

--- a/src/pat/validation/documentation.md
+++ b/src/pat/validation/documentation.md
@@ -89,10 +89,10 @@ In addition both the input element and its label will get an `warning` class.
 </label>
 ```
 
-Checkboxes and radio buttons are treated differently: if they are contained in a fieldset with class `checklist` error messages are added at the end of the fieldset.
+Checkboxes and radio buttons are treated differently: The error message is alywas set after the last element of the inputs with the same name.
 
 ```html
-<fieldset class="checklist radio">
+<fieldset>
     <label><input type="radio" name="radio" /> Strawberry</label>
     <label><input type="radio" name="radio" /> Banana</label>
     <label><input type="radio" name="radio" /> Raspberry</label>

--- a/src/pat/validation/index.html
+++ b/src/pat/validation/index.html
@@ -115,8 +115,6 @@
             yellow</label>
         </fieldset>
 
-        <hr />
-
         <label>Planning start
           <input class="pat-date-picker"
                  id="planning-start"
@@ -134,8 +132,7 @@
                  autocomplete="off"
                  name="measure.planning_end:records"
                  type="date"
-                 value="2015-09-10"
-                 data-pat-date-picker="after: #planning-start"
+                 value="2015-09-09"
                  data-pat-validation="not-before: #planning-start; message-date: This date must be on or after the start date."
           />
         </label>
@@ -248,6 +245,154 @@
           <button formnovalidate>Cancel</button>
         </fieldset>
       </fieldset>
+    </form>
+
+    <h2>Demo with max-values / min-values support</h2>
+    <form class="pat-validation pat-checklist"
+          action="."
+          method="post"
+    >
+        <fieldset>
+          <legend>Multi select</legend>
+          <select
+              name="select"
+              multiple
+              required
+              data-pat-validation="
+                min-values: 2;
+                max-values: 3;
+              "
+          >
+              <option value="a">a</option>
+              <option value="b">b</option>
+              <option value="c">c</option>
+              <option value="d">d</option>
+          </select>
+        </fieldset>
+
+        <fieldset>
+          <legend>Multiple checkboxes</legend>
+          <label>
+            a
+            <input
+                type="checkbox"
+                name="checkbox[]"
+                value="a"
+                data-pat-validation="
+                  min-values: 1;
+                  max-values: 3;
+                "
+            />
+          </label>
+          <label>
+            b
+            <input
+                type="checkbox"
+                name="checkbox[]"
+                value="b"
+                data-pat-validation="
+                  min-values: 1;
+                  max-values: 3;
+                "
+            />
+          </label>
+          <label>
+            c
+            <input
+                type="checkbox"
+                name="checkbox[]"
+                value="c"
+                data-pat-validation="
+                  min-values: 1;
+                  max-values: 3;
+                "
+            />
+          </label>
+          <label>
+            d
+            <input
+                type="checkbox"
+                name="checkbox[]"
+                value="d"
+                data-pat-validation="
+                  min-values: 1;
+                  max-values: 3;
+                "
+            />
+          </label>
+        </fieldset>
+
+        <fieldset
+            data-pat-validation="
+                min-values: 2;
+                max-values: 3;
+            "
+        >
+          <legend>Demo with mixed inputs and max/min values support.</legend>
+          <fieldset>
+            <select
+                name="multiple"
+                multiple
+            >
+                <option value="a">a</option>
+                <option value="b">b</option>
+                <option value="c">c</option>
+                <option value="d">d</option>
+            </select>
+          </fieldset>
+          <fieldset>
+            <label>
+              a
+              <input
+                  type="checkbox"
+                  name="multiple"
+                  value="a"
+              />
+            </label>
+            <label>
+              b
+              <input
+                  type="checkbox"
+                  name="multiple"
+                  value="b"
+              />
+            </label>
+            <label>
+              c
+              <input
+                  type="checkbox"
+                  name="multiple"
+                  value="c"
+              />
+            </label>
+            <label>
+              d
+              <input
+                  type="checkbox"
+                  name="multiple"
+                  value="d"
+              />
+            </label>
+          </fieldset>
+          <fieldset>
+            <label>
+              input 1
+              <input name="multiple"/>
+            </label>
+            <label>
+              input 2
+              <input name="multiple"/>
+            </label>
+            <label>
+              input 3
+              <input name="multiple"/>
+            </label>
+          </fieldset>
+        </fieldset>
+        <fieldset class="buttons">
+          <button>Submit</button>
+          <button formnovalidate>Cancel</button>
+        </fieldset>
     </form>
 
     <div class="pat-modal">

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -257,7 +257,7 @@ class Pattern extends BasePattern {
 
             if (!validity_state.customError) {
                 // No error to handle. Return.
-                this.remove_error(input, true);
+                this.remove_error({ input });
                 return;
             }
         } else {
@@ -354,8 +354,13 @@ class Pattern extends BasePattern {
         }
     }
 
-    remove_error(input, all_of_group = false, skip_event = false) {
-        // Remove error message and related referencesfrom input.
+    remove_error({
+        input,
+        all_of_group = true,
+        clear_state = true,
+        skip_event = false,
+    }) {
+        // Remove error message and related references from input.
 
         let inputs = [input];
         if (all_of_group) {
@@ -363,6 +368,9 @@ class Pattern extends BasePattern {
             inputs = this.inputs.filter((it) => it.name === input.name);
         }
         for (const it of inputs) {
+            if (clear_state) {
+                this.set_error({ input: it, msg: "", skip_event: true });
+            }
             const error_node = it[KEY_ERROR_EL];
             it[KEY_ERROR_EL] = null;
             error_node?.remove();
@@ -385,7 +393,12 @@ class Pattern extends BasePattern {
 
     set_error_message(input) {
         // First, remove the old error message.
-        this.remove_error(input, false, true);
+        this.remove_error({
+            input,
+            all_of_group: false,
+            clear_state: false,
+            skip_event: true
+        });
 
         // Do not set a error message for a input group like radio buttons or
         // checkboxes where one has already been set.

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -132,6 +132,11 @@ class Pattern extends BasePattern {
         );
     }
 
+    siblings(input) {
+        // Get all siblings of an input with the same name.
+        return this.inputs.filter((_input) => _input.name === input.name);
+    }
+
     validate_all(event) {
         // Check all inputs.
         for (const input of this.inputs) {
@@ -297,17 +302,7 @@ class Pattern extends BasePattern {
                 const max_values = input_options.maxValues !== null && parseInt(input_options.maxValues, 10) || null;
 
                 let number_values = 0;
-                for (const _inp of this.form.elements) {
-                    // Filter for siblings with same name.
-                    if (
-                        // Keep only inputs with same name
-                        _inp.name !== input.name
-                        // Skip all form elements which are no input elements
-                        || ! ["INPUT", "SELECT", "TEXTAREA"].includes(_inp.tagName)
-                    ) {
-                        continue;
-                    }
-
+                for (const _inp of this.siblings(input)) {
                     // Check if checkboxes or radios are checked ...
                     if (_inp.type === "checkbox" || _inp.type === "radio") {
                         if (_inp.checked) {
@@ -433,8 +428,7 @@ class Pattern extends BasePattern {
         msg = msg.replace(/%{value}/g, JSON.stringify(input.value));
 
         // Set the error state the input itself and on all siblings, if any.
-        const inputs = [...this.form.elements].filter((_input) => _input.name === input.name);
-        for (const _input of inputs) {
+        for (const _input of this.siblings(input)) {
             _input.setCustomValidity(msg);
         }
         // Store the error message on the input.
@@ -458,7 +452,7 @@ class Pattern extends BasePattern {
         let inputs = [input];
         if (all_of_group) {
             // Get all inputs with the same name - e.g. radio buttons, checkboxes.
-            inputs = [...this.form.elements].filter((_input) => _input.name === input.name);
+            inputs = this.siblings(input);
         }
         for (const it of inputs) {
             if (clear_state) {
@@ -495,7 +489,7 @@ class Pattern extends BasePattern {
 
         // Do not set a error message for a input group like radio buttons or
         // checkboxes where one has already been set.
-        const inputs = [...this.form.elements].filter((_input) => _input.name === input.name);
+        const inputs = this.siblings(input);
         if (inputs.length > 1 && inputs.some((it) => !!it[KEY_ERROR_EL])) {
             // error message for input group already set.
             return;

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -125,7 +125,7 @@ class Pattern extends BasePattern {
         );
     }
 
-    get disableable() {
+    get disableables() {
         // Return all elements, which should be disabled when there are errors.
         return [...this.form.elements].filter((input) =>
             input.matches(this.options.disableSelector)
@@ -302,23 +302,23 @@ class Pattern extends BasePattern {
                 const max_values = input_options.maxValues !== null && parseInt(input_options.maxValues, 10) || null;
 
                 let number_values = 0;
-                for (const _inp of this.siblings(input)) {
+                for (const _input of this.siblings(input)) {
                     // Check if checkboxes or radios are checked ...
-                    if (_inp.type === "checkbox" || _inp.type === "radio") {
-                        if (_inp.checked) {
+                    if (_input.type === "checkbox" || _input.type === "radio") {
+                        if (_input.checked) {
                             number_values++;
                         }
                         continue;
                     }
 
                     // Select, if select is selected.
-                    if (_inp.tagName === "SELECT") {
-                        number_values += _inp.selectedOptions.length;
+                    if (_input.tagName === "SELECT") {
+                        number_values += _input.selectedOptions.length;
                         continue;
                     }
 
                     // For the rest a value must be set.
-                    if (_inp.value === 0 || _inp.value) {
+                    if (_input.value === 0 || _input.value) {
                         number_values++;
                     }
                 }
@@ -454,21 +454,21 @@ class Pattern extends BasePattern {
             // Get all inputs with the same name - e.g. radio buttons, checkboxes.
             inputs = this.siblings(input);
         }
-        for (const it of inputs) {
+        for (const _input of inputs) {
             if (clear_state) {
-                this.set_error({ input: it, msg: "", skip_event: true });
+                this.set_error({ input: _input, msg: "", skip_event: true });
             }
-            const error_node = it[KEY_ERROR_EL];
-            it[KEY_ERROR_EL] = null;
+            const error_node = _input[KEY_ERROR_EL];
+            _input[KEY_ERROR_EL] = null;
             error_node?.remove();
         }
 
         // disable selector
         if (this.form.checkValidity()) {
-            for (const it of this.disableable) {
-                if (it.disabled) {
-                    it.removeAttribute("disabled");
-                    it.classList.remove("disabled");
+            for (const _input of this.disableables) {
+                if (_input.disabled) {
+                    _input.removeAttribute("disabled");
+                    _input.classList.remove("disabled");
                 }
             }
         }
@@ -490,7 +490,7 @@ class Pattern extends BasePattern {
         // Do not set a error message for a input group like radio buttons or
         // checkboxes where one has already been set.
         const inputs = this.siblings(input);
-        if (inputs.length > 1 && inputs.some((it) => !!it[KEY_ERROR_EL])) {
+        if (inputs.length > 1 && inputs.some((_input) => !!_input[KEY_ERROR_EL])) {
             // error message for input group already set.
             return;
         }
@@ -507,15 +507,15 @@ class Pattern extends BasePattern {
         input[KEY_ERROR_EL] = error_node;
 
         let did_disable = false;
-        for (const it of this.disableable) {
+        for (const _input of this.disableables) {
             // Disable for melements if they are not already disabled and which
             // do not have set the `formnovalidate` attribute, e.g.
             // `<button formnovalidate>cancel</button>`.
-            if (!it.disabled && !it.formNoValidate) {
+            if (!_input.disabled && !_input.formNoValidate) {
                 did_disable = true;
-                it.setAttribute("disabled", "disabled");
-                it.classList.add("disabled");
-                logger.debug("Disable element", it);
+                _input.setAttribute("disabled", "disabled");
+                _input.classList.add("disabled");
+                logger.debug("Disable element", _input);
             }
         }
 

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -479,15 +479,9 @@ class Pattern extends BasePattern {
             this.error_template(validation_message)
         ).firstChild;
 
-        let fieldset;
-        if (input.type === "radio" || input.type === "checkbox") {
-            fieldset = input.closest("fieldset.pat-checklist");
-        }
-        if (fieldset) {
-            fieldset.append(error_node);
-        } else {
-            input.after(error_node);
-        }
+        // Put error messge after the erronous input or - in case of multiple
+        // inputs with the same name - after the last one of the group.
+        inputs.pop().after(error_node);
         input[KEY_ERROR_EL] = error_node;
 
         let did_disable = false;

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -104,7 +104,11 @@ class Pattern extends BasePattern {
         }
     }
 
-    check_input({ input, event, stop = false }) {
+    check_input({
+        input, // Input to check.
+        event = null, // Optional event which triggered the check.
+        stop = false // Stop flag to avoid infinite loops. Will not check dependent inputs.
+    }) {
         if (input.disabled) {
             // No need to check disabled inputs.
             return;
@@ -413,11 +417,10 @@ class Pattern extends BasePattern {
             }
         }
 
-        // Do an initial check of the whole form when a form element (e.g. the
-        // submit button) was disabled. We want to show the user all possible
-        // errors at once and after the submit button is disabled there is no
-        // way to check the whole form at once. ... well we also do not want to
-        // check the whole form when one input was changed....
+        // Check the whole form when a form element (e.g. the submit button)
+        // was disabled. We want to show the user all possible errors at once
+        // and after the submit button is disabled there is no way for the user
+        // to check the whole form at once.
         if (did_disable) {
             logger.debug("Checking whole form after element was disabled.");
             for (const _input of this.inputs.filter((it) => it !== input)) {

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -39,8 +39,12 @@ class Pattern extends BasePattern {
     static parser = parser;
 
     init() {
+        // The element is the form - make it clearer in the code what we're
+        // referring to.
+        this.form = this.el;
+
         events.add_event_listener(
-            this.el,
+            this.form,
             "submit",
             `pat-validation--submit--validator`,
             (e) => {
@@ -59,21 +63,21 @@ class Pattern extends BasePattern {
         );
 
         this.initialize_inputs();
-        $(this.el).on("pat-update", () => {
+        $(this.form).on("pat-update", () => {
             this.initialize_inputs();
         });
 
         // Set ``novalidate`` attribute to disable the browser's validation
         // bubbles but not disable the validation API.
-        this.el.setAttribute("novalidate", "");
+        this.form.setAttribute("novalidate", "");
     }
 
     initialize_inputs() {
         this.inputs = [
-            ...this.el.querySelectorAll("input[name], select[name], textarea[name]"),
+            ...this.form.querySelectorAll("input[name], select[name], textarea[name]"),
         ];
         this.disabled_elements = [
-            ...this.el.querySelectorAll(this.options.disableSelector),
+            ...this.form.querySelectorAll(this.options.disableSelector),
         ];
 
         for (const [cnt, input] of this.inputs.entries()) {
@@ -132,7 +136,7 @@ class Pattern extends BasePattern {
 
             if (
                 input_options.equality &&
-                this.el.querySelector(`[name=${input_options.equality}]`)?.value !==
+                this.form.querySelector(`[name=${input_options.equality}]`)?.value !==
                     input.value
             ) {
                 const message =
@@ -361,7 +365,7 @@ class Pattern extends BasePattern {
         }
 
         // disable selector
-        if (this.el.checkValidity()) {
+        if (this.form.checkValidity()) {
             for (const it of this.disabled_elements) {
                 if (it.disabled) {
                     it.removeAttribute("disabled");

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -69,6 +69,20 @@ class Pattern extends BasePattern {
         this.form.setAttribute("novalidate", "");
     }
 
+    get inputs() {
+        // Return all inputs elements
+        return [...this.form.elements].filter((input) =>
+            input.matches("input[name], select[name], textarea[name]")
+        );
+    }
+
+    get disableable() {
+        // Return all elements, which should be disabled when there are errors.
+        return [...this.form.elements].filter((input) =>
+            input.matches(this.options.disableSelector)
+        );
+    }
+
     validate_all(event) {
         // Check all inputs.
         for (const input of this.inputs) {
@@ -77,13 +91,6 @@ class Pattern extends BasePattern {
     }
 
     initialize_inputs() {
-        this.inputs = [
-            ...this.form.querySelectorAll("input[name], select[name], textarea[name]"),
-        ];
-        this.disabled_elements = [
-            ...this.form.querySelectorAll(this.options.disableSelector),
-        ];
-
         for (const [cnt, input] of this.inputs.entries()) {
             // Cancelable debouncer.
             const debouncer = utils.debounce((e) => {
@@ -365,7 +372,7 @@ class Pattern extends BasePattern {
         let inputs = [input];
         if (all_of_group) {
             // Get all inputs with the same name - e.g. radio buttons, checkboxes.
-            inputs = this.inputs.filter((it) => it.name === input.name);
+            inputs = [...this.form.elements].filter((_input) => _input.name === input.name);
         }
         for (const it of inputs) {
             if (clear_state) {
@@ -378,7 +385,7 @@ class Pattern extends BasePattern {
 
         // disable selector
         if (this.form.checkValidity()) {
-            for (const it of this.disabled_elements) {
+            for (const it of this.disableable) {
                 if (it.disabled) {
                     it.removeAttribute("disabled");
                     it.classList.remove("disabled");
@@ -402,7 +409,7 @@ class Pattern extends BasePattern {
 
         // Do not set a error message for a input group like radio buttons or
         // checkboxes where one has already been set.
-        const inputs = this.inputs.filter((it) => it.name === input.name);
+        const inputs = [...this.form.elements].filter((_input) => _input.name === input.name);
         if (inputs.length > 1 && inputs.some((it) => !!it[KEY_ERROR_EL])) {
             // error message for input group already set.
             return;
@@ -426,7 +433,7 @@ class Pattern extends BasePattern {
         input[KEY_ERROR_EL] = error_node;
 
         let did_disable = false;
-        for (const it of this.disabled_elements) {
+        for (const it of this.disableable) {
             // Disable for melements if they are not already disabled and which
             // do not have set the `formnovalidate` attribute, e.g.
             // `<button formnovalidate>cancel</button>`.

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -47,14 +47,11 @@ class Pattern extends BasePattern {
             this.form,
             "submit",
             `pat-validation--submit--validator`,
-            (e) => {
+            (event) => {
                 // On submit, check all.
                 // Immediate, non-debounced check with submit. Otherwise submit
                 // is not cancelable.
-                for (const input of this.inputs) {
-                    logger.debug("Checking input for submit", input, e);
-                    this.check_input({ input: input, event: e });
-                }
+                this.validate_all(event);
             },
             // Make sure this event handler is run early, in the capturing
             // phase in order to be able to cancel later non-capturing submit
@@ -70,6 +67,13 @@ class Pattern extends BasePattern {
         // Set ``novalidate`` attribute to disable the browser's validation
         // bubbles but not disable the validation API.
         this.form.setAttribute("novalidate", "");
+    }
+
+    validate_all(event) {
+        // Check all inputs.
+        for (const input of this.inputs) {
+            this.check_input({ input: input, event: event, stop: true });
+        }
     }
 
     initialize_inputs() {
@@ -426,10 +430,7 @@ class Pattern extends BasePattern {
         // and after the submit button is disabled there is no way for the user
         // to check the whole form at once.
         if (did_disable) {
-            logger.debug("Checking whole form after element was disabled.");
-            for (const _input of this.inputs.filter((it) => it !== input)) {
-                this.check_input({ input: _input, stop: true });
-            }
+            this.validate_all();
         }
     }
 

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -178,7 +178,13 @@ class Pattern extends BasePattern {
                     msg: message,
                     attribute: input_options.equality,
                 });
-            } else if (input_options.not.after || input_options.not.before) {
+            }
+
+            if (
+                ! validity_state.customError && // No error from previous checks.
+                input_options.not.after ||
+                input_options.not.before
+            ) {
                 const msg = input_options.message.date || input_options.message.datetime;
                 const msg_default_not_before = "The date must be after %{attribute}";
                 const msg_default_not_after = "The date must be before %{attribute}";
@@ -280,7 +286,13 @@ class Pattern extends BasePattern {
                     logger.debug("Check `no-before` input.", not_after_el);
                     this.check_input({ input: not_before_el, stop: true });
                 }
-            } else if (input_options.minValues || input_options.maxValues) {
+            }
+
+            if (
+                ! validity_state.customError && // No error from previous checks.
+                input_options.minValues ||
+                input_options.maxValues
+            ) {
                 const min_values = input_options.minValues !== null && parseInt(input_options.minValues, 10) || null;
                 const max_values = input_options.maxValues !== null && parseInt(input_options.maxValues, 10) || null;
 

--- a/src/pat/validation/validation.js
+++ b/src/pat/validation/validation.js
@@ -338,12 +338,6 @@ class Pattern extends BasePattern {
                     })
                 }
             }
-
-            if (!validity_state.customError) {
-                // No error to handle. Return.
-                this.remove_error({ input });
-                return;
-            }
         } else {
             // Default error cases with custom messages.
 
@@ -403,6 +397,12 @@ class Pattern extends BasePattern {
                 this.emit_update("invalid");
             }
 
+        }
+
+        if (validity_state.valid) {
+            // No error to handle. Remove eventual error and return.
+            this.remove_error({ input });
+            return;
         }
 
         if (event?.type === "submit") {

--- a/src/pat/validation/validation.test.js
+++ b/src/pat/validation/validation.test.js
@@ -477,7 +477,7 @@ describe("pat-validation", function () {
             const instance = new Pattern(el);
             await events.await_pattern_init(instance);
 
-            document.querySelector("[name=i1]").dispatchEvent(events.blur_event());
+            document.querySelector("[name=i1]").dispatchEvent(events.focusout_event());
             await utils.timeout(1); // wait a tick for async to settle.
 
             expect(el.querySelectorAll("em.warning").length).toBe(2);
@@ -498,7 +498,7 @@ describe("pat-validation", function () {
             const instance = new Pattern(el);
             await events.await_pattern_init(instance);
 
-            document.querySelector("[name=i1]").dispatchEvent(events.blur_event());
+            document.querySelector("[name=i1]").dispatchEvent(events.focusout_event());
             await utils.timeout(1); // wait a tick for async to settle.
 
             expect(el.querySelectorAll("em.warning").length).toBe(1);
@@ -584,6 +584,41 @@ describe("pat-validation", function () {
             const warning = form.querySelector("em.warning");
             expect(warning).toBeTruthy();
             expect(warning.matches("input:nth-child(3) + em.warning")).toBe(true);
+        });
+
+        it("1.24 - Supports dynamic forms.", async function () {
+            document.body.innerHTML = `
+                <form class="pat-validation" id="form">
+                   <input name="input1" required/>
+                </form>
+            `;
+            const form = document.querySelector(".pat-validation");
+            const input1 = form.querySelector("[name=input1]");
+
+            const instance = new Pattern(form);
+            await events.await_pattern_init(instance);
+
+            form.dispatchEvent(events.submit_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(document.querySelectorAll("em.warning").length).toBe(1);
+
+            input1.value = "ok";
+            input1.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(document.querySelectorAll("em.warning").length).toBe(0);
+
+            const input2 = document.createElement("input");
+            input2.name = "input2";
+            input2.required = true;
+            form.appendChild(input2);
+
+            form.dispatchEvent(events.submit_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(document.querySelectorAll("em.warning").length).toBe(1);
+            expect(document.querySelector("em.warning").matches("input[name=input2] + em.warning")).toBe(true);
         });
     });
 

--- a/src/pat/validation/validation.test.js
+++ b/src/pat/validation/validation.test.js
@@ -1535,4 +1535,213 @@ describe("pat-validation", function () {
             expect(el.querySelector("#form-buttons-create").disabled).toBe(false);
         });
     });
+
+    describe("8 - min/max value validation", function () {
+        it("8.1 - validate min and max number of checked checkboxes", async function () {
+            document.body.innerHTML = `
+              <form class="pat-validation">
+                <fieldset
+                    data-pat-validation="
+                        min-values: 2;
+                        max-values: 3;
+                        message-min-values: Please select at least 2 options;
+                        message-max-values: Please select at most 3 options;
+                    "
+                  >
+                    <input type="checkbox" name="check" value="1">
+                    <input type="checkbox" name="check" value="2">
+                    <input type="checkbox" name="check" value="3">
+                    <input type="checkbox" name="check" value="4">
+                </fieldset>
+              </form>
+            `;
+
+            const form = document.querySelector("form");
+            const check1 = form.querySelector("[name=check][value='1']");
+            const check2 = form.querySelector("[name=check][value='2']");
+            const check3 = form.querySelector("[name=check][value='3']");
+            const check4 = form.querySelector("[name=check][value='4']");
+
+            const instance = new Pattern(form);
+            await events.await_pattern_init(instance);
+
+            check1.checked = true;
+            check1.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(check1.matches(":invalid")).toBe(true);
+            expect(check2.matches(":invalid")).toBe(true);
+            expect(check3.matches(":invalid")).toBe(true);
+            expect(check4.matches(":invalid")).toBe(true);
+            expect(form.querySelectorAll("em.warning").length).toBe(1);
+            expect(form.querySelectorAll("em.warning")[0].textContent).toBe(
+                "Please select at least 2 options"
+            );
+
+            check2.checked = true;
+            check2.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(check1.matches(":invalid")).toBe(false);
+            expect(check2.matches(":invalid")).toBe(false);
+            expect(check3.matches(":invalid")).toBe(false);
+            expect(check4.matches(":invalid")).toBe(false);
+            expect(form.querySelectorAll("em.warning").length).toBe(0);
+
+            check3.checked = true;
+            check3.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(check1.matches(":invalid")).toBe(false);
+            expect(check2.matches(":invalid")).toBe(false);
+            expect(check3.matches(":invalid")).toBe(false);
+            expect(check4.matches(":invalid")).toBe(false);
+            expect(form.querySelectorAll("em.warning").length).toBe(0);
+
+            check4.checked = true;
+            check4.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(check1.matches(":invalid")).toBe(true);
+            expect(check2.matches(":invalid")).toBe(true);
+            expect(check3.matches(":invalid")).toBe(true);
+            expect(check4.matches(":invalid")).toBe(true);
+            expect(form.querySelectorAll("em.warning").length).toBe(1);
+            expect(form.querySelectorAll("em.warning")[0].textContent).toBe(
+                "Please select at most 3 options"
+            );
+
+            check4.checked = false;
+            check4.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(check1.matches(":invalid")).toBe(false);
+            expect(check2.matches(":invalid")).toBe(false);
+            expect(check3.matches(":invalid")).toBe(false);
+            expect(check4.matches(":invalid")).toBe(false);
+            expect(form.querySelectorAll("em.warning").length).toBe(0);
+        });
+
+        it("8.2 - validate min and max number with mixed inputs", async function () {
+            document.body.innerHTML = `
+              <form class="pat-validation">
+                <fieldset
+                    data-pat-validation="
+                        min-values: 2;
+                        max-values: 3;
+                        message-min-values: Please select at least 2 options;
+                        message-max-values: Please select at most 3 options;
+                    "
+                  >
+                    <input id="i1" name="multiple" type="radio" value="1">
+                    <input id="i2" name="multiple" type="checkbox" value="4">
+                    <select id="i3" name="multiple" multiple>
+                        <option id="i31" value="5">1</option>
+                    </select>
+                    <input id="i4" name="multiple">
+                    <textarea id="i5" name="multiple"></textarea>
+                </fieldset>
+              </form>
+            `;
+
+            const form = document.querySelector("form");
+            const id1 = form.querySelector("#i1");
+            const id2 = form.querySelector("#i2");
+            const id3 = form.querySelector("#i3");
+            const id31 = form.querySelector("#i31");
+            const id4 = form.querySelector("#i4");
+            const id5 = form.querySelector("#i5");
+
+            const instance = new Pattern(form);
+            await events.await_pattern_init(instance);
+
+            id1.checked = true;
+            id1.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(id1.matches(":invalid")).toBe(true);
+            expect(id2.matches(":invalid")).toBe(true);
+            expect(id3.matches(":invalid")).toBe(true);
+            expect(id4.matches(":invalid")).toBe(true);
+            expect(id5.matches(":invalid")).toBe(true);
+            expect(form.querySelectorAll("em.warning").length).toBe(1);
+            expect(form.querySelectorAll("em.warning")[0].textContent).toBe(
+                "Please select at least 2 options"
+            );
+
+            id2.checked = true;
+            id2.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(id1.matches(":invalid")).toBe(false);
+            expect(id2.matches(":invalid")).toBe(false);
+            expect(id3.matches(":invalid")).toBe(false);
+            expect(id4.matches(":invalid")).toBe(false);
+            expect(id5.matches(":invalid")).toBe(false);
+            expect(form.querySelectorAll("em.warning").length).toBe(0);
+
+            id31.selected = true;
+            id3.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(id1.matches(":invalid")).toBe(false);
+            expect(id2.matches(":invalid")).toBe(false);
+            expect(id3.matches(":invalid")).toBe(false);
+            expect(id4.matches(":invalid")).toBe(false);
+            expect(id5.matches(":invalid")).toBe(false);
+            expect(form.querySelectorAll("em.warning").length).toBe(0);
+
+            id4.value = "okay";
+            id4.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(id1.matches(":invalid")).toBe(true);
+            expect(id2.matches(":invalid")).toBe(true);
+            expect(id3.matches(":invalid")).toBe(true);
+            expect(id4.matches(":invalid")).toBe(true);
+            expect(id5.matches(":invalid")).toBe(true);
+            expect(form.querySelectorAll("em.warning").length).toBe(1);
+            expect(form.querySelectorAll("em.warning")[0].textContent).toBe(
+                "Please select at most 3 options"
+            );
+
+            id2.checked = false;
+            id2.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(id1.matches(":invalid")).toBe(false);
+            expect(id2.matches(":invalid")).toBe(false);
+            expect(id3.matches(":invalid")).toBe(false);
+            expect(id4.matches(":invalid")).toBe(false);
+            expect(id5.matches(":invalid")).toBe(false);
+            expect(form.querySelectorAll("em.warning").length).toBe(0);
+
+            id5.value = "okay";
+            id4.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(id1.matches(":invalid")).toBe(true);
+            expect(id2.matches(":invalid")).toBe(true);
+            expect(id3.matches(":invalid")).toBe(true);
+            expect(id4.matches(":invalid")).toBe(true);
+            expect(id5.matches(":invalid")).toBe(true);
+            expect(form.querySelectorAll("em.warning").length).toBe(1);
+            expect(form.querySelectorAll("em.warning")[0].textContent).toBe(
+                "Please select at most 3 options"
+            );
+
+            id4.value = "";
+            id4.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(id1.matches(":invalid")).toBe(false);
+            expect(id2.matches(":invalid")).toBe(false);
+            expect(id3.matches(":invalid")).toBe(false);
+            expect(id4.matches(":invalid")).toBe(false);
+            expect(id5.matches(":invalid")).toBe(false);
+            expect(form.querySelectorAll("em.warning").length).toBe(0);
+        });
+
+    });
+
 });

--- a/src/pat/validation/validation.test.js
+++ b/src/pat/validation/validation.test.js
@@ -564,6 +564,27 @@ describe("pat-validation", function () {
             expect(input.matches(":invalid")).toBe(true);
             expect(button.matches(":disabled")).toBe(true);
         });
+
+        it("1.23 - Puts the warning at the end of same-name inputs.", async function () {
+            document.body.innerHTML = `
+                <form class="pat-validation" id="form">
+                   <input name="group" type="radio" required/>
+                   <input name="group" type="radio" required/>
+                   <input name="group" type="radio" required/>
+                </form>
+            `;
+            const form = document.querySelector(".pat-validation");
+
+            const instance = new Pattern(form);
+            await events.await_pattern_init(instance);
+
+            form.dispatchEvent(events.submit_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            const warning = form.querySelector("em.warning");
+            expect(warning).toBeTruthy();
+            expect(warning.matches("input:nth-child(3) + em.warning")).toBe(true);
+        });
     });
 
     describe("2 - required inputs", function () {

--- a/src/pat/validation/validation.test.js
+++ b/src/pat/validation/validation.test.js
@@ -538,6 +538,32 @@ describe("pat-validation", function () {
             expect(event.detail.dom).toBe(el);
             expect(event.detail.action).toBe("valid");
         });
+
+        it("1.22 - Supports validation of inputs outside forms.", async function () {
+            document.body.innerHTML = `
+                <input name="outside" form="form" required/>
+                <form class="pat-validation" id="form">
+                </form>
+                <button form="form">submit</button>
+            `;
+            const form = document.querySelector(".pat-validation");
+            const input = document.querySelector("[name=outside]");
+            const button = document.querySelector("button");
+
+            const instance = new Pattern(form);
+            await events.await_pattern_init(instance);
+
+            input.value = "";
+            input.dispatchEvent(events.change_event());
+            await utils.timeout(1); // wait a tick for async to settle.
+
+            expect(document.querySelectorAll("em.warning").length).toBe(1);
+            // Skip, as jsDOM does not support the `:invalid` or `:valid`
+            // pseudo selectors on forms.
+            //expect(form.matches(":invalid")).toBe(true);
+            expect(input.matches(":invalid")).toBe(true);
+            expect(button.matches(":disabled")).toBe(true);
+        });
     });
 
     describe("2 - required inputs", function () {


### PR DESCRIPTION
Hi @cornae 

we had the need to validate if at least one checkbox in a group of checkboxes was checked.
This was not yet supported by pat-validation nor by the HTML specficiation.

As a side note - required radio buttons are supported. A `required` attribute on one or all radio inputs in a group of radio inputs is supported by the HTML specification and validated by pat-validation.

We were in need to quickly support that in one of our projects and I did a implementation which we deployed but still can change if there is anything to improve - behavior wise, parameter naming or whatever.

These parameters were added:

| Property         | Description                                                                                                                | Default                                              | Type                                   |
| ---------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------------------------------------- |
| message-min-values | The error message when the minimim number of checked, selected or filled-out fields has not been reached.                | You need to select at least %{count} item(s).        | String                                 |
| message-max-values | The error message when the maximum number of checked, selected or filled-out fields has not been reached.                | You need to select at most %{count} item(s).         | String                                 |
| min-values       | Minimum number of checked, selected or filled out form elements.                                                           | null                                                 | Integer (or null)                      |
| max-values       | Maximum number of checked, selected or filled out form elements.                                                           | null                                                 | Integer (or null)                      |


Note: this does not only work with checkboxes but with any kind of input.
I recognized that we can use the same name for any kind of input - any input, select or textarea. All of the values will be submitted to the server. Therefore this implementation is not only limited to checkboxes but any kind of input.


Along the way I did some other improvements:

- The documentation is updated and extended.

- pat-validation now fully supports input elements outside the form itself, e.g.:
```html
<input name="outside" form="myform" required>
<form id="myform">
</form>
<button form="myform">submit</button>
```
- pat-validation also fully supports dynamic forms without re-initalizing or sending a special "pat-update" event. You can add form elements even without pat-inject and it should immediately take part in validation.

- And a important one:
For multiple input elements with the same name the error message was shown wether immediately after the last input which the user interacted with or the the end of a `fieldset.checkbox` element.
I have changed that, so that the error message is just shown after the last input with the same name.
We needed that also for our project and I believe it's better because it works just out of the box and there is no need to add a `fieldset.checkbox` element.
