### PR TITLE
DRAFT: fix(core registry): Re-scan the document after module federati…

### DIFF
--- a/src/core/registry.js
+++ b/src/core/registry.js
@@ -66,6 +66,14 @@ const registry = {
                 // Do not reinitialize a already initialized registry.
                 return;
             }
+            events.add_event_listener(
+                document,
+                "patternslib__mf--loaded",
+                "registry_rescan_mf",
+                () => {
+                    registry.scan(document.body);
+                }
+            );
             window.__patternslib_registry_initialized = true;
             log.debug("Loaded: " + Object.keys(registry.patterns).sort().join(", "));
             registry.scan(document.body);


### PR DESCRIPTION
…on bundle initialization for any new Patterns.

HEADS UP: remove, as this is not needed.
Registering a bundle already scans the DOM for that one bundle.