### PR TITLE
Use long commit hash to simplify pnpm installations with patternslib dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "select2": "^3.5.1",
         "showdown": "^2.1.0",
         "showdown-prettify": "^1.3.0",
-        "slick-carousel": "git+https://github.com/kenwheeler/slick.git#d0716f1",
+        "slick-carousel": "git+https://github.com/kenwheeler/slick.git#d0716f19aa730006ee80ab026625fb1107816a97",
         "slides": "git+https://github.com/Patternslib/slides.git",
         "spectrum-colorpicker": "^1.8.0",
         "tippy.js": "^6.3.7"


### PR DESCRIPTION
`pnpm` doesn't accept short commit hashes so we had to define an override here: https://github.com/plone/mockup/blob/master/package.json#L127 