### PR TITLE
maint(core mockup-parser): Extend the tests.

### DIFF
--- a/src/core/mockup-parser.test.js
+++ b/src/core/mockup-parser.test.js
@@ -44,6 +44,7 @@ describe("The mockup-parser", function () {
         expect(options.option2).toBe("value2");
         expect(options.injectedOption).toBe("injectedValue");
     });
+
     it("parses JSON data attribute of a single node", function () {
         const el = document.createElement("div");
         el.setAttribute(
@@ -55,5 +56,46 @@ describe("The mockup-parser", function () {
 
         expect(options.option1).toBe("value1");
         expect(options.option2).toBe("value2");
+    });
+
+    it("parses JSON data attributes and interprets native types", function () {
+        const el = document.createElement("div");
+        el.setAttribute(
+            "data-pat-testpattern",
+            `{
+                "option1": "value1",
+                "option2": true,
+                "option3": false,
+                "option4": 0,
+                "option5": 1,
+                "option6": 1000,
+                "option7": 0.001
+             }`
+        );
+
+        const options = mockupParser.getOptions(el, "testpattern");
+
+        expect(options.option1).toBe("value1");
+        expect(options.option2).toBe(true);
+        expect(options.option3).toBe(false);
+        expect(options.option4).toBe(0);
+        expect(options.option5).toBe(1);
+        expect(options.option6).toBe(1000);
+        expect(options.option7).toBe(0.001);
+    });
+
+    it("parses JSON and breaks if invalid", function () {
+        const el = document.createElement("div");
+        el.setAttribute(
+            "data-pat-testpattern",
+            `{
+                "option1": "value1",
+             }`
+        );
+
+        const options = mockupParser.getOptions(el, "testpattern");
+
+        // Invalid JSON strings will result in "undefined"
+        expect(options.option1).toBe(undefined);
     });
 });


### PR DESCRIPTION
Extend the mockup parser tests with tests showing that native JSON values are converted to their JavaScript equivalent.